### PR TITLE
fix(ui): show hours in session player when duration reaches one hour

### DIFF
--- a/ui/apps/console/src/components/sessions/SessionPlayer.tsx
+++ b/ui/apps/console/src/components/sessions/SessionPlayer.tsx
@@ -6,13 +6,16 @@ import { Dropdown, IconButton } from "@shellhub/design-system/primitives";
 
 type Speed = 0.5 | 1 | 1.5 | 2;
 
-function formatTime(secs: number): string {
-  const m = Math.floor(secs / 60)
-    .toString()
-    .padStart(2, "0");
-  const s = Math.floor(secs % 60)
-    .toString()
-    .padStart(2, "0");
+function padZero(num: number): string {
+  return num.toString().padStart(2, "0");
+}
+
+function formatTime(secs: number, showHours = false): string {
+  const h = padZero(Math.floor(secs / 3600));
+  const m = padZero(Math.floor(secs / 60) % 60);
+  const s = padZero(Math.floor(secs % 60));
+
+  if (showHours || h !== "00") return `${h}:${m}:${s}`;
   return `${m}:${s}`;
 }
 
@@ -267,7 +270,7 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
         </IconButton>
 
         <span className="text-xs font-mono tabular-nums text-text-secondary shrink-0">
-          {formatTime(currentTime)} / {formatTime(duration)}
+          {formatTime(currentTime, duration >= 3600)} / {formatTime(duration)}
         </span>
 
         <input

--- a/ui/apps/console/src/components/sessions/__tests__/SessionPlayer.test.tsx
+++ b/ui/apps/console/src/components/sessions/__tests__/SessionPlayer.test.tsx
@@ -71,29 +71,30 @@ describe("SessionPlayer", () => {
   });
 
   describe("playback state", () => {
-    it("shows the duration and a pause affordance once playback starts", async () => {
-      renderPlayer();
-      await emit("playing");
+    beforeEach(() => { renderPlayer(); });
 
+    it("shows the duration and a pause affordance once playback starts", async () => {
+      await emit("playing");
       expect(screen.getByText("00:00 / 01:00")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
     });
 
     it("advances the time readout as playback progresses", async () => {
-      renderPlayer();
       await emit("playing");
-
       currentTime = 5;
-
       expect(await screen.findByText("00:05 / 01:00")).toBeInTheDocument();
     });
 
     it("returns to a play affordance when playback ends", async () => {
-      renderPlayer();
       await emit("playing");
       await emit("ended");
-
       expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument();
+    });
+
+    it("shows the time formatted as HH:MM:SS when the duration is one hour or more", async () => {
+      duration = 3600;
+      await emit("playing");
+      expect(screen.getByText("00:00:00 / 01:00:00")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## What

The session player time readout switched to `HH:MM:SS` format when the recording duration is one hour or longer. Previously `formatTime` used a fixed `MM:SS` layout, so hour-long sessions displayed values like `60:00`.

## Why

`formatTime` only computed minutes and seconds, with no modulo wrap at 60 minutes. A one-hour recording showed `60:00 / 60:00` instead of `01:00:00 / 01:00:00`, and anything longer was equally wrong.

## Changes

- **`SessionPlayer.tsx`**: `formatTime` now accepts a `showHours` flag; when set (or when the computed hours are non-zero), it returns `HH:MM:SS`. The minutes calculation wraps at 60. The call site passes `duration >= 3600` so both the elapsed and total sides use the same format.
- **`SessionPlayer.test.tsx`**: added a boundary test at exactly `duration = 3600`; deduplicated `renderPlayer()` calls into a `beforeEach`.