### PR TITLE
feat(server): publish dialer connection metrics on an internal endpoint

### DIFF
--- a/server/api/routes/internal-metrics.go
+++ b/server/api/routes/internal-metrics.go
@@ -1,0 +1,36 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	routesmiddleware "github.com/shellhub-io/shellhub/server/api/routes/middleware"
+)
+
+// InternalMetricsURL is where the process publishes its Prometheus registry.
+//
+// It sits under /internal rather than beside [WithMetrics]'s /metrics because
+// the gateway answers 404 to /internal* deliberately. /metrics is unreachable
+// from outside only because no proxy rule happens to match it today.
+const InternalMetricsURL = "/internal/metrics"
+
+// registerInternalMetrics publishes the default registry, unconditionally.
+//
+// Unconditional and not behind METRICS, which ships false and was false on the
+// host whose connection count could not be read. A flag an operator can trim
+// out of an env file is one that turns out to be off during the incident that
+// needs it.
+//
+// It costs nothing when nobody scrapes: the request histograms METRICS installs
+// are middleware on every request, while this is a handler and a collector that
+// reads counters the store already maintains. The default registry brings
+// go_goroutines, go_memstats_* and process_resident_memory_bytes with it, none
+// of which the server publishes today.
+func registerInternalMetrics(router *echo.Echo, authn *routesmiddleware.Authenticator) {
+	router.GET(InternalMetricsURL, echo.WrapHandler(promhttp.Handler()))
+
+	if authn != nil {
+		authn.AllowAnonymous(http.MethodGet, InternalMetricsURL)
+	}
+}

--- a/server/api/routes/internal-metrics_test.go
+++ b/server/api/routes/internal-metrics_test.go
@@ -1,0 +1,28 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInternalMetricsNeedsNoCredential pins both decisions behind this
+// endpoint: it is registered unconditionally, and it answers without one. An
+// operator reaches it during an incident, from inside the deployment, with no
+// token to hand; the gateway is what keeps it off the internet.
+func TestInternalMetricsNeedsNoCredential(t *testing.T) {
+	router, _, _ := authenticatedRouter(t)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, InternalMetricsURL, nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The runtime collectors the default registry installs are most of what an
+	// incident asks for, and they arrive without us registering anything.
+	assert.Contains(t, rec.Body.String(), "go_goroutines")
+	assert.Contains(t, rec.Body.String(), "process_resident_memory_bytes")
+}

--- a/server/api/routes/routes.go
+++ b/server/api/routes/routes.go
@@ -265,6 +265,8 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	// MCP server (Model Context Protocol) for AI assistants.
 	SetupMCPRoutes(router)
 
+	registerInternalMetrics(router, handler.authn)
+
 	if handler.authn != nil {
 		registerAnonymousRoutes(handler.authn)
 	}

--- a/server/app/openapi_test.go
+++ b/server/app/openapi_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v5"
+	"github.com/shellhub-io/shellhub/server/api/routes"
 	"github.com/shellhub-io/shellhub/server/api/routes/middleware"
 	sshhttp "github.com/shellhub-io/shellhub/server/ssh/http"
 	"github.com/shellhub-io/shellhub/server/ssh/web"
@@ -128,6 +129,9 @@ func TestOpenAPIValidationSkipper(t *testing.T) {
 		{web.WebsocketSSHBridgeRoute, true},
 		{"/metrics", true},
 		{"/internal/auth", true},
+		// Always registered, and answers with an exposition format no OpenAPI
+		// schema describes.
+		{routes.InternalMetricsURL, true},
 		// Sits under the bridge route but answers with a JSON body, so prefix matching
 		// would wrongly exempt it.
 		{web.WebSessionRoute, false},

--- a/server/app/server.go
+++ b/server/app/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v5"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/cache"
 	"github.com/shellhub-io/shellhub/pkg/envs"
@@ -293,6 +294,13 @@ func (s *Server) setupSSH(service services.Service) error {
 	}
 
 	d := dialer.NewDialer(service, s.heartbeater)
+
+	// Published on routes.InternalMetricsURL, which is always on. Registration
+	// is the only thing that can fail here, and it does not stop the SSH
+	// server: losing a gauge is not a reason to refuse device connections.
+	if err := prometheus.Register(dialer.NewCollector(d.Manager)); err != nil {
+		log.WithError(err).Warning("failed to register the dialer connection metrics")
+	}
 
 	sshhttp.Register(s.router, s.authn, d, service, &sshhttp.Config{
 		RequireAcceptedTunnel: env.RequireAcceptedTunnel,

--- a/server/go.mod
+++ b/server/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mark3labs/mcp-go v0.58.0
 	github.com/multiformats/go-multistream v0.6.1
 	github.com/pires/go-proxyproto v0.15.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/shellhub-io/shellhub v0.0.0
 	github.com/sirupsen/logrus v1.10.0
 	github.com/spf13/cobra v1.10.2
@@ -74,6 +75,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.7 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
@@ -93,7 +95,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/server/ssh/pkg/dialer/manager.go
+++ b/server/ssh/pkg/dialer/manager.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/yamux"
@@ -20,6 +21,37 @@ type Manager struct {
 	Connections             *SyncSliceMap
 	DialerDoneCallback      func(string)
 	DialerKeepAliveCallback func(string)
+
+	// displaced counts the connections evict has closed. It is monotonic and
+	// read by [Collector]; the store's own size says nothing about how often
+	// this happened, because a displaced connection is gone by the next scrape.
+	displaced atomic.Uint64
+}
+
+// Stats is a snapshot of what a [Manager] holds.
+//
+// Connections and Devices are equal in a healthy store; the difference is the
+// connections a reconnect displaced whose teardown has not finished.
+type Stats struct {
+	Connections int
+	Devices     int
+	Displaced   uint64
+}
+
+// Stats reports the store's size and how many connections have been displaced
+// since the process started.
+//
+// The two sizes come from one read of the store, so they describe the same
+// instant. The counter does not, which costs nothing: it is monotonic and is
+// never compared against the sizes within a single read.
+func (m *Manager) Stats() Stats {
+	devices, connections := m.Connections.Stats()
+
+	return Stats{
+		Connections: connections,
+		Devices:     devices,
+		Displaced:   m.displaced.Load(),
+	}
 }
 
 func NewManager() *Manager {
@@ -74,6 +106,8 @@ func (m *Manager) evict(key string, displaced []any) {
 	if len(displaced) == 0 {
 		return
 	}
+
+	m.displaced.Add(uint64(len(displaced)))
 
 	log.WithFields(log.Fields{
 		"key":  key,

--- a/server/ssh/pkg/dialer/metrics.go
+++ b/server/ssh/pkg/dialer/metrics.go
@@ -1,0 +1,63 @@
+package dialer
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// perProcess is appended to every help text below. Each server replica owns its
+// own [Manager], so nothing here is a fleet number on its own.
+const perProcess = "Counted per server process; sum() across replicas for a fleet total."
+
+var (
+	connectionsDesc = prometheus.NewDesc(
+		"shellhub_ssh_dialer_connections",
+		"Reverse connections currently held, across every device. "+perProcess,
+		nil, nil,
+	)
+
+	devicesDesc = prometheus.NewDesc(
+		"shellhub_ssh_dialer_devices",
+		"Devices holding at least one reverse connection. "+perProcess,
+		nil, nil,
+	)
+
+	displacedDesc = prometheus.NewDesc(
+		"shellhub_ssh_dialer_connections_displaced_total",
+		"Reverse connections displaced by a newer registration for the same device. "+perProcess,
+		nil, nil,
+	)
+)
+
+// Collector publishes the state of a [Manager]'s connection store.
+//
+// The two gauges are equal in a healthy store. Every unit of difference is a
+// connection a reconnect displaced and whose teardown has not finished. That
+// backlog is deliberately not a third series: subtract the two in the query,
+// because a metric that is always the difference of two others is one more
+// thing to forget to update.
+//
+// The gauges answer how big the store is right now; the counter answers how
+// often devices reconnect over a live one, which is the rate that stays
+// informative once the store drains at registration time.
+type Collector struct {
+	manager *Manager
+}
+
+func NewCollector(manager *Manager) *Collector {
+	return &Collector{manager: manager}
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- connectionsDesc
+	ch <- devicesDesc
+	ch <- displacedDesc
+}
+
+// Collect reads counters the manager already maintains rather than walking its
+// store. A scrape of a fleet-sized store must not hold the lock the dial path
+// reads under.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	stats := c.manager.Stats()
+
+	ch <- prometheus.MustNewConstMetric(connectionsDesc, prometheus.GaugeValue, float64(stats.Connections))
+	ch <- prometheus.MustNewConstMetric(devicesDesc, prometheus.GaugeValue, float64(stats.Devices))
+	ch <- prometheus.MustNewConstMetric(displacedDesc, prometheus.CounterValue, float64(stats.Displaced))
+}

--- a/server/ssh/pkg/dialer/metrics_test.go
+++ b/server/ssh/pkg/dialer/metrics_test.go
@@ -1,0 +1,118 @@
+package dialer
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	connectionsMetric = "shellhub_ssh_dialer_connections"
+	devicesMetric     = "shellhub_ssh_dialer_devices"
+	displacedMetric   = "shellhub_ssh_dialer_connections_displaced_total"
+)
+
+// expositionOf renders what a scrape must return. The help text is written out
+// once here rather than per case, so rewording it is one edit and a scrape that
+// silently changes its own contract still fails.
+func expositionOf(connections, devices int) string {
+	return fmt.Sprintf(`
+		# HELP shellhub_ssh_dialer_connections Reverse connections currently held, across every device. Counted per server process; sum() across replicas for a fleet total.
+		# TYPE shellhub_ssh_dialer_connections gauge
+		shellhub_ssh_dialer_connections %d
+		# HELP shellhub_ssh_dialer_devices Devices holding at least one reverse connection. Counted per server process; sum() across replicas for a fleet total.
+		# TYPE shellhub_ssh_dialer_devices gauge
+		shellhub_ssh_dialer_devices %d
+	`, connections, devices)
+}
+
+func displacedExpositionOf(displaced int) string {
+	return fmt.Sprintf(`
+		# HELP shellhub_ssh_dialer_connections_displaced_total Reverse connections displaced by a newer registration for the same device. Counted per server process; sum() across replicas for a fleet total.
+		# TYPE shellhub_ssh_dialer_connections_displaced_total counter
+		shellhub_ssh_dialer_connections_displaced_total %d
+	`, displaced)
+}
+
+func TestCollectorReportsTheStoreSize(t *testing.T) {
+	cases := []struct {
+		title       string
+		setup       func(m *Manager)
+		connections int
+		devices     int
+	}{
+		{
+			title:       "reports zero for a store nothing has registered on",
+			setup:       func(_ *Manager) {},
+			connections: 0,
+			devices:     0,
+		},
+		{
+			title: "counts one connection per device",
+			setup: func(m *Manager) {
+				m.Connections.Store(NewKey("tenant", "uid1"), "connection1")
+				m.Connections.Store(NewKey("tenant", "uid2"), "connection2")
+			},
+			connections: 2,
+			devices:     2,
+		},
+		{
+			// The gap between the two gauges is the number an operator sizing
+			// the store cannot get anywhere else: connections a reconnect
+			// displaced and that are not yet torn down.
+			title: "separates the gauges when a device holds a second connection",
+			setup: func(m *Manager) {
+				key := NewKey("tenant", "uid")
+				m.Connections.Store(key, "connection1")
+				m.Connections.Store(key, "connection2")
+			},
+			connections: 2,
+			devices:     1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			m := NewManager()
+			tc.setup(m)
+
+			expected := strings.NewReader(expositionOf(tc.connections, tc.devices))
+
+			assert.NoError(t, testutil.CollectAndCompare(NewCollector(m), expected, connectionsMetric, devicesMetric))
+		})
+	}
+}
+
+// TestCollectorCountsDisplacedConnections drives the counter through the path
+// that increments it: a device that reconnects before the server noticed its
+// previous socket was gone. That rate is the signal the gauges cannot carry,
+// because the store drains at registration time and reads healthy moments
+// later.
+func TestCollectorCountsDisplacedConnections(t *testing.T) {
+	key := NewKey("tenant", "uid")
+
+	m := NewManager()
+	collector := NewCollector(m)
+
+	// Every reconnect below waits for the previous teardown, so each one
+	// displaces exactly one connection.
+	reconnect := func() {
+		require.NoError(t, m.Bind("tenant", "uid", newAgentConn(t)))
+		require.Eventually(t, func() bool { return m.Connections.Size(key) == 1 },
+			time.Second, 10*time.Millisecond, "the displaced connection was never torn down")
+	}
+
+	reconnect()
+	assert.NoError(t, testutil.CollectAndCompare(collector, strings.NewReader(displacedExpositionOf(0)), displacedMetric),
+		"a first registration displaces nothing")
+
+	reconnect()
+	reconnect()
+
+	assert.NoError(t, testutil.CollectAndCompare(collector, strings.NewReader(displacedExpositionOf(2)), displacedMetric))
+}

--- a/server/ssh/pkg/dialer/syncslicemap.go
+++ b/server/ssh/pkg/dialer/syncslicemap.go
@@ -16,6 +16,21 @@ import (
 type SyncSliceMap struct {
 	mu     sync.RWMutex
 	values map[any][]any
+
+	// total is the number of values across every key, maintained by the
+	// mutating operations below so [SyncSliceMap.Stats] costs a lock rather
+	// than a walk of a map that holds one entry per connected device.
+	total int
+}
+
+// Stats returns how many keys the map holds and how many values across all of
+// them, under one read lock so the two describe the same instant. They differ
+// only while some key holds more than one value.
+func (ssm *SyncSliceMap) Stats() (keys, values int) {
+	ssm.mu.RLock()
+	defer ssm.mu.RUnlock()
+
+	return len(ssm.values), ssm.total
 }
 
 // Load retrieves the most recently stored value for the key.
@@ -42,6 +57,7 @@ func (ssm *SyncSliceMap) Store(key, value any) []any {
 
 	displaced := slices.Clone(ssm.values[key])
 	ssm.values[key] = append(ssm.values[key], value)
+	ssm.total++
 
 	return displaced
 }
@@ -53,9 +69,15 @@ func (ssm *SyncSliceMap) Delete(key, value any) int {
 	ssm.mu.Lock()
 	defer ssm.mu.Unlock()
 
-	remaining := slices.DeleteFunc(ssm.values[key], func(v any) bool {
+	// DeleteFunc writes through the array but leaves this header alone, so the
+	// two lengths still bracket how many values it dropped. It drops every
+	// match, which need not be one.
+	stored := ssm.values[key]
+	remaining := slices.DeleteFunc(stored, func(v any) bool {
 		return v == value
 	})
+
+	ssm.total -= len(stored) - len(remaining)
 
 	if len(remaining) == 0 {
 		delete(ssm.values, key)

--- a/server/ssh/pkg/dialer/syncslicemap_test.go
+++ b/server/ssh/pkg/dialer/syncslicemap_test.go
@@ -331,3 +331,136 @@ func TestConcurrentStoreAndDeleteReportOneWinner(t *testing.T) {
 	assert.Equal(t, 1, emptied, "exactly one teardown must see the key empty")
 	assert.Equal(t, 0, ssm.Size("key"))
 }
+
+func TestStats(t *testing.T) {
+	type Expected struct {
+		keys   int
+		values int
+	}
+
+	cases := []struct {
+		title    string
+		setup    func() *SyncSliceMap
+		expected Expected
+	}{
+		{
+			title: "reports an empty map as zero",
+			setup: func() *SyncSliceMap {
+				return &SyncSliceMap{}
+			},
+			expected: Expected{keys: 0, values: 0},
+		},
+		{
+			title: "counts every value held, across keys",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key1", "value1.1")
+				ssm.Store("key1", "value1.2")
+				ssm.Store("key2", "value2.1")
+
+				return ssm
+			},
+			expected: Expected{keys: 2, values: 3},
+		},
+		{
+			title: "drops both counts when a key loses its last value",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key1", "value1.1")
+				ssm.Store("key2", "value2.1")
+				ssm.Delete("key2", "value2.1")
+
+				return ssm
+			},
+			expected: Expected{keys: 1, values: 1},
+		},
+		{
+			title: "keeps the key when only one of its values goes",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value1")
+				ssm.Store("key", "value2")
+				ssm.Delete("key", "value1")
+
+				return ssm
+			},
+			expected: Expected{keys: 1, values: 1},
+		},
+		{
+			title: "ignores a delete of a value the key never held",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value1")
+				ssm.Delete("key", "other")
+				ssm.Delete("missing", "value1")
+
+				return ssm
+			},
+			expected: Expected{keys: 1, values: 1},
+		},
+		{
+			// Delete drops every match, so the total must fall by more than one.
+			title: "subtracts every copy a single delete removes",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value")
+				ssm.Store("key", "value")
+				ssm.Store("key", "survivor")
+				ssm.Delete("key", "value")
+
+				return ssm
+			},
+			expected: Expected{keys: 1, values: 1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			keys, values := tc.setup().Stats()
+
+			assert.Equal(t, tc.expected, Expected{keys, values})
+		})
+	}
+}
+
+// TestStatsSurvivesConcurrentMutation guards the running total against the map
+// it summarizes: a count maintained outside the critical sections drifts, and a
+// gauge that drifts is worse than no gauge at all. Run under -race.
+func TestStatsSurvivesConcurrentMutation(t *testing.T) {
+	const (
+		keys       = 20
+		perKey     = 10
+		goroutines = keys * perKey
+	)
+
+	ssm := &SyncSliceMap{}
+
+	mutate := func(op func(key, value any)) {
+		var wg sync.WaitGroup
+
+		wg.Add(goroutines)
+
+		for k := range keys {
+			for v := range perKey {
+				go func() {
+					defer wg.Done()
+					op(fmt.Sprintf("key%d", k), fmt.Sprintf("value%d.%d", k, v))
+				}()
+			}
+		}
+
+		wg.Wait()
+	}
+
+	mutate(func(key, value any) { ssm.Store(key, value) })
+
+	gotKeys, gotValues := ssm.Stats()
+	assert.Equal(t, keys, gotKeys)
+	assert.Equal(t, goroutines, gotValues)
+
+	mutate(func(key, value any) { ssm.Delete(key, value) })
+
+	gotKeys, gotValues = ssm.Stats()
+	assert.Equal(t, 0, gotKeys)
+	assert.Equal(t, 0, gotValues)
+}


### PR DESCRIPTION
## What

The server publishes the size of its reverse-connection store, plus the rate at which device
reconnects displace a live connection, on an always-on `/internal/metrics` endpoint.

## Why

Nothing reported the dialer's store size. Answering "are 104k established connections for 58k
devices normal?" took source archaeology across two versions, because the only signal was a log
line that fires on the anomaly and says nothing when the store is healthy. Sizing the store on the
host meant counting sockets inside the gateway's network namespace, which double-counts every
proxied connection, and that caveat is what made the reading wrong.

The correctness defects behind that question are already fixed on master by `3292f0528`. This is
the remaining item: make the state observable so the next investigation reads a gauge.

Fixes: shellhub-io/team#219

## Changes

- **`server/ssh/pkg/dialer`**: `shellhub_ssh_dialer_connections` and `shellhub_ssh_dialer_devices`
  gauges, and a `shellhub_ssh_dialer_connections_displaced_total` counter incremented where
  `Manager.evict` already logs and closes. The gauges are equal in a healthy store, so their
  difference is the displaced connections still tearing down. That difference stays a PromQL
  subtraction rather than a third series that would only ever be two others subtracted.
- **`SyncSliceMap.Stats()`**: O(1). A running total maintained inside the existing `Store` and
  `Delete` critical sections, so a scrape never walks a map holding one key per connected device
  and never contends with `Load` on the dial path.
- **`/internal/metrics`**: registered unconditionally, not behind `METRICS`. That flag ships
  `false` and was `false` on the host that could not be read; a flag an operator can trim out of an
  env file is one that turns out to be off during the incident that needs it. The gateway 404s
  `/internal*` deliberately and says why, while `/metrics` is unreachable from outside only because
  no proxy rule happens to match it today. The default registry also brings `go_goroutines`,
  `go_memstats_*` and `process_resident_memory_bytes`, none of which the server publishes anywhere
  today. `SHELLHUB_METRICS` is untouched and still gates the request histograms.

Every series is per-process: each replica owns its own `Manager`, so a fleet total is `sum()`
across instances. The help text says so.

## Testing

The realistic consumer is an ad-hoc read during an incident:

```
docker compose exec server curl -s localhost:8080/internal/metrics
```

Worth probing: the endpoint answers without a credential (it is declared through the fail-closed
`AllowAnonymous` allowlist, not by widening `exemptPrefixes`), and the same path through the
gateway returns 404. Verified both on the dev stack, along with the gauges reading 1/1 with an
agent connected.

This buys a regression guard and a rate signal, not monitoring. No Prometheus is deployed in front
of the managed hosts; dashboards and alerts are a separate, much larger project.