### PR TITLE
feat(server): count registered devices without the full statistics read

### DIFF
--- a/server/api/store/mocks/mock_store.go
+++ b/server/api/store/mocks/mock_store.go
@@ -1157,6 +1157,72 @@ func (_c *MockStore_ActiveSessionUpdate_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// CountRegisteredDevices provides a mock function for the type MockStore
+func (_mock *MockStore) CountRegisteredDevices(ctx context.Context, sc scope.Scope) (int, error) {
+	ret := _mock.Called(ctx, sc)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountRegisteredDevices")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, scope.Scope) (int, error)); ok {
+		return returnFunc(ctx, sc)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, scope.Scope) int); ok {
+		r0 = returnFunc(ctx, sc)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, scope.Scope) error); ok {
+		r1 = returnFunc(ctx, sc)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CountRegisteredDevices_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountRegisteredDevices'
+type MockStore_CountRegisteredDevices_Call struct {
+	*mock.Call
+}
+
+// CountRegisteredDevices is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sc scope.Scope
+func (_e *MockStore_Expecter) CountRegisteredDevices(ctx any, sc any) *MockStore_CountRegisteredDevices_Call {
+	return &MockStore_CountRegisteredDevices_Call{Call: _e.mock.On("CountRegisteredDevices", ctx, sc)}
+}
+
+func (_c *MockStore_CountRegisteredDevices_Call) Run(run func(ctx context.Context, sc scope.Scope)) *MockStore_CountRegisteredDevices_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 scope.Scope
+		if args[1] != nil {
+			arg1 = args[1].(scope.Scope)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CountRegisteredDevices_Call) Return(n int, err error) *MockStore_CountRegisteredDevices_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockStore_CountRegisteredDevices_Call) RunAndReturn(run func(ctx context.Context, sc scope.Scope) (int, error)) *MockStore_CountRegisteredDevices_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeviceConflicts provides a mock function for the type MockStore
 func (_mock *MockStore) DeviceConflicts(ctx context.Context, sc scope.Scope, target *models.DeviceConflicts, opts ...store.QueryOption) ([]string, bool, error) {
 	var tmpRet mock.Arguments

--- a/server/api/store/pg/stats.go
+++ b/server/api/store/pg/stats.go
@@ -57,6 +57,16 @@ func (pg *Pg) GetStats(ctx context.Context, sc scope.Scope) (*models.Stats, erro
 	return stats, nil
 }
 
+func (pg *Pg) CountRegisteredDevices(ctx context.Context, sc scope.Scope) (int, error) {
+	db := pg.GetConnection(ctx)
+
+	if !sc.IsValid() {
+		return 0, store.ErrInvalidScope
+	}
+
+	return countInScope(ctx, buildRegisteredDevicesQuery(db), sc)
+}
+
 func countInScope(ctx context.Context, query *bun.SelectQuery, sc scope.Scope) (int, error) {
 	query, err := applyScopedOptions(ctx, query, sc)
 	if err != nil {

--- a/server/api/store/pg/store_test.go
+++ b/server/api/store/pg/store_test.go
@@ -112,6 +112,7 @@ func TestPgStore(t *testing.T) {
 	runSubSuite(t, "StatsStore", func(suite *storetest.Suite, t *testing.T) {
 		suite.TestGetStats(t)
 		suite.TestGetStatsOnlineBoundary(t)
+		suite.TestCountRegisteredDevices(t)
 	})
 
 	runSubSuite(t, "PrivateKeyStore", func(suite *storetest.Suite, t *testing.T) {
@@ -182,6 +183,7 @@ func TestPgStore(t *testing.T) {
 		suite.TestScopeIsolationMembershipInvitationResolve(t)
 		suite.TestScopeIsolationNamespaceMembershipInvitationList(t)
 		suite.TestScopeIsolationGetStats(t)
+		suite.TestScopeIsolationCountRegisteredDevices(t)
 		suite.TestScopeIsolationAccessPolicyList(t)
 		suite.TestScopeIsolationAccessPolicyResolve(t)
 		suite.TestScopeIsolationSSHIdentityList(t)

--- a/server/api/store/stats.go
+++ b/server/api/store/stats.go
@@ -11,4 +11,12 @@ type StatsStore interface {
 	// GetStats retrieves device and session statistics within the given namespace scope. An
 	// unbounded scope returns instance-wide statistics.
 	GetStats(ctx context.Context, sc scope.Scope) (*models.Stats, error)
+
+	// CountRegisteredDevices reports how many devices are accepted within the given namespace
+	// scope. An unbounded scope counts across the whole instance.
+	//
+	// It exists alongside GetStats for callers that need this count alone: GetStats answers five
+	// questions, four of them by scanning the devices table, and a caller that wants one of them
+	// pays for all five.
+	CountRegisteredDevices(ctx context.Context, sc scope.Scope) (int, error)
 }

--- a/server/api/store/storetest/scope_isolation_tests.go
+++ b/server/api/store/storetest/scope_isolation_tests.go
@@ -423,6 +423,31 @@ func (s *Suite) TestScopeIsolationGetStats(t *testing.T) {
 	assert.Equal(t, 1, allStats.RegisteredDevices)
 }
 
+// TestScopeIsolationCountRegisteredDevices pins that the narrow count honours the scope it is
+// given, so a bounded caller cannot read another namespace's devices through it.
+func (s *Suite) TestScopeIsolationCountRegisteredDevices(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+	require.NoError(t, s.provider.CleanDatabase(t))
+
+	owner := s.CreateNamespace(t)
+	other := s.CreateNamespace(t)
+	s.CreateDevice(t, WithTenantID(owner), WithDeviceName("dev"), WithDeviceStatus(models.DeviceStatusAccepted))
+
+	ownerCount, err := st.CountRegisteredDevices(ctx, scope.MustBounded(owner))
+	require.NoError(t, err)
+	assert.Equal(t, 1, ownerCount)
+
+	otherCount, err := st.CountRegisteredDevices(ctx, scope.MustBounded(other))
+	require.NoError(t, err)
+	assert.Equal(t, 0, otherCount)
+
+	// The unbounded scope is what the license evaluation asks for, and it does span both.
+	allCount, err := st.CountRegisteredDevices(ctx, scope.NewUnbounded("test: instance-wide device count spans every namespace"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, allCount)
+}
+
 // TestScopeRejectsUnconstructedScope pins the zero value: a [scope.Scope] that was never built is
 // neither bounded nor deliberately unbounded, so the store refuses it instead of reading everything.
 func (s *Suite) TestScopeRejectsUnconstructedScope(t *testing.T) {

--- a/server/api/store/storetest/stats_tests.go
+++ b/server/api/store/storetest/stats_tests.go
@@ -138,3 +138,77 @@ func (s *Suite) TestGetStatsOnlineBoundary(t *testing.T) {
 		assert.Equal(t, 0, stats.OnlineDevices, "the window follows the clock, not wall time")
 	})
 }
+
+// TestCountRegisteredDevices covers the narrow count the license and firewall evaluations use.
+// It answers the same question as GetStats' RegisteredDevices field, so the two must agree on
+// what "registered" means: accepted only, pending and rejected excluded.
+func (s *Suite) TestCountRegisteredDevices(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	t.Run("counts accepted devices across every namespace when unbounded", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant1 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("pending"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("rejected"))
+
+		tenant2 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant2), WithDeviceStatus("accepted"))
+
+		count, err := st.CountRegisteredDevices(ctx, scope.NewUnbounded(reasonTestQueryMechanics))
+		require.NoError(t, err)
+
+		assert.Equal(t, 3, count, "2 accepted from tenant1 + 1 from tenant2, ignoring pending and rejected")
+	})
+
+	t.Run("counts only the scoped namespace when bounded", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant1 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("pending"))
+
+		tenant2 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant2), WithDeviceStatus("accepted"))
+
+		count, err := st.CountRegisteredDevices(ctx, scope.MustBounded(tenant1))
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, count)
+	})
+
+	t.Run("returns zero for a namespace with no accepted devices", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenantID := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("pending"))
+
+		count, err := st.CountRegisteredDevices(ctx, scope.MustBounded(tenantID))
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("agrees with GetStats", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenantID := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("rejected"))
+
+		sc := scope.NewUnbounded(reasonTestQueryMechanics)
+
+		stats, err := st.GetStats(ctx, sc)
+		require.NoError(t, err)
+
+		count, err := st.CountRegisteredDevices(ctx, sc)
+		require.NoError(t, err)
+
+		assert.Equal(t, stats.RegisteredDevices, count)
+	})
+}

--- a/server/api/store/storetest/suite.go
+++ b/server/api/store/storetest/suite.go
@@ -102,6 +102,7 @@ func (s *Suite) Run(t *testing.T) {
 	t.Run("StatsStore", func(t *testing.T) {
 		s.TestGetStats(t)
 		s.TestGetStatsOnlineBoundary(t)
+		s.TestCountRegisteredDevices(t)
 	})
 
 	t.Run("PrivateKeyStore", func(t *testing.T) {
@@ -171,6 +172,7 @@ func (s *Suite) Run(t *testing.T) {
 		s.TestScopeIsolationMembershipInvitationResolve(t)
 		s.TestScopeIsolationNamespaceMembershipInvitationList(t)
 		s.TestScopeIsolationGetStats(t)
+		s.TestScopeIsolationCountRegisteredDevices(t)
 		s.TestScopeIsolationAccessPolicyList(t)
 		s.TestScopeIsolationAccessPolicyResolve(t)
 		s.TestScopeIsolationSSHIdentityList(t)


### PR DESCRIPTION
> Stacked on #6883. Base is `perf/device-heartbeat-hot-updates`, not `master`.
> The consumer side lives in shellhub-io/cloud#2516, which is what closes
> shellhub-io/team#212. This PR on its own changes no behaviour.

## What

Adds `CountRegisteredDevices(ctx, scope) (int, error)` to `StatsStore`, alongside the existing `GetStats`.

## Why

`GetStats` answers five questions in five statements, four of them sequential scans of `devices`, and returns them as one object. That is right for the dashboard and the admin console, which want all five fields.

It is wrong for a caller that wants one. Three evaluations on the SSH connection path ask for the full object and read only `RegisteredDevices`, so every connection sweeps the table four times to learn one number. On the deployment measured in shellhub-io/team#212 (58,670 devices) that is roughly 235,000 rows read per connection, and about 43% of all sequential scans recorded against `devices` over 66 days.

The cost is not confined to the connection that paid it: repeatedly sweeping the table evicts other queries' pages from `shared_buffers`, which is part of why that host sits at an 84.76% buffer cache hit ratio against a healthy target above 99%.

This PR adds the narrow question. The three call sites move to it in the cloud PR.

## Changes

- `StatsStore` gains `CountRegisteredDevices`. `GetStats` is untouched.
- The Postgres implementation composes `buildRegisteredDevicesQuery` with `countInScope`. No new SQL is written, so "registered" cannot drift between this and `GetStats`.
- Same fail-closed behaviour as `GetStats` on an unconstructed scope (`store.ErrInvalidScope`).
- Store mock regenerated (mockery v3.7.1, the version pinned in `server/Dockerfile`).

No migration, no index, no schema change. An index on device status is deliberately not the answer here: it conflicts with the HOT work in #6883. This removes three quarters of the work rather than making all of it faster.

## Testing

Store suite, against a real PostgreSQL via testcontainers:

- `TestCountRegisteredDevices` - counts accepted across every namespace when unbounded; only the scoped namespace when bounded; zero for a namespace with no accepted devices; and agrees with `GetStats().RegisteredDevices` on the same fixture.
- `TestScopeIsolationCountRegisteredDevices` - a bounded caller cannot read another namespace's devices through it.

Registered in both `storetest/suite.go` and `pg/store_test.go`. The second is what executes; nothing enforces that the two lists match.

```
go test ./... -count=1        0 failures
golangci-lint run ./...       0 issues
go mod tidy                   clean, root and server
```

## Exercising the path by hand

Not trivial, so worth writing down. The count is only reached under a specific set of conditions:

1. **Enterprise or cloud edition.** In community the evaluator is nil and returns immediately.
2. **A license with a non-negative device ceiling.** `Features.Devices < 0` means unlimited, and the evaluator returns before counting. A default dev license is typically unlimited, which is why an SSH connection can produce zero count statements and look like the code never ran.
3. **A namespace in legacy SSH access mode**, if you want the firewall site too. Firewall is skipped for identity mode, and namespaces created after migration `016` are born `identity`. Flip `ssh_access_mode` and `ssh_legacy_allowed` on the row to simulate a grandfathered customer.

To measure, with the UI tab closed (the dashboard polls `/stats` and pollutes the counters):

```sql
select pg_stat_reset();
select pg_stat_statements_reset();
-- make exactly one SSH connection, then:
select seq_scan, seq_tup_read from pg_stat_user_tables where relname = 'devices';
select calls, query from pg_stat_statements where query ilike '%count(*) from "devices"%';
```

`pg_stat_statements` is available in the dev stack as of #6886. Run it once with the cloud change and once without: the delta in `calls` is the claim this series makes.

## Follow-up, not in scope

`GetStats` could answer all five in one statement using `count(*) FILTER (WHERE ...)`, which would help the `/stats` polling that accounts for the other share of the scans on this table. Separate change, separate measurement, deliberately not bundled here.
