### PR TITLE
deps: bump Go from 1.25.13 to 1.26.7

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -2,11 +2,11 @@
 # Default build: production multiarch
 # Development: use --target development
 
-ARG GOLANG_VERSION=1.25.13
+ARG GOLANG_VERSION=1.26.7
 ARG ALPINE_VERSION=3.24
 
 # Base stage for both development and production
-FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION:-1.25}-alpine${ALPINE_VERSION:-3.24} AS base
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION:-1.26}-alpine${ALPINE_VERSION:-3.24} AS base
 
 ARG GOPROXY
 ARG TARGETARCH

--- a/agent/Dockerfile.test
+++ b/agent/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.25.13-alpine3.24
+FROM golang:1.26.7-alpine3.24
 
 ARG GOPROXY
 

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/agent
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/devscripts/update-go
+++ b/devscripts/update-go
@@ -23,6 +23,8 @@ directories=(
     "" # Parent path
     "server"
     "agent"
+    "gateway"
+    "openapi"
     "tests"
 )
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.25.13-alpine3.24 AS base
+FROM golang:1.26.7-alpine3.24 AS base
 
 ARG GOPROXY
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/gateway
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/caddy-dns/acmedns v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/adhocore/gronx v1.20.3

--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.13-alpine3.24 AS base
+FROM golang:1.26.7-alpine3.24 AS base
 
 ARG GOPROXY
 ENV GOPROXY=${GOPROXY}

--- a/openapi/go.mod
+++ b/openapi/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/openapi
 
-go 1.25.13
+go 1.26.7
 
 require github.com/shellhub-io/shellhub v0.0.0
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,7 +19,7 @@ ARG MJML_VERSION=4.10.1
 FROM scratch AS cloud-src
 
 # ── base stage ────────────────────────────────────────────────────────────────
-FROM golang:1.25.13-alpine3.24 AS base
+FROM golang:1.26.7-alpine3.24 AS base
 
 ARG GOPROXY
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/server
 
-go 1.25.13
+go 1.26.7
 
 require (
 	code.dny.dev/ssrf v0.3.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/tests
 
-go 1.25.13
+go 1.26.7
 
 require (
 	github.com/bramvdbogaerde/go-scp v1.6.1

--- a/ui/apps/docs/src/pages/agent/building-from-source.mdx
+++ b/ui/apps/docs/src/pages/agent/building-from-source.mdx
@@ -10,7 +10,7 @@ Build the ShellHub agent from source for platforms without a pre-built package, 
 
 ## Prerequisites
 
-- Go 1.25+ (see the agent's `go.mod` for the exact version)
+- Go 1.26+ (see the agent's `go.mod` for the exact version)
 - Git
 
 ## Building


### PR DESCRIPTION
## What

Moves all six Go modules and the four builder images to Go 1.26.7, the current 1.26 patch.

## Why

Toolchain currency.

Paired with shellhub-io/cloud#2520, which has to merge first: cloud replaces these modules, and a module cannot depend on one declaring a newer Go than itself.

## Changes

- **go directives**: root, `server`, `agent`, `gateway`, `openapi`, `tests`.
- **builder images**: `server`, `gateway`, `openapi` and `agent/Dockerfile.test` to `golang:1.26.7-alpine3.24`; `agent/Dockerfile`'s `GOLANG_VERSION` arg and the `:-1.25` fallback in its `FROM` tag.
- **docs**: `building-from-source.mdx` states the minimum for building the agent by hand.
- **devscripts/update-go**: added `gateway` and `openapi`, in its own commit. The script drove the go directive for four of the six modules, so the other two needed a manual edit after every run.

## Testing

Per module, under `golang:1.26.7-alpine3.24`:

- `go build ./...` clean for all six, plus `agent` under `-tags docker`
- `go test ./...` passes for root, `server` and `agent`
- `go mod tidy` is a no-op; `go.sum` unchanged everywhere
- golangci-lint v2.11.3 compiles under 1.26 and reports no new findings
- Rebuilt the `server`, `gateway`, `openapi` and `agent` dev images and confirmed `go version` inside each

Two failures predate this bump and are unchanged by it, both reproduced identically at 1.25.13: `agent/installer.go` has a `gofmt -s` comment-alignment miss, and `gateway`'s `TestMain_smoke` asserts 404 on `/internal/whatever` while the built image answers 200 for every path.

https://claude.ai/code/session_01D4BSojj4fmh3ZQSZWkGbD8