### PR TITLE
fix: upgrade libssl3/libcrypto3 in production images for CVE-2026-14456

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -48,7 +48,8 @@ ENTRYPOINT ["/entrypoint.sh"]
 # production stage
 FROM alpine:3.24.1 AS production
 
-RUN apk add --no-cache ca-certificates libgcc
+RUN apk add --no-cache ca-certificates libgcc && \
+    apk upgrade --no-cache libssl3 libcrypto3 # CVE-2026-14456: drop upgrade when alpine base includes the fix
 
 # The account key and the certificates. Declared here rather than in the compose
 # file so the volume exists however the image is run: without it, every recreate

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -93,7 +93,8 @@ ENTRYPOINT ["/entrypoint.sh"]
 # ── production stage ──────────────────────────────────────────────────────────
 FROM alpine:3.24.1 AS production
 
-RUN apk add --no-cache curl openssh-client
+RUN apk add --no-cache curl openssh-client && \
+    apk upgrade --no-cache libssl3 libcrypto3 # CVE-2026-14456: drop upgrade when alpine base includes the fix
 
 COPY --from=builder /server /server
 COPY --from=builder /templates /templates

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -64,6 +64,9 @@ RUN apk add --no-cache brotli gzip && \
 
 FROM alpine:3.24.1 AS production
 
+# CVE-2026-14456: remove when alpine base image includes the fix
+RUN apk upgrade --no-cache libssl3 libcrypto3
+
 # Pinned exactly, not to a major: the header precedence ui/sws.toml relies on is
 # undocumented, so a release that changed it would break caching silently.
 ARG SWS_VERSION=2.44.0


### PR DESCRIPTION
## What

Upgrades `libssl3` and `libcrypto3` in the gateway, server, and ui production images to patch CVE-2026-14456 (OpenSSL QUIC server unbounded memory growth).

## Why

Vulnerability scanners flag the OpenSSL libraries shipped in `alpine:3.24.1`. The CVE targets the QUIC server listener API, which none of our services use — Go handles TLS natively and the ui serves static files via SWS — so it is not exploitable in practice, but upgrading the specific packages silences the scanner without risk.

A blanket `apk upgrade` was considered and rejected: it would pull in unrelated package updates, make builds less reproducible, and require the same cleanup effort later. Targeting only `libssl3`/`libcrypto3` keeps the blast radius to what the CVE actually affects.

## Changes

- **gateway, server Dockerfiles**: appended a targeted `apk upgrade` for `libssl3`/`libcrypto3` to the existing `apk add` line in the production stage
- **ui Dockerfile**: added a standalone `apk upgrade` for the same packages (the production stage had no prior `apk add` to append to)

Each line is marked for removal once the Alpine base image ships the fix.