### PR TITLE
refactor(server): give access policy denials a typed reason

### DIFF
--- a/pkg/models/access-policy.go
+++ b/pkg/models/access-policy.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // PolicySubjectType enumerates who an Access Policy grants access to.
 type PolicySubjectType string
@@ -88,16 +91,64 @@ func NewOwnerAccessPolicy(tenantID, ownerID string) *AccessPolicy {
 	}
 }
 
+// DenialReason is the cause of a denied Decision, as a stable value operators can
+// count and filter on. The human sentence is derived from it (see
+// Decision.Message), never the other way round, so rewording never breaks a query.
+type DenialReason string
+
+const (
+	// ReasonNotAMember refuses because the user does not belong to the device's
+	// namespace, so no policy in it could ever apply to them.
+	ReasonNotAMember DenialReason = "not_a_member"
+	// ReasonDeniedByPolicy refuses because a deny policy matched. Carries PolicyName.
+	ReasonDeniedByPolicy DenialReason = "denied_by_policy"
+	// ReasonPolicyUnevaluable refuses because a deny policy could not be evaluated,
+	// and evaluation fails closed. Carries PolicyName.
+	ReasonPolicyUnevaluable DenialReason = "policy_unevaluable"
+	// ReasonNoGrant refuses because no allow policy grants the requested login on
+	// the device, leaving default-deny to stand. Carries Login.
+	ReasonNoGrant DenialReason = "no_grant"
+)
+
 // Decision is the outcome of an Access Policy authorization check.
 type Decision struct {
-	Allowed bool `json:"allowed"`
+	Allowed bool
 	// RequireReauth is set when access is allowed by a policy that carries the
 	// re-auth flag; the gateway must run a fresh re-authentication before
 	// proceeding, subject to ReauthPeriod.
-	RequireReauth bool `json:"require_reauth"`
+	RequireReauth bool
 	// ReauthPeriod is the matched policy's freshness window in seconds (nil/0 =
 	// always). The gateway skips the re-auth when the identity re-authed within
 	// it. Only meaningful when RequireReauth is set.
-	ReauthPeriod *int   `json:"reauth_period"`
-	Reason       string `json:"reason"`
+	ReauthPeriod *int
+
+	// Reason is the cause of the refusal, empty when Allowed.
+	Reason DenialReason
+	// PolicyName is the policy that produced the refusal. Set for
+	// ReasonDeniedByPolicy and ReasonPolicyUnevaluable only.
+	PolicyName string
+	// Login is the login the request asked for. Set for ReasonNoGrant only.
+	Login string
+}
+
+// Message renders a refusal as an operator-facing sentence for the log. It is
+// presentation: the reason code and its fields are the record, and callers must
+// branch on Reason rather than parse this.
+func (d Decision) Message() string {
+	if d.Allowed {
+		return ""
+	}
+
+	switch d.Reason {
+	case ReasonNotAMember:
+		return "user is not a member of the namespace"
+	case ReasonDeniedByPolicy:
+		return fmt.Sprintf("denied by policy %q", d.PolicyName)
+	case ReasonPolicyUnevaluable:
+		return fmt.Sprintf("denied: policy %q could not be evaluated", d.PolicyName)
+	case ReasonNoGrant:
+		return fmt.Sprintf("no policy grants %q on this device", d.Login)
+	default:
+		return "denied by the access policies"
+	}
 }

--- a/pkg/models/access-policy_test.go
+++ b/pkg/models/access-policy_test.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecisionMessage(t *testing.T) {
+	cases := []struct {
+		description     string
+		decision        Decision
+		expectedMessage string
+	}{
+		{
+			description:     "an allowed decision has no denial message",
+			decision:        Decision{Allowed: true},
+			expectedMessage: "",
+		},
+		{
+			description:     "not a member",
+			decision:        Decision{Reason: ReasonNotAMember},
+			expectedMessage: "user is not a member of the namespace",
+		},
+		{
+			description:     "denied by a policy names the policy",
+			decision:        Decision{Reason: ReasonDeniedByPolicy, PolicyName: "block contractors"},
+			expectedMessage: `denied by policy "block contractors"`,
+		},
+		{
+			description:     "an unevaluable policy names the policy",
+			decision:        Decision{Reason: ReasonPolicyUnevaluable, PolicyName: "block contractors"},
+			expectedMessage: `denied: policy "block contractors" could not be evaluated`,
+		},
+		{
+			description:     "no grant names the requested login",
+			decision:        Decision{Reason: ReasonNoGrant, Login: "root"},
+			expectedMessage: `no policy grants "root" on this device`,
+		},
+		{
+			description:     "a denial with no reason falls back to a generic sentence",
+			decision:        Decision{},
+			expectedMessage: "denied by the access policies",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			require.Equal(t, tc.expectedMessage, tc.decision.Message())
+		})
+	}
+}

--- a/server/api/services/access-policy.go
+++ b/server/api/services/access-policy.go
@@ -63,7 +63,7 @@ func (s *service) Authorize(ctx context.Context, tenantID, userID, deviceUID, lo
 
 	member, ok := namespace.FindMember(userID)
 	if !ok {
-		return &models.Decision{Allowed: false, Reason: "user is not a member of the namespace"}, nil
+		return &models.Decision{Allowed: false, Reason: models.ReasonNotAMember}, nil
 	}
 
 	policies, _, err := s.store.AccessPolicyList(ctx, sc)
@@ -84,11 +84,11 @@ func (s *service) Authorize(ctx context.Context, tenantID, userID, deviceUID, lo
 			log.WithError(err).WithField("access_policy", policy.ID).
 				Warn("deny access policy failed to evaluate; denying")
 
-			return &models.Decision{Allowed: false, Reason: fmt.Sprintf("denied: policy %q could not be evaluated", policy.Name)}, nil
+			return &models.Decision{Allowed: false, Reason: models.ReasonPolicyUnevaluable, PolicyName: policy.Name}, nil
 		}
 
 		if matched {
-			return &models.Decision{Allowed: false, Reason: fmt.Sprintf("denied by policy %q", policy.Name)}, nil
+			return &models.Decision{Allowed: false, Reason: models.ReasonDeniedByPolicy, PolicyName: policy.Name}, nil
 		}
 	}
 
@@ -132,7 +132,7 @@ func (s *service) Authorize(ctx context.Context, tenantID, userID, deviceUID, lo
 	}
 
 	if !allowed {
-		return &models.Decision{Allowed: false, Reason: fmt.Sprintf("no policy grants %q on this device", login)}, nil
+		return &models.Decision{Allowed: false, Reason: models.ReasonNoGrant, Login: login}, nil
 	}
 
 	// Re-auth is an interactive step, so it cannot apply to a service account: there

--- a/server/api/services/access-policy_test.go
+++ b/server/api/services/access-policy_test.go
@@ -38,6 +38,9 @@ func TestAuthorize(t *testing.T) {
 		requireMocks    func(storeMock *storemock.MockStore, queryOptionsMock *storemock.MockQueryOptions)
 		expectedAllowed bool
 		expectedReauth  bool
+		expectedReason  models.DenialReason
+		expectedPolicy  string
+		expectedLogin   string
 		expectedErr     bool
 	}{
 		{
@@ -60,6 +63,7 @@ func TestAuthorize(t *testing.T) {
 					Return(&models.Namespace{TenantID: tenantID}, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNotAMember,
 			expectedErr:     false,
 		},
 		{
@@ -88,6 +92,8 @@ func TestAuthorize(t *testing.T) {
 					Return([]models.AccessPolicy{}, 0, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNoGrant,
+			expectedLogin:   "root",
 			expectedErr:     false,
 		},
 		{
@@ -128,6 +134,8 @@ func TestAuthorize(t *testing.T) {
 					}, 1, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNoGrant,
+			expectedLogin:   "root",
 			expectedErr:     false,
 		},
 		{
@@ -168,6 +176,8 @@ func TestAuthorize(t *testing.T) {
 					}, 1, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNoGrant,
+			expectedLogin:   "root",
 			expectedErr:     false,
 		},
 		{
@@ -228,6 +238,8 @@ func TestAuthorize(t *testing.T) {
 					}, 1, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNoGrant,
+			expectedLogin:   "root",
 			expectedErr:     false,
 		},
 		{
@@ -402,6 +414,8 @@ func TestAuthorize(t *testing.T) {
 					}, 1, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNoGrant,
+			expectedLogin:   "root",
 			expectedErr:     false,
 		},
 		{
@@ -421,6 +435,7 @@ func TestAuthorize(t *testing.T) {
 							Action:  models.PolicyActionAllow,
 						},
 						{
+							Name:    "block root",
 							Subject: models.PolicySubject{Type: models.PolicySubjectUser, Value: userID},
 							Filter:  models.PublicKeyFilter{},
 							Logins:  []string{"root"},
@@ -429,6 +444,8 @@ func TestAuthorize(t *testing.T) {
 					}, 2, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonDeniedByPolicy,
+			expectedPolicy:  "block root",
 			expectedErr:     false,
 		},
 		{
@@ -475,6 +492,7 @@ func TestAuthorize(t *testing.T) {
 							Action:  models.PolicyActionAllow,
 						},
 						{
+							Name:    "block everything",
 							Subject: models.PolicySubject{Type: models.PolicySubjectUser, Value: userID},
 							Filter:  models.PublicKeyFilter{},
 							Logins:  []string{"*"},
@@ -483,6 +501,8 @@ func TestAuthorize(t *testing.T) {
 					}, 2, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonDeniedByPolicy,
+			expectedPolicy:  "block everything",
 			expectedErr:     false,
 		},
 		{
@@ -502,6 +522,7 @@ func TestAuthorize(t *testing.T) {
 							Action:  models.PolicyActionAllow,
 						},
 						{
+							Name:    "broken deny",
 							Subject: models.PolicySubject{Type: models.PolicySubjectUser, Value: userID},
 							Filter:  models.PublicKeyFilter{Hostname: "["},
 							Logins:  []string{"*"},
@@ -510,6 +531,8 @@ func TestAuthorize(t *testing.T) {
 					}, 2, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonPolicyUnevaluable,
+			expectedPolicy:  "broken deny",
 			expectedErr:     false,
 		},
 		{
@@ -523,6 +546,7 @@ func TestAuthorize(t *testing.T) {
 				storeMock.On("AccessPolicyList", ctx, mock.Anything).
 					Return([]models.AccessPolicy{
 						{
+							Name:    "block root",
 							Subject: models.PolicySubject{Type: models.PolicySubjectUser, Value: userID},
 							Filter:  models.PublicKeyFilter{},
 							Logins:  []string{"root"},
@@ -531,6 +555,8 @@ func TestAuthorize(t *testing.T) {
 					}, 1, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonDeniedByPolicy,
+			expectedPolicy:  "block root",
 			expectedErr:     false,
 		},
 		{
@@ -544,6 +570,7 @@ func TestAuthorize(t *testing.T) {
 				storeMock.On("AccessPolicyList", ctx, mock.Anything).
 					Return([]models.AccessPolicy{
 						{
+							Name:    "deny all",
 							Subject: models.PolicySubject{Type: models.PolicySubjectAllMembers},
 							Filter:  models.PublicKeyFilter{},
 							Logins:  []string{"*"},
@@ -558,6 +585,8 @@ func TestAuthorize(t *testing.T) {
 					}, 2, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonDeniedByPolicy,
+			expectedPolicy:  "deny all",
 			expectedErr:     false,
 		},
 		{
@@ -604,6 +633,8 @@ func TestAuthorize(t *testing.T) {
 					}, 1, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNoGrant,
+			expectedLogin:   "root",
 			expectedErr:     false,
 		},
 		{
@@ -646,6 +677,7 @@ func TestAuthorize(t *testing.T) {
 							Action:  models.PolicyActionAllow,
 						},
 						{
+							Name:     "block office range",
 							Subject:  models.PolicySubject{Type: models.PolicySubjectAllMembers},
 							Filter:   models.PublicKeyFilter{},
 							Logins:   []string{"*"},
@@ -655,6 +687,8 @@ func TestAuthorize(t *testing.T) {
 					}, 2, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonDeniedByPolicy,
+			expectedPolicy:  "block office range",
 			expectedErr:     false,
 		},
 		{
@@ -750,6 +784,7 @@ func TestAuthorize(t *testing.T) {
 							Action:  models.PolicyActionAllow,
 						},
 						{
+							Name:     "block office range",
 							Subject:  models.PolicySubject{Type: models.PolicySubjectAllMembers},
 							Filter:   models.PublicKeyFilter{},
 							Logins:   []string{"*"},
@@ -759,6 +794,8 @@ func TestAuthorize(t *testing.T) {
 					}, 2, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonPolicyUnevaluable,
+			expectedPolicy:  "block office range",
 			expectedErr:     false,
 		},
 		{
@@ -782,6 +819,8 @@ func TestAuthorize(t *testing.T) {
 					}, 1, nil).Once()
 			},
 			expectedAllowed: false,
+			expectedReason:  models.ReasonNoGrant,
+			expectedLogin:   "root",
 			expectedErr:     false,
 		},
 	}
@@ -803,6 +842,9 @@ func TestAuthorize(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedAllowed, decision.Allowed)
 				require.Equal(t, tc.expectedReauth, decision.RequireReauth)
+				require.Equal(t, tc.expectedReason, decision.Reason)
+				require.Equal(t, tc.expectedPolicy, decision.PolicyName)
+				require.Equal(t, tc.expectedLogin, decision.Login)
 			}
 
 			storeMock.AssertExpectations(t)

--- a/server/ssh/session/auther.go
+++ b/server/ssh/session/auther.go
@@ -255,7 +255,15 @@ func (s *Session) authorize(ctx context.Context) (*models.Decision, error) {
 	case dec == nil:
 		logger.Error("access policy evaluation returned no decision")
 	default:
-		logger.WithField("reason", dec.Reason).Warn("ssh access denied by the access policies")
+		// The message stays constant so operators can still group and alert on it;
+		// what varies goes in the fields. dec.Login is not among them, since
+		// LogFields already carries the same value as "username".
+		fields := log.Fields{"reason": dec.Reason, "detail": dec.Message()}
+		if dec.PolicyName != "" {
+			fields["policy_name"] = dec.PolicyName
+		}
+
+		logger.WithFields(fields).Warn("ssh access denied by the access policies")
 	}
 
 	return nil, ErrAccessDenied

--- a/server/ssh/session/identity_test.go
+++ b/server/ssh/session/identity_test.go
@@ -11,6 +11,7 @@ import (
 
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/api/services"
 	servicemocks "github.com/shellhub-io/shellhub/server/api/services/mocks"
@@ -87,7 +88,7 @@ func TestResolveKeyAuth(t *testing.T) {
 	})
 
 	t.Run("dead key is rejected, not sent to enrollment", func(t *testing.T) {
-		consumedAt := time.Now()
+		consumedAt := clock.Now()
 
 		serviceMock := servicemocks.NewMockService(t)
 		// A burned single-use key resolves but is no longer active.
@@ -106,7 +107,7 @@ func TestResolveKeyAuth(t *testing.T) {
 	})
 
 	t.Run("an expired key is rejected too", func(t *testing.T) {
-		expiredAt := time.Now().Add(-time.Hour)
+		expiredAt := clock.Now().Add(-time.Hour)
 
 		serviceMock := servicemocks.NewMockService(t)
 		serviceMock.EXPECT().
@@ -216,7 +217,7 @@ func TestAuthorize(t *testing.T) {
 		serviceMock := servicemocks.NewMockService(t)
 		serviceMock.EXPECT().
 			Authorize(mock.Anything, "tenant-id", "user-id", "device-uid", "user", "127.0.0.1").
-			Return(&models.Decision{Allowed: false, Reason: `no policy grants "root" on this device`}, nil).
+			Return(&models.Decision{Allowed: false, Reason: models.ReasonNoGrant, Login: "user"}, nil).
 			Once()
 
 		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
@@ -231,13 +232,40 @@ func TestAuthorize(t *testing.T) {
 
 		entry := hook.LastEntry()
 		assert.Equal(t, log.WarnLevel, entry.Level)
-		assert.Equal(t, `no policy grants "root" on this device`, entry.Data["reason"])
+		assert.Equal(t, "ssh access denied by the access policies", entry.Message)
+		assert.Equal(t, models.ReasonNoGrant, entry.Data["reason"])
+		assert.Equal(t, `no policy grants "user" on this device`, entry.Data["detail"])
+		assert.NotContains(t, entry.Data, "policy_name")
 		assert.Equal(t, "tenant-id", entry.Data["tenant"])
 		assert.Equal(t, "user-id", entry.Data["user"])
 		assert.Equal(t, "device-uid", entry.Data["device"])
 		assert.Equal(t, "user", entry.Data["username"])
 		assert.Equal(t, "127.0.0.1", entry.Data["ip"])
 		assert.Equal(t, "test-uid", entry.Data["session"])
+	})
+
+	t.Run("a denial by a named policy carries the policy on the entry", func(t *testing.T) {
+		hook := captureLogs(t)
+
+		serviceMock := servicemocks.NewMockService(t)
+		serviceMock.EXPECT().
+			Authorize(mock.Anything, "tenant-id", "user-id", "device-uid", "user", "127.0.0.1").
+			Return(&models.Decision{Allowed: false, Reason: models.ReasonDeniedByPolicy, PolicyName: "block contractors"}, nil).
+			Once()
+
+		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
+		sess.UserID = "user-id"
+
+		_, err := sess.authorize(ctx)
+		require.ErrorIs(t, err, ErrAccessDenied)
+
+		require.Len(t, hook.AllEntries(), 1)
+
+		entry := hook.LastEntry()
+		assert.Equal(t, "ssh access denied by the access policies", entry.Message)
+		assert.Equal(t, models.ReasonDeniedByPolicy, entry.Data["reason"])
+		assert.Equal(t, "block contractors", entry.Data["policy_name"])
+		assert.Equal(t, `denied by policy "block contractors"`, entry.Data["detail"])
 	})
 
 	t.Run("a failure to evaluate the policies is reported as a malfunction", func(t *testing.T) {


### PR DESCRIPTION
## What

Access policy denials carry a typed `DenialReason` code with the specifics (`PolicyName`, `Login`) as their own fields, instead of a sentence built with `fmt.Sprintf`. The SSH gateway's denial log emits that code as a structured field under a constant message, and the human sentence is derived from the code rather than being its source.

## Why

shellhub-io/team#229 routed the reason string to the operator's log, which made it load-bearing while it was still unstructured. Three costs followed: counting refusals by cause needed substring matching that breaks the first time someone rewords a sentence; the service's 35-case test table asserted `Allowed` and `RequireReauth` but never the reason, so phrasing could drift silently; and a caller wanting to treat "not a member" differently from "no policy grants this" had only prose to inspect, which is what shellhub-io/team#233 needs.

Fixes: shellhub-io/team#232 — cross-repo, so the trailer will not close it automatically.

## Changes

- **pkg/models**: added `DenialReason` with `ReasonNotAMember`, `ReasonDeniedByPolicy`, `ReasonPolicyUnevaluable`, and `ReasonNoGrant`; `Decision` gained `PolicyName` and `Login`, and `Message()` renders the four sentences verbatim from them, so no existing log wording changed.
- **pkg/models**: dropped `Decision`'s JSON tags. No handler returns it and no OpenAPI schema describes it, so the tags implied a public contract that does not exist. shellhub-io/team#233 can add them back deliberately if a handler ever serializes a decision.
- **server/api/services**: the four construction sites in `Authorize` set a code and its fields.
- **server/ssh/session**: the denial log keeps its constant message so existing grouping and alerting on message text still work, and puts what varies in fields: `reason` (the code), `detail` (the rendered sentence), and `policy_name` only when a policy actually produced the refusal. `Decision.Login` is deliberately not a field, since `LogFields` already carries the same value as `username`.
- **tests**: the service table now asserts `Reason`, `PolicyName`, and `Login` on all 15 non-error denials, with real names on the deny fixtures so the `PolicyName` assertion has something to catch. A new `pkg/models` table pins each sentence. A new SSH subtest locks `policy_name` on a named-policy denial.

## Testing

The wording is now asserted in two places that must agree: `TestDecisionMessage` in `pkg/models` pins the sentences, and `TestAuthorize` in `server/ssh/session` pins what reaches the log entry. Changing a sentence should fail the first; changing the log's field names should fail the second.

Worth a look: `policy_name` is attached conditionally, so `not_a_member` and `no_grant` entries no longer carry an empty key. If you would rather have a stable field set across all denials, that is a one-line change.

Two `time.Now()` calls in `identity_test.go` moved to `clock.Now()`. They predate this branch; the repo's convention hook flags them on any edit to that file.
