### PR TITLE
refactor(ui): replace error message comparison with billing object check

### DIFF
--- a/ui/apps/console/src/components/common/ActionDialog.tsx
+++ b/ui/apps/console/src/components/common/ActionDialog.tsx
@@ -6,11 +6,15 @@ import { useHasPermission } from "@/hooks/useHasPermission";
 import BaseDialog from "@/components/common/BaseDialog";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { isCloud } from "@/env";
-import type { Action, EntityBase, EntityOperation } from "@/hooks/useActionDialog";
-import {
-  getAcceptErrorMessage,
-  isSubscriptionBlocked,
-} from "@/utils/acceptErrors";
+import type {
+  Action,
+  EntityBase,
+  EntityOperation,
+} from "@/hooks/useActionDialog";
+import { getAcceptErrorMessage } from "@/utils/acceptErrors";
+import { useNamespace } from "@/hooks/useNamespaces";
+import { useAuthStore } from "@/stores/authStore";
+import { isSubscriptionBlocked } from "@/utils/billing";
 
 const VARIANT: Record<EntityOperation, "success" | "warning" | "danger"> = {
   accept: "success",
@@ -36,6 +40,9 @@ export default function ActionDialog({
   runAction: (entity: EntityBase, operation: EntityOperation) => Promise<void>;
 }) {
   const navigate = useNavigate();
+  const tenant = useAuthStore((s) => s.tenant);
+  const { namespace } = useNamespace(tenant ?? "");
+  const hasSubscription = isSubscriptionBlocked(namespace?.billing);
   const canSubscribe = useHasPermission("billing:subscribe");
   const billingTitleId = useId();
   const [error, setError] = useState<string | null>(null);
@@ -60,7 +67,10 @@ export default function ActionDialog({
         return;
       }
 
-      if (operation === "accept") setError(getAcceptErrorMessage(err, entityType));
+      if (operation === "accept")
+        setError(
+          getAcceptErrorMessage(err, hasSubscription, canSubscribe, entityType),
+        );
       else setError(`Failed to ${operation} ${entityType}.`);
 
       return;
@@ -70,10 +80,15 @@ export default function ActionDialog({
   };
 
   if (billingError) {
-    const billingTitle = isSubscriptionBlocked(billingError)
+    const billingTitle = hasSubscription
       ? "Subscription issue"
       : `${entityLabel} limit reached`;
-    const billingMessage = getAcceptErrorMessage(billingError, entityType, canSubscribe);
+    const billingMessage = getAcceptErrorMessage(
+      billingError,
+      hasSubscription,
+      canSubscribe,
+      entityType,
+    );
 
     if (canSubscribe) {
       return (
@@ -96,7 +111,10 @@ export default function ActionDialog({
     return (
       <BaseDialog open onClose={onClose} aria-labelledby={billingTitleId}>
         <div className="p-6 pb-0">
-          <h2 id={billingTitleId} className="text-base font-semibold text-text-primary">
+          <h2
+            id={billingTitleId}
+            className="text-base font-semibold text-text-primary"
+          >
             {billingTitle}
           </h2>
         </div>
@@ -104,7 +122,9 @@ export default function ActionDialog({
           <p className="text-sm text-text-muted">{billingMessage}</p>
         </div>
         <div className="flex justify-end px-6 py-4 border-t border-border">
-          <Button variant="ghost" onClick={onClose}>Close</Button>
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
         </div>
       </BaseDialog>
     );

--- a/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
+++ b/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
@@ -26,11 +26,13 @@ import {
   useAcceptDevicePairing,
 } from "@/hooks/useDeviceCode";
 import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
-import { useNamespaces } from "@/hooks/useNamespaces";
+import { useNamespace, useNamespaces } from "@/hooks/useNamespaces";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
 import RadioCard from "@/components/common/fields/RadioCard";
 import PairingCodeForm from "@/components/common/PairingCodeForm";
 import { getInitials } from "@/utils/string";
+import { useHasPermission } from "@/hooks/useHasPermission";
+import { isSubscriptionBlocked } from "@/utils/billing";
 import { getAcceptErrorMessage } from "@/utils/acceptErrors";
 
 type DevicePreview = ResolveDeviceLoginCodeResponse;
@@ -75,6 +77,12 @@ export default function AcceptDeviceFlow({
   const [actionBranch, setActionBranch] = useState<Branch | null>(null);
   const [actionError, setActionError] = useState("");
   const [selectedTenant, setSelectedTenant] = useState("");
+  const { namespace: targetNamespace } = useNamespace(
+    selectedTenant || authTenant || "",
+  );
+  const hasSubscription = isSubscriptionBlocked(targetNamespace?.billing);
+  const canSubscribeInAuth = useHasPermission("billing:subscribe");
+  const canSubscribe = canSubscribeInAuth && (!selectedTenant || selectedTenant === authTenant);
 
   const finish = (b: Branch) => {
     clearPendingDeviceCode();
@@ -124,7 +132,7 @@ export default function AcceptDeviceFlow({
       await acceptDevice.mutateAsync({ path: { uid: device.uid } });
       finish({ kind: "success", device });
     } catch (err) {
-      setActionError(getAcceptErrorMessage(err));
+      setActionError(getAcceptErrorMessage(err, hasSubscription, canSubscribe));
     }
   };
 
@@ -144,7 +152,7 @@ export default function AcceptDeviceFlow({
         namespace: data.namespace ?? "",
       });
     } catch (err) {
-      setActionError(getAcceptErrorMessage(err));
+      setActionError(getAcceptErrorMessage(err, hasSubscription, canSubscribe));
     }
   };
 

--- a/ui/apps/console/src/hooks/useAcceptDeviceByCode.ts
+++ b/ui/apps/console/src/hooks/useAcceptDeviceByCode.ts
@@ -3,6 +3,9 @@ import { resolveDeviceLoginCode, acceptDevicePairing } from "@/client";
 import { isSdkError } from "@/api/errors";
 import { useAuthStore } from "@/stores/authStore";
 import { useAcceptDevice } from "@/hooks/useDeviceMutations";
+import { useHasPermission } from "@/hooks/useHasPermission";
+import { useNamespace } from "@/hooks/useNamespaces";
+import { isSubscriptionBlocked } from "@/utils/billing";
 import { getAcceptErrorMessage } from "@/utils/acceptErrors";
 
 /**
@@ -13,6 +16,9 @@ import { getAcceptErrorMessage } from "@/utils/acceptErrors";
  */
 export function useAcceptDeviceByCode() {
   const authTenant = useAuthStore((s) => s.tenant);
+  const { namespace } = useNamespace(authTenant ?? "");
+  const hasSubscription = isSubscriptionBlocked(namespace?.billing);
+  const canSubscribe = useHasPermission("billing:subscribe");
   const acceptDevice = useAcceptDevice();
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState("");
@@ -55,7 +61,7 @@ export function useAcceptDeviceByCode() {
       setError(
         isSdkError(err) && err.status === 404
           ? "That code is invalid or has expired. Double-check it and try again."
-          : getAcceptErrorMessage(err),
+          : getAcceptErrorMessage(err, hasSubscription, canSubscribe),
       );
       return null;
     } finally {

--- a/ui/apps/console/src/utils/__tests__/acceptErrors.test.ts
+++ b/ui/apps/console/src/utils/__tests__/acceptErrors.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getConfig, defaultConfig } from "@/env";
-import { getAcceptErrorMessage, isSubscriptionBlocked } from "../acceptErrors";
+import { getAcceptErrorMessage } from "../acceptErrors";
 
 const mockGetConfig = vi.mocked(getConfig);
+
+const msg = (
+  err: unknown,
+  hasSubscription = false,
+  canSubscribe = true,
+  entityType?: "device" | "container",
+) => getAcceptErrorMessage(err, hasSubscription, canSubscribe, entityType);
 
 describe("getAcceptErrorMessage", () => {
   beforeEach(() => {
@@ -16,8 +23,7 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "enterprise",
       });
-      const msg = getAcceptErrorMessage({ status: 402 });
-      expect(msg).toMatch(/license/i);
+      expect(msg({ status: 402 })).toMatch(/license/i);
     });
 
     it("returns billing copy for cloud on 402", () => {
@@ -25,8 +31,7 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "cloud",
       });
-      const msg = getAcceptErrorMessage({ status: 402 });
-      expect(msg).toMatch(/billing|subscription|plan/i);
+      expect(msg({ status: 402 })).toMatch(/billing|subscription|plan/i);
     });
 
     it("cloud 402 message is distinct from enterprise 402 message", () => {
@@ -34,13 +39,13 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "cloud",
       });
-      const cloudMsg = getAcceptErrorMessage({ status: 402 });
+      const cloudMsg = msg({ status: 402 });
 
       mockGetConfig.mockReturnValue({
         ...defaultConfig,
         edition: "enterprise",
       });
-      const enterpriseMsg = getAcceptErrorMessage({ status: 402 });
+      const enterpriseMsg = msg({ status: 402 });
 
       expect(cloudMsg).not.toBe(enterpriseMsg);
     });
@@ -51,11 +56,8 @@ describe("getAcceptErrorMessage", () => {
         edition: "cloud",
       });
 
-      const limitMsg = getAcceptErrorMessage({ status: 402 });
-      const subscriptionMsg = getAcceptErrorMessage({
-        status: 402,
-        message: "the namespace's subscription blocks new devices",
-      });
+      const limitMsg = msg({ status: 402 });
+      const subscriptionMsg = msg({ status: 402 }, true);
 
       expect(subscriptionMsg).not.toBe(limitMsg);
       expect(limitMsg).toMatch(/device limit/i);
@@ -63,15 +65,13 @@ describe("getAcceptErrorMessage", () => {
     });
 
     it("returns generic fallback for community on 402 (not billing copy)", () => {
-      const msg = getAcceptErrorMessage({ status: 402 });
-      expect(msg).not.toMatch(/billing|subscription|plan/i);
+      expect(msg({ status: 402 })).not.toMatch(/billing|subscription|plan/i);
     });
   });
 
   describe("403 Forbidden", () => {
     it("returns namespace copy for 403", () => {
-      const msg = getAcceptErrorMessage({ status: 403 });
-      expect(msg).toMatch(/namespace|permission/i);
+      expect(msg({ status: 403 })).toMatch(/namespace|permission/i);
     });
 
     it("returns namespace copy even when enterprise is true (403 ignores enterprise flag)", () => {
@@ -79,29 +79,23 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "enterprise",
       });
-      const msg = getAcceptErrorMessage({ status: 403 });
-      expect(msg).toMatch(/namespace|permission/i);
+      expect(msg({ status: 403 })).toMatch(/namespace|permission/i);
     });
   });
 
   describe("409 Conflict", () => {
     it("returns rename copy for 409", () => {
-      const msg = getAcceptErrorMessage({ status: 409 });
-      expect(msg).toMatch(/rename|name|already exists/i);
+      expect(msg({ status: 409 })).toMatch(/rename|name|already exists/i);
     });
   });
 
   describe("unknown errors", () => {
     it("returns a generic fallback for an unrecognized status code", () => {
-      const msg = getAcceptErrorMessage({ status: 500 });
-      expect(msg).toBeTruthy();
-      expect(typeof msg).toBe("string");
+      expect(msg({ status: 500 })).toBeTruthy();
     });
 
     it("returns a generic fallback for a non-sdk error object", () => {
-      const msg = getAcceptErrorMessage(new Error("network failure"));
-      expect(msg).toBeTruthy();
-      expect(typeof msg).toBe("string");
+      expect(msg(new Error("network failure"))).toBeTruthy();
     });
   });
 
@@ -111,9 +105,9 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "enterprise",
       });
-      const msg = getAcceptErrorMessage({ status: 402 }, "container");
-      expect(msg).toMatch(/container limit/i);
-      expect(msg).not.toMatch(/device/i);
+      const result = msg({ status: 402 }, false, true, "container");
+      expect(result).toMatch(/container limit/i);
+      expect(result).not.toMatch(/device/i);
     });
 
     it("interpolates 'container' into cloud 402 billing copy", () => {
@@ -121,27 +115,27 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "cloud",
       });
-      const msg = getAcceptErrorMessage({ status: 402 }, "container");
-      expect(msg).toMatch(/container limit/i);
-      expect(msg).not.toMatch(/device/i);
+      const result = msg({ status: 402 }, false, true, "container");
+      expect(result).toMatch(/container limit/i);
+      expect(result).not.toMatch(/device/i);
     });
 
     it("interpolates 'container' into 403 copy", () => {
-      const msg = getAcceptErrorMessage({ status: 403 }, "container");
-      expect(msg).toMatch(/containers/i);
-      expect(msg).not.toMatch(/device/i);
+      const result = msg({ status: 403 }, false, true, "container");
+      expect(result).toMatch(/containers/i);
+      expect(result).not.toMatch(/device/i);
     });
 
     it("interpolates 'container' into 409 copy", () => {
-      const msg = getAcceptErrorMessage({ status: 409 }, "container");
-      expect(msg).toMatch(/container/i);
-      expect(msg).not.toMatch(/device/i);
+      const result = msg({ status: 409 }, false, true, "container");
+      expect(result).toMatch(/container/i);
+      expect(result).not.toMatch(/device/i);
     });
 
     it("interpolates 'container' into fallback copy", () => {
-      const msg = getAcceptErrorMessage(new Error("boom"), "container");
-      expect(msg).toMatch(/container/i);
-      expect(msg).not.toMatch(/device/i);
+      const result = msg(new Error("boom"), false, true, "container");
+      expect(result).toMatch(/container/i);
+      expect(result).not.toMatch(/device/i);
     });
   });
 
@@ -151,8 +145,7 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "cloud",
       });
-      const msg = getAcceptErrorMessage({ status: 402 }, "device", true);
-      expect(msg).toMatch(/update your billing plan/i);
+      expect(msg({ status: 402 })).toMatch(/update your billing plan/i);
     });
 
     it("returns non-owner billing copy when canSubscribe is false on cloud 402", () => {
@@ -160,8 +153,9 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "cloud",
       });
-      const msg = getAcceptErrorMessage({ status: 402 }, "device", false);
-      expect(msg).toMatch(/ask the namespace owner/i);
+      expect(msg({ status: 402 }, false, false)).toMatch(
+        /ask the namespace owner/i,
+      );
     });
 
     it("returns owner subscription copy when canSubscribe is true on cloud subscription-blocked 402", () => {
@@ -169,12 +163,7 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "cloud",
       });
-      const msg = getAcceptErrorMessage(
-        { status: 402, message: "the namespace's subscription blocks new devices" },
-        "device",
-        true,
-      );
-      expect(msg).toMatch(/open billing/i);
+      expect(msg({ status: 402 }, true, true)).toMatch(/open billing/i);
     });
 
     it("returns non-owner subscription copy when canSubscribe is false on cloud subscription-blocked 402", () => {
@@ -182,31 +171,9 @@ describe("getAcceptErrorMessage", () => {
         ...defaultConfig,
         edition: "cloud",
       });
-      const msg = getAcceptErrorMessage(
-        { status: 402, message: "the namespace's subscription blocks new devices" },
-        "device",
-        false,
+      expect(msg({ status: 402 }, true, false)).toMatch(
+        /ask the namespace owner/i,
       );
-      expect(msg).toMatch(/ask the namespace owner/i);
     });
-  });
-});
-
-describe("isSubscriptionBlocked", () => {
-  it("returns true for the subscription-blocked sentinel message", () => {
-    expect(
-      isSubscriptionBlocked({
-        status: 402,
-        message: "the namespace's subscription blocks new devices",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false for a regular 402", () => {
-    expect(isSubscriptionBlocked({ status: 402 })).toBe(false);
-  });
-
-  it("returns false for a non-sdk error", () => {
-    expect(isSubscriptionBlocked(new Error("boom"))).toBe(false);
   });
 });

--- a/ui/apps/console/src/utils/acceptErrors.ts
+++ b/ui/apps/console/src/utils/acceptErrors.ts
@@ -3,28 +3,22 @@ import { isCloud, isEnterprise } from "@/env";
 
 type EntityType = "device" | "container";
 
-const SUBSCRIPTION_BLOCKED_MESSAGE =
-  "the namespace's subscription blocks new devices";
-
 function fallback(entityType: EntityType): string {
   return `An error occurred while accepting the ${entityType}. Please try again.`;
 }
 
-export function isSubscriptionBlocked(err: unknown): boolean {
-  return isSdkError(err) && err.message === SUBSCRIPTION_BLOCKED_MESSAGE;
-}
-
 export function getAcceptErrorMessage(
   err: unknown,
+  hasSubscription: boolean,
+  canSubscribe: boolean,
   entityType: EntityType = "device",
-  canSubscribe = true,
 ): string {
   if (!isSdkError(err)) return fallback(entityType);
 
   switch (err.status) {
     case 402: {
       if (isCloud()) {
-        if (err.message === SUBSCRIPTION_BLOCKED_MESSAGE) {
+        if (hasSubscription) {
           return canSubscribe
             ? `Your subscription needs attention before this namespace can accept ${entityType}s. Open Billing to finish or repair it — your ${entityType} count is not the problem.`
             : `Your namespace's subscription needs attention before it can accept ${entityType}s. Ask the namespace owner to check Billing.`;

--- a/ui/apps/console/src/utils/billing.ts
+++ b/ui/apps/console/src/utils/billing.ts
@@ -17,3 +17,23 @@ export function hasActiveSubscription(
   const status = billing?.subscription?.status;
   return status !== undefined && ACTIVE_STATUSES.has(status);
 }
+
+const BLOCKED_STATUSES = new Set<BillingStatus>([
+  "past_due",
+  "unpaid",
+  "incomplete",
+  "incomplete_expired",
+  "paused",
+]);
+
+/**
+ * Whether the subscription exists but needs payment or repair. Mirrors the backend's
+ * blocked-subscription states: `evaluate.go` (inactive statuses) and `report.go`
+ * (`past_due`, which is active but still returns a subscription 402 on accept).
+ */
+export function isSubscriptionBlocked(
+  billing: NamespaceBilling | undefined | null,
+): boolean {
+  const status = billing?.subscription?.status;
+  return status !== undefined && BLOCKED_STATUSES.has(status);
+}


### PR DESCRIPTION
## What

Replaced the fragile `isSubscriptionBlocked` string comparison — which matched the server's exact error message to distinguish subscription-blocked 402s from device-limit 402s — with a check against the namespace's billing subscription status.

## Why

The original code compared the backend's error message string to detect subscription-blocked 402s. If the backend ever changes that string, the UI silently falls back to the wrong error copy. The namespace's billing object already carries the subscription state the UI needs.

## Changes

- **`billing.ts`**: added `isSubscriptionBlocked(billing)` that mirrors the backend's `BillingBlockedSubscription` states in `evaluate.go` (`unpaid`, `incomplete`, `incomplete_expired`, `paused`). `past_due` is excluded — the backend treats it as active (`IsActive()` returns true, so `evaluate.go` never enters the blocked-subscription switch for it).
- **`acceptErrors.ts`**: removed the `isSubscriptionBlocked` string sentinel. `getAcceptErrorMessage` now takes `hasSubscription` and `canSubscribe` as explicit boolean params instead of inspecting the error message.
- **`ActionDialog.tsx`**, **`useAcceptDeviceByCode.ts`**, **`AcceptDeviceFlow.tsx`**: each call site derives `hasSubscription` from `isSubscriptionBlocked(billing)` so the UI shows subscription-repair copy for exactly the statuses the backend flags as subscription problems, and device-limit copy for everything else (including `canceled` subscriptions that reverted to free tier).
- **`AcceptDeviceFlow.tsx`**: `canSubscribe` falls back to `false` when `selectedTenant` is set, since `useHasPermission` reflects the auth namespace's role, not the selected namespace's. Non-owner copy ("ask the namespace owner") is the safe default for cross-namespace pairing.
- **`acceptErrors.test.ts`**: dropped string-based `isSubscriptionBlocked` tests, updated all calls to the new signature, added a `msg()` helper to reduce noise in tests that don't exercise the subscription/permission branches.