### PR TITLE
chore(lint): stop linting the Go sources npm ships under ui/node_modules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,9 @@ linters:
   exclusions:
     paths:
       - "mocks/.*\\.go$"
+      # npm ships Go sources inside ui/node_modules. CI never installs them for the
+      # Go jobs, so only a local run sees the package — and lints a vendor's code.
+      - "node_modules/"
   disable:
     - errcheck
   enable:

--- a/SECURITY-SCANNING.md
+++ b/SECURITY-SCANNING.md
@@ -134,7 +134,10 @@ Before this work, `.golangci.yaml` blanket-excluded four gosec rules: G104, G301
 | G302 | File created with permissions > 0600 | `agent/server/utmp/utmp.go` (`OpenFile 0o644`) | Kept at `0o644` — utmp/wtmp files are conventionally world-readable per POSIX; tighter permissions break system accounting tools. Annotated |
 | G304 | File path from variable (potential traversal) | `agent/pkg/keygen/keygen.go` (`Create`, `ReadFile`), `agent/pkg/sysinfo/network.go` (`ReadFile`), `api/store/pg/` tests (`Open`, `ReadFile`) | keygen: path comes from a configured env var, not user input — annotated. sysinfo: path rooted under `/sys/class/net` (read-only kernel VFS) — annotated. agent: added `cleanKeyPath` guard rejecting raw `..` sequences before `generatePrivateKey`/`readPublicKey`. Tests: paths from `runtime.Caller`, not user input — annotated |
 
-The gateway module received its own `.golangci.yaml` (separate Go module, golangci-lint v2 does not inherit parent configs) with the same G104-only exclusion.
+The exclusion lives in the repository's single `.golangci.yaml`. `gateway` and the other
+submodules symlink to it, so there is one file to edit rather than one per module.
+golangci-lint resolves a single config instead of merging several, so a module that ever
+needs its own rules replaces the symlink with a real file and restates everything it keeps.
 
 ---
 


### PR DESCRIPTION
## What

Excludes `node_modules/` from golangci-lint, and corrects a note in `SECURITY-SCANNING.md` about how submodules get their config.

## Why

`flatted` vendors a Go package under `ui/node_modules`, so linting the root module locally reports five issues in a dependency's source: four `nlreturn`, one `modernize`. CI never sees them, because the Go jobs do not install the UI's node_modules. The gap means a local run and the `golint-stop` hook disagree with CI, and the noise is in code nobody here can change.

Found while surveying the lint config for a wider rule expansion.

## Changes

- **.golangci.yaml**: added `node_modules/` to `linters.exclusions.paths`.
- **SECURITY-SCANNING.md**: the gosec section claimed gateway "received its own `.golangci.yaml` (golangci-lint v2 does not inherit parent configs)". Both halves are misleading: gateway's file is a symlink to the root config, not a copy, and the reason submodules resolve it is that golangci-lint picks the nearest config walking up. Reworded to say what is actually there.

## Testing

`golangci-lint run ./...` under `golang:1.26.7-alpine3.24` across all seven lint entry points — root, `server`, `agent`, `gateway`, `openapi`, `tests`, `pkg` — reports `0 issues` with this change, against 5 in the root module before it. No other module's output changes.

https://claude.ai/code/session_01D4BSojj4fmh3ZQSZWkGbD8