### PR TITLE
fix(ssh): report the reason an access policy denied a connection

### DIFF
--- a/server/ssh/session/auther.go
+++ b/server/ssh/session/auther.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/ssh/pkg/banner"
 	"github.com/shellhub-io/shellhub/server/ssh/pkg/magickey"
+	log "github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -230,13 +231,34 @@ func (s *Session) awaitApproval(gctx gliderssh.Context) (string, error) {
 // authorize is the hard identity-mode gate: it refuses here, before any key is
 // minted, so the agent is never contacted for a login the policies deny. It
 // returns the decision so the caller can honor a step-up requirement.
+//
+// A refusal is reported here rather than by the callers: this is the last point
+// at which a denial, a failed evaluation and a missing decision are still
+// distinguishable, and every caller refuses through it.
 func (s *Session) authorize(ctx context.Context) (*models.Decision, error) {
 	dec, err := s.service.Authorize(ctx, s.Namespace.TenantID, s.UserID, s.Device.UID, s.Target.Username, s.IPAddress)
-	if err != nil || dec == nil || !dec.Allowed {
-		return nil, ErrAccessDenied
+	if err == nil && dec != nil && dec.Allowed {
+		return dec, nil
 	}
 
-	return dec, nil
+	// The log is the only place the reason can go: the sentinel below carries no
+	// detail, and must not, since the reason names policies the client may not be
+	// entitled to know about.
+	logger := log.WithFields(s.LogFields()).WithFields(log.Fields{
+		"tenant": s.Namespace.TenantID,
+		"user":   s.UserID,
+	})
+
+	switch {
+	case err != nil:
+		logger.WithError(err).Error("failed to evaluate the access policies")
+	case dec == nil:
+		logger.Error("access policy evaluation returned no decision")
+	default:
+		logger.WithField("reason", dec.Reason).Warn("ssh access denied by the access policies")
+	}
+
+	return nil, ErrAccessDenied
 }
 
 // approvalAuth authenticates a session whose presented key is not an identity

--- a/server/ssh/session/identity_test.go
+++ b/server/ssh/session/identity_test.go
@@ -1,8 +1,10 @@
 package session
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +15,8 @@ import (
 	"github.com/shellhub-io/shellhub/server/api/services"
 	servicemocks "github.com/shellhub-io/shellhub/server/api/services/mocks"
 	"github.com/shellhub-io/shellhub/server/ssh/pkg/target"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -183,5 +187,122 @@ func TestResolveKeyAuth(t *testing.T) {
 		// created and waited on, not what the person decided.
 		require.ErrorIs(t, auth.Evaluate(sess), ErrApprovalRejected)
 		assert.Equal(t, "AB12CD34", sess.ApprovalCode)
+	})
+}
+
+// captureLogs collects what the session logs on the standard logger, at debug
+// level so entries below the default threshold are recorded too.
+func captureLogs(t *testing.T) *test.Hook {
+	t.Helper()
+
+	hook := test.NewGlobal()
+	level := log.GetLevel()
+	log.SetLevel(log.DebugLevel)
+
+	t.Cleanup(func() {
+		log.SetLevel(level)
+		hook.Reset()
+	})
+
+	return hook
+}
+
+func TestAuthorize(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a policy denial is reported with the reason the policies gave", func(t *testing.T) {
+		hook := captureLogs(t)
+
+		serviceMock := servicemocks.NewMockService(t)
+		serviceMock.EXPECT().
+			Authorize(mock.Anything, "tenant-id", "user-id", "device-uid", "user", "127.0.0.1").
+			Return(&models.Decision{Allowed: false, Reason: `no policy grants "root" on this device`}, nil).
+			Once()
+
+		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
+		sess.UserID = "user-id"
+
+		dec, err := sess.authorize(ctx)
+
+		require.ErrorIs(t, err, ErrAccessDenied)
+		assert.Nil(t, dec)
+
+		require.Len(t, hook.AllEntries(), 1)
+
+		entry := hook.LastEntry()
+		assert.Equal(t, log.WarnLevel, entry.Level)
+		assert.Equal(t, `no policy grants "root" on this device`, entry.Data["reason"])
+		assert.Equal(t, "tenant-id", entry.Data["tenant"])
+		assert.Equal(t, "user-id", entry.Data["user"])
+		assert.Equal(t, "device-uid", entry.Data["device"])
+		assert.Equal(t, "user", entry.Data["username"])
+		assert.Equal(t, "127.0.0.1", entry.Data["ip"])
+		assert.Equal(t, "test-uid", entry.Data["session"])
+	})
+
+	t.Run("a failure to evaluate the policies is reported as a malfunction", func(t *testing.T) {
+		hook := captureLogs(t)
+
+		serviceMock := servicemocks.NewMockService(t)
+		serviceMock.EXPECT().
+			Authorize(mock.Anything, "tenant-id", "user-id", "device-uid", "user", "127.0.0.1").
+			Return(nil, errors.New("the store is unreachable")).
+			Once()
+
+		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
+		sess.UserID = "user-id"
+
+		dec, err := sess.authorize(ctx)
+
+		require.ErrorIs(t, err, ErrAccessDenied)
+		assert.Nil(t, dec)
+
+		require.Len(t, hook.AllEntries(), 1)
+
+		entry := hook.LastEntry()
+		assert.Equal(t, log.ErrorLevel, entry.Level)
+		assert.EqualError(t, entry.Data[log.ErrorKey].(error), "the store is unreachable")
+		assert.NotContains(t, entry.Data, "reason")
+	})
+
+	t.Run("an absent decision is reported as a malfunction", func(t *testing.T) {
+		hook := captureLogs(t)
+
+		serviceMock := servicemocks.NewMockService(t)
+		serviceMock.EXPECT().
+			Authorize(mock.Anything, "tenant-id", "user-id", "device-uid", "user", "127.0.0.1").
+			Return(nil, nil).
+			Once()
+
+		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
+		sess.UserID = "user-id"
+
+		dec, err := sess.authorize(ctx)
+
+		require.ErrorIs(t, err, ErrAccessDenied)
+		assert.Nil(t, dec)
+
+		require.Len(t, hook.AllEntries(), 1)
+		assert.Equal(t, log.ErrorLevel, hook.LastEntry().Level)
+	})
+
+	t.Run("an allowed decision is returned without a log line", func(t *testing.T) {
+		hook := captureLogs(t)
+
+		serviceMock := servicemocks.NewMockService(t)
+		serviceMock.EXPECT().
+			Authorize(mock.Anything, "tenant-id", "user-id", "device-uid", "user", "127.0.0.1").
+			Return(&models.Decision{Allowed: true, RequireReauth: true}, nil).
+			Once()
+
+		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
+		sess.UserID = "user-id"
+
+		dec, err := sess.authorize(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, dec)
+		assert.True(t, dec.RequireReauth)
+		assert.Empty(t, hook.AllEntries())
 	})
 }


### PR DESCRIPTION
## What

When Access Policies refuse an SSH connection, the server now logs why: tenant, user, device, login, source IP and the reason. Nothing changes for the client.

## Why

The policy service computes one of four reasons on every refusal (not a member, denied by a policy, a policy that could not be evaluated, no policy grants that login). The gate threw all of them away and returned a bare sentinel.

The only line left came from one level up, where the public key layer reports every evaluation failure as a failure of the key itself - so a policy refusal looked like a bad credential, with no tenant, login, IP or reason. Support cannot tell "not a member" from "no policy grants root", which need completely different fixes.

The reason stays server-side: it names policies the client may not be entitled to know about.

## Changes

- The gate logs the refusal before discarding it. It logs there, not in its callers, because it is the last point where the reason is in scope and both callers refuse through it.
- The three outcomes it collapsed are split: an unreachable policy engine and a missing decision are malfunctions (`Error`); a refusal is an expected answer (`Warn`). All three still return the same sentinel. Otherwise a store outage would log as a denial with an empty reason.
- Fields reuse the session's `LogFields()` set plus `tenant` and `user`, so a refusal correlates with the rest of that session's output.
- Tests for the gate, which had none.

Out of scope, worth their own issues: four other refusals return the same sentinel and are still silent, and `approvalAuth.Evaluate` discards the decision entirely, so step-up re-auth is skipped on the post-approval path.

## Testing

`go test ./ssh/session/ -run TestAuthorize -count=1 -v` - four cases: a denial asserts `Warn`, the reason and the fields; both malfunction arms assert `Error`; the allow path asserts nothing is logged. All assert the sentinel is still returned. Full `server` suite and `golangci-lint run ./...` clean.

End to end on a dev stack:

1. Put the namespace in **identity access mode** - policies are only consulted there.
2. Create at least one policy, then a `deny` matching your device. With zero policies the refusal happens earlier, at a path that is still silent by design.
3. Connect and watch: `./bin/docker-compose logs -f server | grep "access denied by the access policies"`

```
WARN ssh access denied by the access policies device=<device-uid> ip=<client-ip> reason="denied by policy \"<policy-name>\"" session=<session-uid> sshid=<sshid> tenant=<tenant-id> user=<user-id> username=<login>
```

The old misleading line still follows it; fixing that is out of scope. The two `Error` arms are covered by unit tests, since staging them by hand is awkward.

Fixes: shellhub-io/team#229