### PR TITLE
fix(ui): fix action buttons alignment in `AcceptDeviceFlow`'s error branch

### DIFF
--- a/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
+++ b/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
@@ -197,7 +197,7 @@ export default function AcceptDeviceFlow({
             </>
           }
           action={
-            <div className="space-y-3">
+            <div className="flex flex-col items-center gap-3">
               <Button
                 variant="secondary"
                 size="md"


### PR DESCRIPTION
## What
Made the action buttons wrapper on error branch a flex container, properly putting the buttons in a column and aligning them at center.

## Why
The buttons were appearing in the same line, with no space between them.

## Testing
Go to `/accept-device?code=INVALID` and see the buttons in a column and centered, with proper gap between them.
