### PR TITLE
fix(ui): use identity-mode wording in the access denied banner

### DIFF
--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -9,6 +9,10 @@ import { generateSignature } from "@/utils/sshKeys";
 import type { TerminalSession } from "@/stores/terminalStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
+import { useAuthStore } from "@/stores/authStore";
+import { useNamespace } from "@/hooks/useNamespaces";
+import { useRecordingsStore } from "@/stores/recordingsStore";
+import { OpfsCastRecorder } from "@/utils/recordings";
 import { nextFontSize } from "./fontSizeShortcut";
 import type { TerminalError } from "./terminalErrors";
 import TerminalErrorBanner from "./TerminalErrorBanner";
@@ -23,8 +27,6 @@ import {
 } from "./terminalErrors";
 import SSHApproval from "@/pages/SSHApproval";
 import { cn } from "@shellhub/design-system/cn";
-import { OpfsCastRecorder } from "@/utils/recordings";
-import { useRecordingsStore } from "@/stores/recordingsStore";
 
 interface TerminalInstanceProps {
   session: TerminalSession;
@@ -49,6 +51,10 @@ export default function TerminalInstance({
   const [approvalCode, setApprovalCode] = useState<string | null>(null);
 
   const { theme, fontFamilyWithFallback, fontSize } = useTerminalThemeStore();
+
+  const tenant = useAuthStore((s) => s.tenant);
+  const { namespace } = useNamespace(tenant ?? "");
+  const isIdentityMode = namespace?.settings?.ssh_access_mode === "identity";
 
   const updateStatus = useCallback(
     (s: "connecting" | "connected" | "disconnected") => {
@@ -283,7 +289,7 @@ export default function TerminalInstance({
             case WS_KIND.ERROR: {
               lastError = true;
               updateStatus("disconnected");
-              setError(resolveError(msg.data, session.deviceUid));
+              setError(resolveError(msg.data, session.deviceUid, isIdentityMode));
               break;
             }
             case WS_KIND.SESSION: {

--- a/ui/apps/console/src/components/terminal/terminalErrors.test.ts
+++ b/ui/apps/console/src/components/terminal/terminalErrors.test.ts
@@ -1,21 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { resolveError } from "./terminalErrors";
-import { getConfig } from "@/env";
+import { defaultConfig, getConfig } from "@/env";
 
 const mockGetConfig = vi.mocked(getConfig);
 
-beforeEach(() => {
-  mockGetConfig.mockReturnValue({
-    edition: "community",
-  } as ReturnType<typeof getConfig>);
-});
-
 describe("resolveError", () => {
+  beforeEach(() => {
+    mockGetConfig.mockReturnValue({
+      ...defaultConfig,
+      edition: "community",
+    });
+  });
   describe("access to the device has been denied", () => {
     it("resolves with reconnect false", () => {
       const result = resolveError(
         "access to the device has been denied",
         "uid-1",
+        false,
       );
       expect(result.reconnect).toBe(false);
     });
@@ -24,6 +25,7 @@ describe("resolveError", () => {
       const result = resolveError(
         "access to the device has been denied",
         "uid-1",
+        false,
       );
       expect(result.title).toBe("Access denied");
     });
@@ -32,6 +34,7 @@ describe("resolveError", () => {
       const result = resolveError(
         "access to the device has been denied",
         "uid-1",
+        false,
       );
       expect(result.message).toContain("permission");
     });
@@ -40,6 +43,7 @@ describe("resolveError", () => {
       const result = resolveError(
         "access to the device has been denied",
         "uid-1",
+        false,
       );
       const hintText = result.hints.join(" ").toLowerCase();
       expect(hintText.includes("billing") || hintText.includes("policy")).toBe(
@@ -49,11 +53,13 @@ describe("resolveError", () => {
 
     it("does not show the word 'firewall' twice when cloud edition appends its hint", () => {
       mockGetConfig.mockReturnValue({
+        ...defaultConfig,
         edition: "cloud",
-      } as ReturnType<typeof getConfig>);
+      });
       const result = resolveError(
         "access to the device has been denied",
         "uid-1",
+        false,
       );
       const allHintText = result.hints.join(" ").toLowerCase();
       const count = (allHintText.match(/firewall/g) ?? []).length;
@@ -62,11 +68,13 @@ describe("resolveError", () => {
 
     it("includes a firewall/rules link when cloud or enterprise is enabled", () => {
       mockGetConfig.mockReturnValue({
+        ...defaultConfig,
         edition: "cloud",
-      } as ReturnType<typeof getConfig>);
+      });
       const result = resolveError(
         "access to the device has been denied",
         "uid-1",
+        false,
       );
       expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(true);
     });
@@ -75,24 +83,80 @@ describe("resolveError", () => {
       const result = resolveError(
         "access to the device has been denied",
         "uid-1",
+        false,
       );
       expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(false);
+    });
+
+    describe("identity mode", () => {
+      beforeEach(() => {
+        mockGetConfig.mockReturnValue({
+          ...defaultConfig,
+          edition: "cloud",
+        });
+      });
+
+      it("says 'access policy' instead of 'firewall rule' in hints", () => {
+        const result = resolveError(
+          "access to the device has been denied",
+          "uid-1",
+          true,
+        );
+        const hintText = result.hints.join(" ").toLowerCase();
+        expect(hintText).toContain("access policy");
+        expect(hintText).not.toContain("firewall");
+      });
+
+      it("labels the link 'Access policies' instead of 'Firewall rules'", () => {
+        const result = resolveError(
+          "access to the device has been denied",
+          "uid-1",
+          true,
+        );
+        const link = result.links.find((l) => l.to === "/firewall-rules");
+        expect(link).toBeDefined();
+        expect(link!.label).toBe("Access policies");
+      });
+
+      it("says 'access policy' instead of 'namespace policy' in the base hint", () => {
+        const result = resolveError(
+          "access to the device has been denied",
+          "uid-1",
+          true,
+        );
+        const hintText = result.hints.join(" ").toLowerCase();
+        expect(hintText).toContain("access policy");
+        expect(hintText).not.toContain("namespace policy");
+      });
+
+      it("keeps firewall wording when not in identity mode", () => {
+        const result = resolveError(
+          "access to the device has been denied",
+          "uid-1",
+          false,
+        );
+        const hintText = result.hints.join(" ").toLowerCase();
+        expect(hintText).toContain("firewall");
+        expect(result.links.some((l) => l.label === "Firewall rules")).toBe(
+          true,
+        );
+      });
     });
   });
 
   describe("invalid sshid format", () => {
     it("resolves with reconnect false", () => {
-      const result = resolveError("invalid sshid format", "uid-2");
+      const result = resolveError("invalid sshid format", "uid-2", false);
       expect(result.reconnect).toBe(false);
     });
 
     it("uses an 'Invalid connection identifier' title, not 'Connection failed'", () => {
-      const result = resolveError("invalid sshid format", "uid-2");
+      const result = resolveError("invalid sshid format", "uid-2", false);
       expect(result.title).toBe("Invalid connection identifier");
     });
 
     it("includes a hint showing the username@namespace.device@host form", () => {
-      const result = resolveError("invalid sshid format", "uid-2");
+      const result = resolveError("invalid sshid format", "uid-2", false);
       const hintText = result.hints.join(" ");
       // Must show the SSHID format pattern
       expect(hintText).toMatch(/@.*\./);
@@ -102,23 +166,49 @@ describe("resolveError", () => {
 
   describe("unknown error key", () => {
     it("returns the generic 'Connection failed' title", () => {
-      const result = resolveError("some unknown error", "uid-3");
+      const result = resolveError("some unknown error", "uid-3", false);
       expect(result.title).toBe("Connection failed");
     });
   });
 
   describe("firewall link behavior for other known errors", () => {
     it("does not include firewall/rules link for authentication errors on community edition", () => {
-      const result = resolveError("failed to authenticate to device", "uid-4");
+      const result = resolveError(
+        "failed to authenticate to device",
+        "uid-4",
+        false,
+      );
       expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(false);
     });
 
     it("includes firewall/rules link for authentication errors on cloud edition", () => {
       mockGetConfig.mockReturnValue({
+        ...defaultConfig,
         edition: "cloud",
-      } as ReturnType<typeof getConfig>);
-      const result = resolveError("failed to authenticate to device", "uid-4");
+      });
+
+      const result = resolveError(
+        "failed to authenticate to device",
+        "uid-4",
+        false,
+      );
       expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(true);
+    });
+
+    it("labels the link 'Access policies' in identity mode", () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        edition: "cloud",
+      });
+
+      const result = resolveError(
+        "failed to authenticate to device",
+        "uid-4",
+        true,
+      );
+      const link = result.links.find((l) => l.to === "/firewall-rules");
+      expect(link).toBeDefined();
+      expect(link!.label).toBe("Access policies");
     });
   });
 });

--- a/ui/apps/console/src/components/terminal/terminalErrors.ts
+++ b/ui/apps/console/src/components/terminal/terminalErrors.ts
@@ -180,7 +180,11 @@ export function parseMessage(
   return null;
 }
 
-export function resolveError(raw: string, deviceUid: string): TerminalError {
+export function resolveError(
+  raw: string,
+  deviceUid: string,
+  isIdentityMode: boolean,
+): TerminalError {
   const entry = errorMap[raw];
   if (!entry) {
     return {
@@ -192,19 +196,25 @@ export function resolveError(raw: string, deviceUid: string): TerminalError {
     };
   }
 
-  const hasFirewall = isEnterpriseOrCloud();
-
-  const hints = [...entry.hints];
-  if (hasFirewall) {
-    hints.push("A firewall rule may be blocking this connection.");
-  }
+  const hints = entry.hints.map((h) =>
+    isIdentityMode ? h.replace("namespace policy", "access policy") : h,
+  );
 
   const links = (entry.links ?? []).map((l) => ({
     ...l,
-    to: l.to.split("$uid").join(deviceUid),
+    to: l.to.replace("$uid", encodeURIComponent(deviceUid)),
   }));
-  if (hasFirewall) {
-    links.push({ label: "Firewall rules", to: "/firewall-rules" });
+
+  if (isEnterpriseOrCloud()) {
+    hints.push(
+      isIdentityMode
+        ? "An access policy may be blocking this connection."
+        : "A firewall rule may be blocking this connection.",
+    );
+    links.push({
+      label: isIdentityMode ? "Access policies" : "Firewall rules",
+      to: "/firewall-rules",
+    });
   }
 
   return {


### PR DESCRIPTION
## What

The terminal error banner now uses identity-mode terminology when the namespace has `ssh_access_mode` set to `identity`, instead of unconditionally blaming firewall rules.

## Why

In identity mode, firewall rules do not exist — the sidebar hides them and the feature is replaced by Access Policies. The banner said "A firewall rule may be blocking this connection" and linked to "Firewall rules" regardless, naming a concept that isn't available and ignoring Access Policies entirely. The base hint also said "namespace policy", which matches no term in the product.

Closes shellhub-io/team#233

## Changes

- **`terminalErrors.ts`**: `resolveError` accepts a required `isIdentityMode` boolean. When true: the appended hint says "An access policy may be blocking this connection", the link is labeled "Access policies", and the base access-denied hint replaces "namespace policy" with "access policy". The `/firewall-rules` destination is unchanged — `LegacyAccessGuard` already redirects to Access Policies in identity mode. Non-identity-mode wording is unchanged.
- **`TerminalInstance.tsx`**: derives `isIdentityMode` from the namespace's `ssh_access_mode` setting (same pattern as the Sidebar) and passes it to `resolveError`.
- **`terminalErrors.test.ts`**: five new identity-mode test cases; existing tests updated to pass `isIdentityMode` explicitly and use `defaultConfig` spread instead of type casts.