### PR TITLE
fix(agent): use `unless-stopped` restart policy in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,36 @@ enroll_agent_interactively() {
   $_AGENT_CMD login || true
 }
 
+check_podman_boot_restart() {
+  [ "${SKIP_BOOT_RESTART_CHECK}" = "1" ] && {
+    printf "⚠️  SKIP_BOOT_RESTART_CHECK is set; skipping podman-restart.service check.\n"
+    printf "   The agent container will NOT auto-start on boot unless you manage it yourself\n"
+    printf "   (Quadlet, an orchestrator, etc.).\n"
+    return 0
+  }
+
+  if ! command -v systemctl >/dev/null 2>&1; then
+    printf "❌ ERROR: systemctl not found. Podman needs podman-restart.service to start\n"
+    printf "   the agent container on boot, which requires systemd.\n"
+    printf "   Set SKIP_BOOT_RESTART_CHECK=1 to install anyway (if you manage the container\n"
+    printf "   lifecycle yourself), or use INSTALL_METHOD=docker or standalone.\n"
+    exit 1
+  fi
+
+  if ! systemctl is-enabled podman-restart.service >/dev/null 2>&1; then
+    printf "❌ ERROR: podman-restart.service is not enabled. Without it the agent container\n"
+    printf "   will not start on boot.\n\n"
+    printf "   Enable it with:\n\n"
+    printf "     sudo systemctl enable podman-restart.service\n\n"
+    printf "   Then re-run this script. Set SKIP_BOOT_RESTART_CHECK=1 to install anyway\n"
+    printf "   (if you manage the container lifecycle yourself).\n"
+    exit 1
+  fi
+}
+
 podman_install() {
+  check_podman_boot_restart
+
   [ -n "${KEEPALIVE_INTERVAL}" ] && ARGS="$ARGS -e SHELLHUB_KEEPALIVE_INTERVAL=$KEEPALIVE_INTERVAL"
   [ -n "${PREFERRED_HOSTNAME}" ] && ARGS="$ARGS -e SHELLHUB_PREFERRED_HOSTNAME=$PREFERRED_HOSTNAME"
   [ -n "${PREFERRED_IDENTITY}" ] && ARGS="$ARGS -e SHELLHUB_PREFERRED_IDENTITY=$PREFERRED_IDENTITY"
@@ -171,7 +200,7 @@ podman_install() {
   $SUDO podman run -d \
     --name=$CONTAINER_NAME \
     --replace \
-    --restart=on-failure \
+    --restart=unless-stopped \
     --privileged \
     --pid=host \
     --security-opt label=disable \
@@ -259,7 +288,7 @@ docker_install() {
 
   $SUDO docker run -d \
     --name=$CONTAINER_NAME \
-    --restart=on-failure \
+    --restart=unless-stopped \
     --privileged \
     --net=host \
     --pid=host \


### PR DESCRIPTION
## What

Switches the agent container restart policy from `on-failure` to `unless-stopped` in both the Podman and Docker install paths, and adds a pre-flight check for `podman-restart.service` in the Podman path.

## Why

`--restart=on-failure` never starts the agent container on boot under Podman. Podman has no daemon — boot-time container startup is handled by `podman-restart.service`, which only picks up containers whose restart policy is `always` or `unless-stopped`. With `on-failure`, the agent goes offline on the first reboot and stays offline until manually started.

On Docker the current policy works only by accident: `on-failure` restarts after a daemon restart only when the last exit was non-zero, and the agent happens to die with 143 (unhandled SIGTERM). Adding graceful shutdown to the agent in the future would make it exit 0 and silently break this.

Closes #6958

## Changes

- **`install.sh` restart policy**: `--restart=on-failure` → `--restart=unless-stopped` on both the Podman (`podman run`) and Docker (`docker run`) branches. Fixes Podman and removes the exit-code dependency on Docker.
- **`install.sh` boot-restart pre-flight**: new `check_podman_boot_restart()` called at the top of `podman_install()`. Aborts when `systemctl` is missing or `podman-restart.service` is not enabled, with actionable error messages. The unit is never enabled silently — it affects all containers on the host, not just ours.
- **`SKIP_BOOT_RESTART_CHECK=1`**: escape hatch for managed environments (Quadlet, orchestrators, CI) where boot-time container lifecycle is handled externally. Skips the check and prints what was skipped.
- **`tests/install-boot-check_test.sh`**: shell test covering all five branches of the check function (no systemctl, service disabled, service enabled, skip+no systemctl, skip+disabled).

## Testing

Run the shell test: `bash tests/install-boot-check_test.sh` (5 pass). For end-to-end verification on a Podman host (Fedora/RHEL), install the agent, confirm `podman inspect` shows `unless-stopped`, and verify the container survives a reboot via `podman-restart.service`.