### PR TITLE
fix(server): use edition-aware connection announcement

### DIFF
--- a/pkg/envs/announcement.go
+++ b/pkg/envs/announcement.go
@@ -1,0 +1,46 @@
+package envs
+
+import (
+	"fmt"
+	"strings"
+)
+
+const announcementFormat = `
+******************************************************************
+*                                                                *
+*%s*
+*                                                                *
+* ShellHub is a centralized SSH gateway for managing Linux       *
+* devices and servers. Access any device from a web browser,     *
+* mobile, or standard SSH client — no VPN, no public IP needed.  *
+*                                                                *
+%s* For assistance, contact the system administrator.              *
+*                                                                *
+******************************************************************
+`
+
+const communityLinks = `* Explore Cloud and Enterprise editions with advanced features:  *
+* https://shellhub.io                                            *
+*                                                                *
+* Contribute to the open-source project:                         *
+* https://github.com/shellhub-io/shellhub                       *
+*                                                                *
+`
+
+// AnnouncementFor returns the SSH connection banner for the given edition.
+func AnnouncementFor(edition Edition) string {
+	if edition == "" {
+		edition = Community
+	}
+
+	e := string(edition)
+	title := "Welcome to ShellHub " + strings.ToUpper(e[:1]) + e[1:] + "!"
+	pad := 64 - len(title)
+
+	extra := ""
+	if edition == Community {
+		extra = communityLinks
+	}
+
+	return fmt.Sprintf(announcementFormat, fmt.Sprintf("%*s%s%*s", pad/2, "", title, pad-pad/2, ""), extra)
+}

--- a/pkg/envs/announcement_test.go
+++ b/pkg/envs/announcement_test.go
@@ -1,0 +1,34 @@
+package envs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnnouncementFor(t *testing.T) {
+	cases := []struct {
+		edition       Edition
+		wantTitle     string
+		wantCommunity bool
+	}{
+		{Community, "Welcome to ShellHub Community!", true},
+		{Enterprise, "Welcome to ShellHub Enterprise!", false},
+		{Cloud, "Welcome to ShellHub Cloud!", false},
+		{"", "Welcome to ShellHub Community!", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.edition), func(t *testing.T) {
+			got := AnnouncementFor(tc.edition)
+
+			if !strings.Contains(got, tc.wantTitle) {
+				t.Errorf("expected title %q in announcement, got:\n%s", tc.wantTitle, got)
+			}
+
+			hasCommunityLinks := strings.Contains(got, "github.com/shellhub-io/shellhub")
+			if hasCommunityLinks != tc.wantCommunity {
+				t.Errorf("community links: want %v, got %v", tc.wantCommunity, hasCommunityLinks)
+			}
+		})
+	}
+}

--- a/pkg/models/namespace.go
+++ b/pkg/models/namespace.go
@@ -104,29 +104,6 @@ func (s *NamespaceSettings) IsIdentityAccess() bool {
 	return s != nil && s.SSHAccessMode == SSHAccessModeIdentity
 }
 
-// default Announcement Message for the shellhub namespace
-const DefaultAnnouncementMessage = `
-******************************************************************
-*                                                                *
-*             Welcome to ShellHub Community Edition!             *
-*                                                                *
-* ShellHub is a next-generation SSH server, providing a          *
-* seamless, secure, and user-friendly solution for remote        *
-* access management. With ShellHub, you can manage all your      *
-* devices effortlessly from a single platform, ensuring optimal  *
-* security and productivity.                                     *
-*                                                                *
-* Want to learn more about ShellHub and explore other editions?  *
-* Visit: https://shellhub.io                                     *
-*                                                                *
-* Join our community and contribute to our open-source project:  *
-* https://github.com/shellhub-io/shellhub                        *
-*                                                                *
-* For assistance, please contact the system administrator.       *
-*                                                                *
-******************************************************************
-`
-
 // NamespaceConflicts holds namespace attributes that must be unique for each document and can be utilized in queries
 // to identify conflicts.
 type NamespaceConflicts struct {

--- a/server/admin/services/namespaces.go
+++ b/server/admin/services/namespaces.go
@@ -56,7 +56,7 @@ func (s *service) NamespaceCreate(ctx context.Context, input *inputs.NamespaceCr
 		},
 		Settings: &models.NamespaceSettings{
 			SessionRecord:          true,
-			ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+			ConnectionAnnouncement: envs.AnnouncementFor(envs.CurrentEdition()),
 			SSHAccessMode:          input.SSHAccessMode,
 		},
 		CreatedAt: clock.Now(),

--- a/server/admin/services/namespaces_test.go
+++ b/server/admin/services/namespaces_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
@@ -24,14 +23,13 @@ func TestNamespaceCreate(t *testing.T) {
 		namespace *models.Namespace
 		err       error
 	}
-	now := time.Now()
-
 	mock := new(mocks.MockStore)
 	ctx := context.TODO()
 
 	mockClock := new(clockmock.MockClock)
+	mockClock.On("Now").Return(clock.Now())
 	clock.DefaultBackend = mockClock
-	mockClock.On("Now").Return(now)
+	now := clock.Now()
 
 	cases := []struct {
 		description   string
@@ -85,7 +83,7 @@ func TestNamespaceCreate(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 					},
 					MaxDevices: MaxNumberDevicesUnlimited,
 					CreatedAt:  now,
@@ -125,7 +123,7 @@ func TestNamespaceCreate(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 					},
 					MaxDevices: MaxNumberDevicesUnlimited,
 					CreatedAt:  now,
@@ -146,7 +144,7 @@ func TestNamespaceCreate(t *testing.T) {
 				},
 				Settings: &models.NamespaceSettings{
 					SessionRecord:          true,
-					ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+					ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 				},
 				MaxDevices: MaxNumberDevicesUnlimited,
 				CreatedAt:  now,
@@ -183,7 +181,7 @@ func TestNamespaceCreate(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 					},
 					MaxDevices: MaxNumberDevicesLimited,
 					CreatedAt:  now,
@@ -204,7 +202,7 @@ func TestNamespaceCreate(t *testing.T) {
 				},
 				Settings: &models.NamespaceSettings{
 					SessionRecord:          true,
-					ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+					ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 				},
 				MaxDevices: MaxNumberDevicesLimited,
 				CreatedAt:  now,
@@ -241,7 +239,7 @@ func TestNamespaceCreate(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 					},
 					MaxDevices: MaxNumberDevicesLimited,
 					CreatedAt:  now,
@@ -262,7 +260,7 @@ func TestNamespaceCreate(t *testing.T) {
 				},
 				Settings: &models.NamespaceSettings{
 					SessionRecord:          true,
-					ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+					ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 				},
 				MaxDevices: MaxNumberDevicesLimited,
 				CreatedAt:  now,
@@ -299,7 +297,7 @@ func TestNamespaceCreate(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Enterprise),
 					},
 					MaxDevices: MaxNumberDevicesUnlimited,
 					CreatedAt:  now,
@@ -320,7 +318,7 @@ func TestNamespaceCreate(t *testing.T) {
 				},
 				Settings: &models.NamespaceSettings{
 					SessionRecord:          true,
-					ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+					ConnectionAnnouncement: envs.AnnouncementFor(envs.Enterprise),
 				},
 				MaxDevices: MaxNumberDevicesUnlimited,
 				CreatedAt:  now,
@@ -357,7 +355,7 @@ func TestNamespaceCreate(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Enterprise),
 					},
 					MaxDevices: MaxNumberDevicesUnlimited,
 					CreatedAt:  now,
@@ -378,7 +376,7 @@ func TestNamespaceCreate(t *testing.T) {
 				},
 				Settings: &models.NamespaceSettings{
 					SessionRecord:          true,
-					ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+					ConnectionAnnouncement: envs.AnnouncementFor(envs.Enterprise),
 				},
 				MaxDevices: MaxNumberDevicesUnlimited,
 				CreatedAt:  now,
@@ -407,11 +405,11 @@ func TestNamespaceAddMember(t *testing.T) {
 
 	mock := new(mocks.MockStore)
 	mockClock := new(clockmock.MockClock)
+	mockClock.On("Now").Return(clock.Now())
 	clock.DefaultBackend = mockClock
 
 	ctx := context.TODO()
-	now := time.Now()
-	mockClock.On("Now").Return(now)
+	now := clock.Now()
 
 	cases := []struct {
 		description   string
@@ -517,7 +515,7 @@ func TestNamespaceRemoveMember(t *testing.T) {
 	mock := new(mocks.MockStore)
 
 	ctx := context.TODO()
-	now := time.Now()
+	now := clock.Now()
 
 	cases := []struct {
 		description   string

--- a/server/api/services/namespace.go
+++ b/server/api/services/namespace.go
@@ -83,14 +83,10 @@ func (s *service) CreateNamespace(ctx context.Context, req *requests.NamespaceCr
 		},
 		Settings: &models.NamespaceSettings{
 			SessionRecord:          true,
-			ConnectionAnnouncement: "",
+			ConnectionAnnouncement: envs.AnnouncementFor(envs.CurrentEdition()),
 		},
 		TenantID: req.TenantID,
 		Type:     models.NewDefaultType(),
-	}
-
-	if envs.IsCommunity() {
-		ns.Settings.ConnectionAnnouncement = models.DefaultAnnouncementMessage
 	}
 
 	if models.IsTypeTeam(req.Type) {

--- a/server/api/services/namespace_test.go
+++ b/server/api/services/namespace_test.go
@@ -672,7 +672,7 @@ func TestCreateNamespace(t *testing.T) {
 							},
 							Settings: &models.NamespaceSettings{
 								SessionRecord:          true,
-								ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+								ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 							},
 							MaxDevices: -1,
 						},
@@ -736,7 +736,7 @@ func TestCreateNamespace(t *testing.T) {
 							},
 							Settings: &models.NamespaceSettings{
 								SessionRecord:          true,
-								ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+								ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 							},
 							MaxDevices: -1,
 						},
@@ -797,7 +797,7 @@ func TestCreateNamespace(t *testing.T) {
 							},
 							Settings: &models.NamespaceSettings{
 								SessionRecord:          true,
-								ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+								ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 							},
 							MaxDevices: -1,
 						},
@@ -820,7 +820,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 					},
 					MaxDevices: -1,
 				},
@@ -879,7 +879,7 @@ func TestCreateNamespace(t *testing.T) {
 							},
 							Settings: &models.NamespaceSettings{
 								SessionRecord:          true,
-								ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+								ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 							},
 							MaxDevices: -1,
 						},
@@ -902,7 +902,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 					},
 					MaxDevices: -1,
 				},
@@ -958,7 +958,7 @@ func TestCreateNamespace(t *testing.T) {
 							},
 							Settings: &models.NamespaceSettings{
 								SessionRecord:          true,
-								ConnectionAnnouncement: "",
+								ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 							},
 							MaxDevices: 3,
 						},
@@ -981,7 +981,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: "",
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 					},
 					MaxDevices: 3,
 				},
@@ -1037,7 +1037,7 @@ func TestCreateNamespace(t *testing.T) {
 							},
 							Settings: &models.NamespaceSettings{
 								SessionRecord:          true,
-								ConnectionAnnouncement: "",
+								ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 							},
 							MaxDevices: 3,
 						},
@@ -1060,7 +1060,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: "",
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Cloud),
 					},
 					MaxDevices: 3,
 				},

--- a/server/api/services/setup.go
+++ b/server/api/services/setup.go
@@ -108,7 +108,7 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) (*models.UserAu
 		CreatedAt: clock.Now(),
 		Settings: &models.NamespaceSettings{
 			SessionRecord:          false,
-			ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+			ConnectionAnnouncement: envs.AnnouncementFor(envs.CurrentEdition()),
 		},
 	}
 

--- a/server/api/services/setup_test.go
+++ b/server/api/services/setup_test.go
@@ -11,6 +11,7 @@ import (
 	storecache "github.com/shellhub-io/shellhub/pkg/cache"
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	clockmock "github.com/shellhub-io/shellhub/pkg/clock/mocks"
+	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/uuid"
@@ -42,6 +43,7 @@ func TestSetup(t *testing.T) {
 
 	// Setup calls envs.IsDevelopment() to decide the namespace tenant; not development here.
 	envMock.On("Get", "SHELLHUB_ENV").Return("")
+	envMock.On("Get", "SHELLHUB_EDITION").Return("")
 
 	ctx := context.TODO()
 
@@ -295,7 +297,7 @@ func TestSetup(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          false,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 					},
 					CreatedAt: now,
 				}
@@ -381,7 +383,7 @@ func TestSetup(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          false,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 					},
 					CreatedAt: now,
 				}
@@ -447,7 +449,7 @@ func TestSetup(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          false,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: envs.AnnouncementFor(envs.Community),
 					},
 					CreatedAt: now,
 				}


### PR DESCRIPTION
## What

Namespace creation now stamps an edition-appropriate SSH connection banner instead of always using the Community Edition text.

## Why

Every namespace — including Enterprise and Cloud — was created with a `DefaultAnnouncementMessage` that said "Welcome to ShellHub Community Edition!" and invited the user to explore other editions and contribute on GitHub. That reads wrong to paying customers.

Closes shellhub-io/team#231

## Changes

- **`pkg/envs/announcement.go`**: added `AnnouncementFor(edition)`, which builds the banner from a shared template, capitalizes the edition name for the title, and appends community-only links (GitHub, other editions) only when `edition == Community`. Empty edition defaults to Community.
- **`pkg/models/namespace.go`**: removed the hardcoded `DefaultAnnouncementMessage` constant and the `pkg/envs` import it required — `models` no longer depends on `envs`.
- **`server/api/services/namespace.go`**: replaced the `if envs.IsCommunity()` guard + constant with a single `envs.AnnouncementFor(envs.CurrentEdition())` call in the struct literal.
- **`server/api/services/setup.go`, `server/admin/services/namespaces.go`**: same — all three namespace creation sites now use the same one-liner.
- **Tests**: updated expectations to use `envs.AnnouncementFor` with the explicit edition per test case (Community, Cloud, Enterprise). Added `TestAnnouncementFor` covering all three editions plus the empty-string fallback.

## Testing

`go test ./pkg/envs/ ./server/api/services/ ./server/admin/services/` — all pass. `golangci-lint` clean.