### PR TITLE
feat(server): count registered devices without the full statistics read

### DIFF
--- a/server/api/store/mocks/mock_store.go
+++ b/server/api/store/mocks/mock_store.go
@@ -1157,6 +1157,72 @@ func (_c *MockStore_ActiveSessionUpdate_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// CountRegisteredDevices provides a mock function for the type MockStore
+func (_mock *MockStore) CountRegisteredDevices(ctx context.Context, sc scope.Scope) (int, error) {
+	ret := _mock.Called(ctx, sc)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountRegisteredDevices")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, scope.Scope) (int, error)); ok {
+		return returnFunc(ctx, sc)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, scope.Scope) int); ok {
+		r0 = returnFunc(ctx, sc)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, scope.Scope) error); ok {
+		r1 = returnFunc(ctx, sc)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CountRegisteredDevices_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountRegisteredDevices'
+type MockStore_CountRegisteredDevices_Call struct {
+	*mock.Call
+}
+
+// CountRegisteredDevices is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sc scope.Scope
+func (_e *MockStore_Expecter) CountRegisteredDevices(ctx any, sc any) *MockStore_CountRegisteredDevices_Call {
+	return &MockStore_CountRegisteredDevices_Call{Call: _e.mock.On("CountRegisteredDevices", ctx, sc)}
+}
+
+func (_c *MockStore_CountRegisteredDevices_Call) Run(run func(ctx context.Context, sc scope.Scope)) *MockStore_CountRegisteredDevices_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 scope.Scope
+		if args[1] != nil {
+			arg1 = args[1].(scope.Scope)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CountRegisteredDevices_Call) Return(n int, err error) *MockStore_CountRegisteredDevices_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockStore_CountRegisteredDevices_Call) RunAndReturn(run func(ctx context.Context, sc scope.Scope) (int, error)) *MockStore_CountRegisteredDevices_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeviceConflicts provides a mock function for the type MockStore
 func (_mock *MockStore) DeviceConflicts(ctx context.Context, sc scope.Scope, target *models.DeviceConflicts, opts ...store.QueryOption) ([]string, bool, error) {
 	var tmpRet mock.Arguments

--- a/server/api/store/pg/stats.go
+++ b/server/api/store/pg/stats.go
@@ -57,6 +57,16 @@ func (pg *Pg) GetStats(ctx context.Context, sc scope.Scope) (*models.Stats, erro
 	return stats, nil
 }
 
+func (pg *Pg) CountRegisteredDevices(ctx context.Context, sc scope.Scope) (int, error) {
+	db := pg.GetConnection(ctx)
+
+	if !sc.IsValid() {
+		return 0, store.ErrInvalidScope
+	}
+
+	return countInScope(ctx, buildRegisteredDevicesQuery(db), sc)
+}
+
 func countInScope(ctx context.Context, query *bun.SelectQuery, sc scope.Scope) (int, error) {
 	query, err := applyScopedOptions(ctx, query, sc)
 	if err != nil {

--- a/server/api/store/pg/store_test.go
+++ b/server/api/store/pg/store_test.go
@@ -112,6 +112,7 @@ func TestPgStore(t *testing.T) {
 	runSubSuite(t, "StatsStore", func(suite *storetest.Suite, t *testing.T) {
 		suite.TestGetStats(t)
 		suite.TestGetStatsOnlineBoundary(t)
+		suite.TestCountRegisteredDevices(t)
 	})
 
 	runSubSuite(t, "PrivateKeyStore", func(suite *storetest.Suite, t *testing.T) {
@@ -182,6 +183,7 @@ func TestPgStore(t *testing.T) {
 		suite.TestScopeIsolationMembershipInvitationResolve(t)
 		suite.TestScopeIsolationNamespaceMembershipInvitationList(t)
 		suite.TestScopeIsolationGetStats(t)
+		suite.TestScopeIsolationCountRegisteredDevices(t)
 		suite.TestScopeIsolationAccessPolicyList(t)
 		suite.TestScopeIsolationAccessPolicyResolve(t)
 		suite.TestScopeIsolationSSHIdentityList(t)

--- a/server/api/store/stats.go
+++ b/server/api/store/stats.go
@@ -11,4 +11,12 @@ type StatsStore interface {
 	// GetStats retrieves device and session statistics within the given namespace scope. An
 	// unbounded scope returns instance-wide statistics.
 	GetStats(ctx context.Context, sc scope.Scope) (*models.Stats, error)
+
+	// CountRegisteredDevices reports how many devices are accepted within the given namespace
+	// scope. An unbounded scope counts across the whole instance.
+	//
+	// It exists alongside GetStats for callers that need this count alone: GetStats answers five
+	// questions, four of them by scanning the devices table, and a caller that wants one of them
+	// pays for all five.
+	CountRegisteredDevices(ctx context.Context, sc scope.Scope) (int, error)
 }

--- a/server/api/store/storetest/scope_isolation_tests.go
+++ b/server/api/store/storetest/scope_isolation_tests.go
@@ -423,6 +423,31 @@ func (s *Suite) TestScopeIsolationGetStats(t *testing.T) {
 	assert.Equal(t, 1, allStats.RegisteredDevices)
 }
 
+// TestScopeIsolationCountRegisteredDevices pins that the narrow count honours the scope it is
+// given, so a bounded caller cannot read another namespace's devices through it.
+func (s *Suite) TestScopeIsolationCountRegisteredDevices(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+	require.NoError(t, s.provider.CleanDatabase(t))
+
+	owner := s.CreateNamespace(t)
+	other := s.CreateNamespace(t)
+	s.CreateDevice(t, WithTenantID(owner), WithDeviceName("dev"), WithDeviceStatus(models.DeviceStatusAccepted))
+
+	ownerCount, err := st.CountRegisteredDevices(ctx, scope.MustBounded(owner))
+	require.NoError(t, err)
+	assert.Equal(t, 1, ownerCount)
+
+	otherCount, err := st.CountRegisteredDevices(ctx, scope.MustBounded(other))
+	require.NoError(t, err)
+	assert.Equal(t, 0, otherCount)
+
+	// The unbounded scope is what the license evaluation asks for, and it does span both.
+	allCount, err := st.CountRegisteredDevices(ctx, scope.NewUnbounded("test: instance-wide device count spans every namespace"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, allCount)
+}
+
 // TestScopeRejectsUnconstructedScope pins the zero value: a [scope.Scope] that was never built is
 // neither bounded nor deliberately unbounded, so the store refuses it instead of reading everything.
 func (s *Suite) TestScopeRejectsUnconstructedScope(t *testing.T) {

--- a/server/api/store/storetest/stats_tests.go
+++ b/server/api/store/storetest/stats_tests.go
@@ -128,3 +128,77 @@ func (s *Suite) TestGetStatsOnlineBoundary(t *testing.T) {
 		assert.Equal(t, 0, stats.OnlineDevices, "the window follows the clock, not wall time")
 	})
 }
+
+// TestCountRegisteredDevices covers the narrow count the license and firewall evaluations use.
+// It answers the same question as GetStats' RegisteredDevices field, so the two must agree on
+// what "registered" means: accepted only, pending and rejected excluded.
+func (s *Suite) TestCountRegisteredDevices(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	t.Run("counts accepted devices across every namespace when unbounded", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant1 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("pending"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("rejected"))
+
+		tenant2 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant2), WithDeviceStatus("accepted"))
+
+		count, err := st.CountRegisteredDevices(ctx, scope.NewUnbounded(reasonTestQueryMechanics))
+		require.NoError(t, err)
+
+		assert.Equal(t, 3, count, "2 accepted from tenant1 + 1 from tenant2, ignoring pending and rejected")
+	})
+
+	t.Run("counts only the scoped namespace when bounded", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant1 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenant1), WithDeviceStatus("pending"))
+
+		tenant2 := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenant2), WithDeviceStatus("accepted"))
+
+		count, err := st.CountRegisteredDevices(ctx, scope.MustBounded(tenant1))
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, count)
+	})
+
+	t.Run("returns zero for a namespace with no accepted devices", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenantID := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("pending"))
+
+		count, err := st.CountRegisteredDevices(ctx, scope.MustBounded(tenantID))
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("agrees with GetStats", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenantID := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("accepted"))
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("rejected"))
+
+		sc := scope.NewUnbounded(reasonTestQueryMechanics)
+
+		stats, err := st.GetStats(ctx, sc)
+		require.NoError(t, err)
+
+		count, err := st.CountRegisteredDevices(ctx, sc)
+		require.NoError(t, err)
+
+		assert.Equal(t, stats.RegisteredDevices, count)
+	})
+}

--- a/server/api/store/storetest/suite.go
+++ b/server/api/store/storetest/suite.go
@@ -102,6 +102,7 @@ func (s *Suite) Run(t *testing.T) {
 	t.Run("StatsStore", func(t *testing.T) {
 		s.TestGetStats(t)
 		s.TestGetStatsOnlineBoundary(t)
+		s.TestCountRegisteredDevices(t)
 	})
 
 	t.Run("PrivateKeyStore", func(t *testing.T) {
@@ -171,6 +172,7 @@ func (s *Suite) Run(t *testing.T) {
 		s.TestScopeIsolationMembershipInvitationResolve(t)
 		s.TestScopeIsolationNamespaceMembershipInvitationList(t)
 		s.TestScopeIsolationGetStats(t)
+		s.TestScopeIsolationCountRegisteredDevices(t)
 		s.TestScopeIsolationAccessPolicyList(t)
 		s.TestScopeIsolationAccessPolicyResolve(t)
 		s.TestScopeIsolationSSHIdentityList(t)


### PR DESCRIPTION
Re-lands shellhub-io/shellhub#6965 against `master`.

Refs: shellhub-io/team#212

## Why this exists

shellhub-io/cloud#2516 is merged into cloud `master` and calls `store.CountRegisteredDevices`. That method landed in #6965, which was stacked on `perf/device-heartbeat-hot-updates` (#6883) and merged into that branch instead of `master`. #6883 is still open, so `master` does not have the method and cloud `master` no longer compiles against it.

This PR carries the commit onto `master` by itself.

## What is in it

The commit from #6965, unmodified:

- `StatsStore.CountRegisteredDevices` and its `pg` implementation
- the regenerated store mock
- the storetest cases: the count itself, agreement with `GetStats.RegisteredDevices`, and scope isolation

Nothing from #6883 is included. That PR is migrations 020, 021 and 022 only, and the count depends on none of them. The two changes turned out to be independent once separated.

## Testing

```
go build ./...                     ok
go vet ./api/store/...             ok
cloud master, -tags enterprise     builds against this branch
```

The store-side behaviour is covered by the storetest cases against a real PostgreSQL; the three cloud call sites are covered by the tests already merged in shellhub-io/cloud#2516.

## After this merges

#6883 gets rebased onto `master`, which drops its copy of this commit and leaves it as the three migrations it was always about.
