### PR TITLE
chore(lint): enable perfsprint and usetesting, and apply their rewrites

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -56,6 +56,8 @@ linters:
     - iotamixing
     - unqueryvet
     # Naming and idiom the codebase already follows.
+    - perfsprint
+    - usetesting
     - errname
     - intrange
     - usestdlibvars

--- a/agent/pkg/selfupdater/updater_docker.go
+++ b/agent/pkg/selfupdater/updater_docker.go
@@ -199,7 +199,7 @@ func (d *dockerUpdater) updateContainer(container *dockerContainer, image, name 
 	config.Image = image
 
 	if parent {
-		config.Env = replaceOrAppendEnvValues(config.Env, []string{fmt.Sprintf("PARENT_CONTAINER=%s", container.info.ID)})
+		config.Env = replaceOrAppendEnvValues(config.Env, []string{"PARENT_CONTAINER=" + container.info.ID})
 	}
 
 	netConfig := &network.NetworkingConfig{EndpointsConfig: container.info.NetworkSettings.Networks}

--- a/agent/server/modes/host/command/command_docker.go
+++ b/agent/server/modes/host/command/command_docker.go
@@ -3,7 +3,6 @@
 package command
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -77,7 +76,7 @@ func getWrappedCommand(nsArgs []string, uid, gid uint32, groups []uint32, home s
 
 	setPrivCmd := []string{
 		"/bin/setpriv",
-		fmt.Sprintf("--groups=%s", strings.Join(gids, ",")),
+		"--groups=" + strings.Join(gids, ","),
 		"--ruid",
 		strconv.Itoa(int(uid)),
 		"--regid",
@@ -95,7 +94,7 @@ func getWrappedCommand(nsArgs []string, uid, gid uint32, groups []uint32, home s
 		[]string{
 			"-S",
 			strconv.Itoa(int(uid)),
-			fmt.Sprintf("--wdns=%s", home),
+			"--wdns=" + home,
 		}...,
 	)
 
@@ -123,7 +122,7 @@ func nsenterCommandWrapper(uid, gid uint32, groups []uint32, home string, comman
 	present := map[string]string{}
 
 	for ns, flag := range namespaces {
-		if _, err := statFn(fmt.Sprintf("/proc/1/ns/%s", ns)); err != nil {
+		if _, err := statFn("/proc/1/ns/" + ns); err != nil {
 			continue
 		}
 

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -442,7 +442,7 @@ func (s *Sessioner) SFTP(session gliderssh.Session) error {
 		return errors.New("failed to lookup user")
 	}
 
-	home := fmt.Sprintf("HOME=%s", looked.HomeDir)
+	home := "HOME=" + looked.HomeDir
 	gid := fmt.Sprintf("GID=%d", looked.GID)
 	uid := fmt.Sprintf("UID=%d", looked.UID)
 

--- a/agent/server/session.go
+++ b/agent/server/session.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"os/user"
 	"path"
@@ -35,7 +35,7 @@ func GetSessionType(session gliderssh.Session) (Type, error) {
 
 	requestType, ok := session.Context().Value("request_type").(string)
 	if !ok {
-		return SessionTypeUnknown, fmt.Errorf("failed to get request type from session context")
+		return SessionTypeUnknown, errors.New("failed to get request type from session context")
 	}
 
 	switch {

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"math/rand/v2"
 	"net"
@@ -62,7 +61,7 @@ type client struct {
 	reverser reverser.Reverser
 }
 
-var ErrParseAddress = fmt.Errorf("could not parse the address to the required format")
+var ErrParseAddress = errors.New("could not parse the address to the required format")
 
 // NewClient creates a new ShellHub HTTP client.
 //

--- a/pkg/api/client/client_common.go
+++ b/pkg/api/client/client_common.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"fmt"
-
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
 
@@ -28,7 +26,7 @@ func (c *client) GetDevice(uid string) (*models.Device, error) {
 
 	response, err := c.http.R().
 		SetResult(&device).
-		Get(fmt.Sprintf("/api/devices/%s", uid))
+		Get("/api/devices/" + uid)
 	if err != nil {
 		return nil, ErrConnectionFailed
 	}

--- a/pkg/api/client/client_common_test.go
+++ b/pkg/api/client/client_common_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -162,7 +161,7 @@ func TestGetDevice(t *testing.T) {
 				responder, _ := httpmock.NewJsonResponder(200, models.Device{
 					UID: "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 				})
-				httpmock.RegisterResponder("GET", fmt.Sprintf("/api/devices/%s", "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117"), responder)
+				httpmock.RegisterResponder("GET", "/api/devices/3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117", responder)
 			},
 			expected: Expected{
 				device: &models.Device{
@@ -184,7 +183,7 @@ func TestGetDevice(t *testing.T) {
 					Then(fail).
 					Then(fail).
 					Then(success)
-				httpmock.RegisterResponder("GET", fmt.Sprintf("/api/devices/%s", "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117"), responder)
+				httpmock.RegisterResponder("GET", "/api/devices/3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117", responder)
 			},
 			expected: Expected{
 				device: &models.Device{
@@ -198,7 +197,7 @@ func TestGetDevice(t *testing.T) {
 			uid:         "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 			requiredMocks: func() {
 				responder, _ := httpmock.NewJsonResponder(404, nil)
-				httpmock.RegisterResponder("GET", fmt.Sprintf("/api/devices/%s", "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117"), responder)
+				httpmock.RegisterResponder("GET", "/api/devices/3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117", responder)
 			},
 			expected: Expected{
 				device: nil,
@@ -210,7 +209,7 @@ func TestGetDevice(t *testing.T) {
 			uid:         "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 			requiredMocks: func() {
 				responder, _ := httpmock.NewJsonResponder(400, nil)
-				httpmock.RegisterResponder("GET", fmt.Sprintf("/api/devices/%s", "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117"), responder)
+				httpmock.RegisterResponder("GET", "/api/devices/3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117", responder)
 			},
 			expected: Expected{
 				device: nil,
@@ -222,7 +221,7 @@ func TestGetDevice(t *testing.T) {
 			uid:         "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 			requiredMocks: func() {
 				responder, _ := httpmock.NewJsonResponder(418, nil)
-				httpmock.RegisterResponder("GET", fmt.Sprintf("/api/devices/%s", "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117"), responder)
+				httpmock.RegisterResponder("GET", "/api/devices/3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117", responder)
 			},
 			expected: Expected{
 				device: nil,

--- a/pkg/api/client/reverser.go
+++ b/pkg/api/client/reverser.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -37,7 +36,7 @@ func (r *Reverser) Auth(ctx context.Context, token string, connPath string) erro
 	}
 
 	header := http.Header{
-		"Authorization": []string{fmt.Sprintf("Bearer %s", token)},
+		"Authorization": []string{"Bearer " + token},
 	}
 
 	conn, _, err := DialContext(ctx, uri, header)

--- a/pkg/envs/envs_test.go
+++ b/pkg/envs/envs_test.go
@@ -1,7 +1,6 @@
 package envs_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/shellhub-io/shellhub/pkg/envs"
@@ -147,20 +146,15 @@ func TestParseWithPrefix_with_default(t *testing.T) {
 	tests := []struct {
 		description string
 		prefix      string
-		before      func()
-		after       func()
+		setup       func(t *testing.T)
 		expected    Expected
 	}{
 		{
 			description: "parse envs with prefix empty",
 			prefix:      "",
-			before: func() {
-				os.Setenv("REDIS_URI", "redis://redis:6379/empty")
-				os.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
-			},
-			after: func() {
-				os.Unsetenv("REDIS_URI")
-				os.Unsetenv("MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("REDIS_URI", "redis://redis:6379/empty")
+				t.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -173,15 +167,10 @@ func TestParseWithPrefix_with_default(t *testing.T) {
 		{
 			description: "parse envs with one prefix and an empty",
 			prefix:      "FOO_",
-			before: func() {
-				os.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
-				os.Setenv("REDIS_URI", "redis://redis:6379/empty")
-				os.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
-			},
-			after: func() {
-				os.Unsetenv("FOO_REDIS_URI")
-				os.Unsetenv("REDIS_URI")
-				os.Unsetenv("MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
+				t.Setenv("REDIS_URI", "redis://redis:6379/empty")
+				t.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -194,17 +183,11 @@ func TestParseWithPrefix_with_default(t *testing.T) {
 		{
 			description: "parse envs with one prefix",
 			prefix:      "BAR_",
-			before: func() {
-				os.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
-				os.Setenv("BAR_REDIS_URI", "redis://redis:6379/bar")
-				os.Setenv("FOO_MONGO_URI", "mongodb://mongo:27017/foo")
-				os.Setenv("BAR_MONGO_URI", "mongodb://mongo:27017/bar")
-			},
-			after: func() {
-				os.Unsetenv("FOO_REDIS_URI")
-				os.Unsetenv("BAR_REDIS_URI")
-				os.Unsetenv("FOO_MONGO_URI")
-				os.Unsetenv("BAR_MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
+				t.Setenv("BAR_REDIS_URI", "redis://redis:6379/bar")
+				t.Setenv("FOO_MONGO_URI", "mongodb://mongo:27017/foo")
+				t.Setenv("BAR_MONGO_URI", "mongodb://mongo:27017/bar")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -217,15 +200,10 @@ func TestParseWithPrefix_with_default(t *testing.T) {
 		{
 			description: "parse envs with one prefix and default",
 			prefix:      "FOO_",
-			before: func() {
-				os.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
-				os.Setenv("BAR_REDIS_URI", "redis://redis:6379/bar")
-				os.Setenv("BAR_MONGO_URI", "mongodb://mongo:27017/bar")
-			},
-			after: func() {
-				os.Unsetenv("FOO_REDIS_URI")
-				os.Unsetenv("BAR_REDIS_URI")
-				os.Unsetenv("BAR_MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
+				t.Setenv("BAR_REDIS_URI", "redis://redis:6379/bar")
+				t.Setenv("BAR_MONGO_URI", "mongodb://mongo:27017/bar")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -239,13 +217,11 @@ func TestParseWithPrefix_with_default(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			tt.before()
+			tt.setup(t)
 
 			result, err := envs.ParseWithPrefix[Envs](tt.prefix)
 			assert.Equal(t, tt.expected.Envs, result)
 			assert.ErrorIs(t, err, tt.expected.Error)
-
-			tt.after()
 		})
 	}
 }
@@ -264,20 +240,15 @@ func TestParseWithPrefix_with_required(t *testing.T) {
 	tests := []struct {
 		description string
 		prefix      string
-		before      func()
-		after       func()
+		setup       func(t *testing.T)
 		expected    Expected
 	}{
 		{
 			description: "parse envs with a prefix and no prefixed",
 			prefix:      "FOO_",
-			before: func() {
-				os.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
-				os.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
-			},
-			after: func() {
-				os.Unsetenv("FOO_REDIS_URI")
-				os.Unsetenv("MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
+				t.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -290,13 +261,9 @@ func TestParseWithPrefix_with_required(t *testing.T) {
 		{
 			description: "parse envs with a prefix and no prefixed",
 			prefix:      "FOO_",
-			before: func() {
-				os.Setenv("REDIS_URI", "redis://redis:6379/empty")
-				os.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
-			},
-			after: func() {
-				os.Unsetenv("FOO_REDIS_URI")
-				os.Unsetenv("MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("REDIS_URI", "redis://redis:6379/empty")
+				t.Setenv("MONGO_URI", "mongodb://mongo:27017/empty")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -309,13 +276,9 @@ func TestParseWithPrefix_with_required(t *testing.T) {
 		{
 			description: "fails to parse when two different prefixes",
 			prefix:      "FOO_",
-			before: func() {
-				os.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
-				os.Setenv("BAR_MONGO_URI", "mongodb://mongo:27017/empty")
-			},
-			after: func() {
-				os.Unsetenv("FOO_REDIS_URI")
-				os.Unsetenv("BAR_MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("FOO_REDIS_URI", "redis://redis:6379/foo")
+				t.Setenv("BAR_MONGO_URI", "mongodb://mongo:27017/empty")
 			},
 			expected: Expected{
 				Envs:  nil,
@@ -326,13 +289,11 @@ func TestParseWithPrefix_with_required(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			tt.before()
+			tt.setup(t)
 
 			result, err := envs.ParseWithPrefix[Envs](tt.prefix)
 			assert.Equal(t, tt.expected.Envs, result)
 			assert.ErrorIs(t, err, tt.expected.Error)
-
-			tt.after()
 		})
 	}
 }
@@ -350,19 +311,14 @@ func TestParse_with_default(t *testing.T) {
 
 	tests := []struct {
 		description string
-		before      func()
-		after       func()
+		setup       func(t *testing.T)
 		expected    Expected
 	}{
 		{
 			description: "parse envs",
-			before: func() {
-				os.Setenv("REDIS_URI", "redis://redis:6379/test")
-				os.Setenv("MONGO_URI", "mongodb://mongo:27017/test")
-			},
-			after: func() {
-				os.Unsetenv("REDIS_URI")
-				os.Unsetenv("MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("REDIS_URI", "redis://redis:6379/test")
+				t.Setenv("MONGO_URI", "mongodb://mongo:27017/test")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -374,11 +330,8 @@ func TestParse_with_default(t *testing.T) {
 		},
 		{
 			description: "parse envs with one set and one default",
-			before: func() {
-				os.Setenv("REDIS_URI", "redis://redis:6379/test")
-			},
-			after: func() {
-				os.Unsetenv("REDIS_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("REDIS_URI", "redis://redis:6379/test")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -390,8 +343,7 @@ func TestParse_with_default(t *testing.T) {
 		},
 		{
 			description: "parse envs with all default",
-			before:      func() {},
-			after:       func() {},
+			setup:       func(t *testing.T) {},
 			expected: Expected{
 				Envs: &Envs{
 					RedisURI: "redis://redis:6379/default",
@@ -404,13 +356,11 @@ func TestParse_with_default(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			tt.before()
+			tt.setup(t)
 
 			result, err := envs.Parse[Envs]()
 			assert.Equal(t, tt.expected.Envs, result)
 			assert.ErrorIs(t, err, tt.expected.Error)
-
-			tt.after()
 		})
 	}
 }
@@ -428,19 +378,14 @@ func TestParse_with_required(t *testing.T) {
 
 	tests := []struct {
 		description string
-		before      func()
-		after       func()
+		setup       func(t *testing.T)
 		expected    Expected
 	}{
 		{
 			description: "parse envs",
-			before: func() {
-				os.Setenv("REDIS_URI", "redis://redis:6379/test")
-				os.Setenv("MONGO_URI", "mongodb://mongo:27017/test")
-			},
-			after: func() {
-				os.Unsetenv("REDIS_URI")
-				os.Unsetenv("MONGO_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("REDIS_URI", "redis://redis:6379/test")
+				t.Setenv("MONGO_URI", "mongodb://mongo:27017/test")
 			},
 			expected: Expected{
 				Envs: &Envs{
@@ -452,11 +397,8 @@ func TestParse_with_required(t *testing.T) {
 		},
 		{
 			description: "fail to parse envs when one env is missing",
-			before: func() {
-				os.Setenv("REDIS_URI", "redis://redis:6379/test")
-			},
-			after: func() {
-				os.Unsetenv("REDIS_URI")
+			setup: func(t *testing.T) {
+				t.Setenv("REDIS_URI", "redis://redis:6379/test")
 			},
 			expected: Expected{
 				Error: envs.ErrParse,
@@ -464,9 +406,7 @@ func TestParse_with_required(t *testing.T) {
 		},
 		{
 			description: "fails to parse when all envs are missing",
-			before: func() {
-			},
-			after: func() {
+			setup: func(t *testing.T) {
 			},
 			expected: Expected{
 				Envs:  nil,
@@ -477,13 +417,11 @@ func TestParse_with_required(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			tt.before()
+			tt.setup(t)
 
 			result, err := envs.Parse[Envs]()
 			assert.Equal(t, tt.expected.Envs, result)
 			assert.ErrorIs(t, err, tt.expected.Error)
-
-			tt.after()
 		})
 	}
 }

--- a/pkg/revdial/revdial.go
+++ b/pkg/revdial/revdial.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -101,7 +102,7 @@ func newUniqID() string {
 	buf := make([]byte, 16)
 	rand.Read(buf) // nolint:errcheck
 
-	return fmt.Sprintf("%x", buf)
+	return hex.EncodeToString(buf)
 }
 
 func (d *Dialer) register() {
@@ -258,7 +259,7 @@ func (d *Dialer) serve() error {
 			t.Stop()
 			if err := d.sendMessage(controlMsg{
 				Command:  "conn-ready",
-				ConnPath: d.pickupPath + fmt.Sprintf("&uuid=%s", uuid),
+				ConnPath: d.pickupPath + "&uuid=" + uuid,
 			}); err != nil {
 				d.logger.WithError(err).Debug("failed to send conn-ready message to device")
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"reflect"
 	"regexp"
 
@@ -58,35 +57,35 @@ var Rules = []Rule{
 
 			return err == nil
 		},
-		Error: fmt.Errorf("the regexp is invalid"),
+		Error: errors.New("the regexp is invalid"),
 	},
 	{
 		Tag: NameTag,
 		Handler: func(field validator.FieldLevel) bool {
 			return regexp.MustCompile(`^(.){1,64}$`).MatchString(field.Field().String())
 		},
-		Error: fmt.Errorf("the name must be between 1 and 64 characters"),
+		Error: errors.New("the name must be between 1 and 64 characters"),
 	},
 	{
 		Tag: UserNameTag,
 		Handler: func(field validator.FieldLevel) bool {
 			return regexp.MustCompile(`^([a-z0-9-_.@]){3,32}$`).MatchString(field.Field().String())
 		},
-		Error: fmt.Errorf("the username must be between 3 and 32 characters, and can only contain letters, numbers, and the following characters: -_.@"),
+		Error: errors.New("the username must be between 3 and 32 characters, and can only contain letters, numbers, and the following characters: -_.@"),
 	},
 	{
 		Tag: UserPasswordTag,
 		Handler: func(field validator.FieldLevel) bool {
 			return regexp.MustCompile(`^(.){5,32}$`).MatchString(field.Field().String())
 		},
-		Error: fmt.Errorf("the password cannot be empty and must be between 5 and 32 characters"),
+		Error: errors.New("the password cannot be empty and must be between 5 and 32 characters"),
 	},
 	{
 		Tag: DeviceNameTag,
 		Handler: func(field validator.FieldLevel) bool {
 			return regexp.MustCompile(`^([a-zA-Z0-9_-]){1,64}$`).MatchString(field.Field().String())
 		},
-		Error: fmt.Errorf("the device name can only contain `_`, `-` and alpha numeric characters"),
+		Error: errors.New("the device name can only contain `_`, `-` and alpha numeric characters"),
 	},
 	// api-key_name reports whether a given string is a valid API key name. A valid
 	// name must be between 3 and 20 characters and contain only letters, digits, `-`
@@ -97,7 +96,7 @@ var Rules = []Rule{
 		Handler: func(field validator.FieldLevel) bool {
 			return regexp.MustCompile(`^[a-zA-Z0-9_-]{3,20}$`).MatchString(field.Field().String())
 		},
-		Error: fmt.Errorf("name must be between 3 and 20 characters and can only contain letters, numbers, `-` and `_`"),
+		Error: errors.New("name must be between 3 and 20 characters and can only contain letters, numbers, `-` and `_`"),
 	},
 	// api-key_expires-at reports whether a given int is in [ 30 60 90 365 -1 ].
 	{
@@ -111,7 +110,7 @@ var Rules = []Rule{
 
 			return expiresAt == -1 || expiresAt == 30 || expiresAt == 60 || expiresAt == 90 || expiresAt == 365
 		},
-		Error: fmt.Errorf("expires_at must be in [ -1 30 60 90 365 ]"),
+		Error: errors.New("expires_at must be in [ -1 30 60 90 365 ]"),
 	},
 	// member_role reports whether a given string is a valid role or not
 	{
@@ -119,7 +118,7 @@ var Rules = []Rule{
 		Handler: func(field validator.FieldLevel) bool {
 			return authorizer.RoleFromString(field.Field().String()) != authorizer.RoleInvalid
 		},
-		Error: fmt.Errorf("role must be \"owner\", \"administrator\", \"operator\" or \"observer\""),
+		Error: errors.New("role must be \"owner\", \"administrator\", \"operator\" or \"observer\""),
 	},
 	{
 		Tag: PrivateKeyPEMTag,
@@ -133,7 +132,7 @@ var Rules = []Rule{
 
 			return err == nil && key != nil
 		},
-		Error: fmt.Errorf("the private key is invalid"),
+		Error: errors.New("the private key is invalid"),
 	},
 	{
 		Tag: CertPEMTag,
@@ -147,7 +146,7 @@ var Rules = []Rule{
 
 			return err == nil && cert != nil
 		},
-		Error: fmt.Errorf("the cert is invalid"),
+		Error: errors.New("the cert is invalid"),
 	},
 }
 

--- a/server/admin/namespace.go
+++ b/server/admin/namespace.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -148,7 +149,7 @@ func namespaceList(service serviceFunc) *cobra.Command {
 			}
 
 			if !quiet && len(args) == 1 {
-				return fmt.Errorf("field argument requires -q")
+				return errors.New("field argument requires -q")
 			}
 
 			if !validFields[field] {
@@ -220,22 +221,22 @@ func namespaceInspect(service serviceFunc) *cobra.Command {
 
 			if tenantID != "" {
 				if _, err := uuid.Parse(tenantID); err != nil {
-					return fmt.Errorf("invalid tenant ID: must be a valid UUID")
+					return errors.New("invalid tenant ID: must be a valid UUID")
 				}
 			}
 
 			if tenantID != "" && len(args) > 0 {
-				return fmt.Errorf("cannot provide both a namespace name and --tenant-id")
+				return errors.New("cannot provide both a namespace name and --tenant-id")
 			}
 
 			if len(args) > 0 {
 				if _, err := uuid.Parse(args[0]); err == nil {
-					return fmt.Errorf("it looks like you provided a tenant ID; use the --tenant-id flag")
+					return errors.New("it looks like you provided a tenant ID; use the --tenant-id flag")
 				}
 			}
 
 			if tenantID == "" && len(args) == 0 {
-				return fmt.Errorf("please provide either a namespace name or --tenant-id")
+				return errors.New("please provide either a namespace name or --tenant-id")
 			}
 
 			resolver := services.NamespaceResolverName

--- a/server/api/pkg/openapi/openapi.go
+++ b/server/api/pkg/openapi/openapi.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -68,7 +69,7 @@ func NewOpenAPIValidator(ctx context.Context, config *OpenAPIValidatorConfig) (*
 	}
 
 	if config.SchemaPath == nil {
-		return nil, fmt.Errorf("OpenAPI schema path is not defined")
+		return nil, errors.New("OpenAPI schema path is not defined")
 	}
 
 	loader := &openapi3.Loader{

--- a/server/api/routes/device_test.go
+++ b/server/api/routes/device_test.go
@@ -102,7 +102,7 @@ func TestGetDevice(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			tc.requiredMocks()
 
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/devices/%s", tc.uid), nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/devices/"+tc.uid, nil)
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
 			if tc.tenant != "" {
@@ -250,7 +250,7 @@ func TestDeleteDevice(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			tc.requiredMocks()
 
-			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/devices/%s", tc.uid), nil)
+			req := httptest.NewRequest(http.MethodDelete, "/api/devices/"+tc.uid, nil)
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
 			rec := httptest.NewRecorder()
@@ -317,7 +317,7 @@ func TestRenameDevice(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/devices/%s", tc.renamePayload.UID), strings.NewReader(string(jsonData)))
+			req := httptest.NewRequest(http.MethodPatch, "/api/devices/"+tc.renamePayload.UID, strings.NewReader(string(jsonData)))
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
 			req.Header.Set("X-Tenant-ID", tc.tenant)
@@ -630,7 +630,7 @@ func TestUpdateDevice(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/devices/%s", tc.req.UID), strings.NewReader(string(jsonData)))
+			req := httptest.NewRequest(http.MethodPut, "/api/devices/"+tc.req.UID, strings.NewReader(string(jsonData)))
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
 			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")

--- a/server/api/routes/nsadm_test.go
+++ b/server/api/routes/nsadm_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -149,7 +148,7 @@ func TestGetNamespace(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			tc.requiredMocks()
 
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/namespaces/%s", tc.req), nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/namespaces/"+tc.req, nil)
 
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
@@ -236,7 +235,7 @@ func TestDeleteNamespace(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			tc.requiredMocks()
 
-			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/namespaces/%s", tc.req), nil)
+			req := httptest.NewRequest(http.MethodDelete, "/api/namespaces/"+tc.req, nil)
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
 			req.Header.Set("X-ID", tc.uid)
@@ -343,7 +342,7 @@ func TestEditNamespace(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/users/security/%s", tc.headers["X-Tenant-ID"]), strings.NewReader(string(jsonData)))
+			req := httptest.NewRequest(http.MethodPut, "/api/users/security/"+tc.headers["X-Tenant-ID"], strings.NewReader(string(jsonData)))
 			for k, v := range tc.headers {
 				req.Header.Set(k, v)
 			}

--- a/server/api/routes/session_test.go
+++ b/server/api/routes/session_test.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -280,7 +279,7 @@ func TestGetSession(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			tc.requiredMocks(tc.expected.expectedSession)
 
-			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/sessions/%s", tc.uid), nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+tc.uid, nil)
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
 			if tc.tenant != "" {

--- a/server/api/routes/sshkeys_test.go
+++ b/server/api/routes/sshkeys_test.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -250,7 +249,7 @@ func TestDeletePublicKey(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.requiredMocks()
 
-			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/sshkeys/public-keys/%s", tc.fingerprint), nil)
+			req := httptest.NewRequest(http.MethodDelete, "/api/sshkeys/public-keys/"+tc.fingerprint, nil)
 			for k, v := range tc.headers {
 				req.Header.Set(k, v)
 			}

--- a/server/api/store/errors.go
+++ b/server/api/store/errors.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	stderrors "errors"
-	"fmt"
 
 	"github.com/shellhub-io/shellhub/pkg/errors"
 )
@@ -46,7 +45,7 @@ type DuplicateFieldError struct {
 }
 
 func (e DuplicateFieldError) Error() string {
-	return fmt.Sprintf("duplicate field: %s", e.Field)
+	return "duplicate field: " + e.Field
 }
 
 // DuplicatedField extracts the field name from a DuplicateFieldError wrapped inside err.

--- a/server/api/store/pg/utils_test.go
+++ b/server/api/store/pg/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -106,7 +105,7 @@ func TestFromSQLError(t *testing.T) {
 		},
 		{
 			name:  "generic unmapped error wraps with store.ErrInternal",
-			input: fmt.Errorf("some unexpected db error"),
+			input: errors.New("some unexpected db error"),
 			check: func(t *testing.T, result error) {
 				require.Error(t, result)
 				assert.True(t, errors.Is(result, store.ErrInternal), "expected result to wrap store.ErrInternal")

--- a/server/ssh/pkg/dialer/target.go
+++ b/server/ssh/pkg/dialer/target.go
@@ -27,7 +27,7 @@ func (t SSHOpenTarget) prepare(ctx context.Context, conn net.Conn, version Trans
 	case TransportVersion1:
 		log.Debug("preparing SSH open target for transport version 1")
 
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("/ssh/%s", t.SessionID), nil)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/ssh/"+t.SessionID, nil)
 		if err := req.Write(conn); err != nil {
 			log.Errorf("failed to write HTTP request: %v", err)
 
@@ -55,7 +55,7 @@ type SSHCloseTarget struct{ SessionID string }
 func (t SSHCloseTarget) prepare(ctx context.Context, conn net.Conn, version TransportVersion) (net.Conn, error) { // nolint:ireturn
 	switch version {
 	case TransportVersion1:
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("/ssh/close/%s", t.SessionID), nil)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/ssh/close/"+t.SessionID, nil)
 		if err := req.Write(conn); err != nil {
 			return nil, err
 		}

--- a/server/ssh/session/errors.go
+++ b/server/ssh/session/errors.go
@@ -1,21 +1,24 @@
 package session
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Errors returned by the NewSession to the client.
 var (
 	ErrBillingBlock            = fmt.Errorf("Connection to this device is not available as your current namespace doesn't qualify for the free plan. To gain access, you'll need to contact the namespace owner to initiate an upgrade.\n\nFor a detailed estimate of costs based on your use-cases with ShellHub Cloud, visit our pricing page at https://www.shellhub.io/pricing. If you wish to upgrade immediately, navigate to https://cloud.shellhub.io/settings/billing. Your cooperation is appreciated.") //nolint:all
-	ErrFirewallBlock           = fmt.Errorf("you cannot connect to this device because a firewall rule block your connection")
-	ErrFirewallUnknown         = fmt.Errorf("failed to evaluate the firewall rule")
-	ErrHost                    = fmt.Errorf("failed to get the device address")
-	ErrFindDevice              = fmt.Errorf("failed to find the device")
-	ErrDial                    = fmt.Errorf("failed to connect to device agent, please check the device connection")
-	ErrInvalidVersion          = fmt.Errorf("failed to parse device version")
-	ErrUnsuportedPublicKeyAuth = fmt.Errorf("connections using public keys are not permitted when the agent version is 0.5.x or earlier")
-	ErrUnexpectedAuthMethod    = fmt.Errorf("failed to authenticate the session due to a unexpected method")
-	ErrEvaluatePublicKey       = fmt.Errorf("failed to evaluate the provided public key")
-	ErrSeatAlreadySet          = fmt.Errorf("this seat was already set")
-	ErrSeatNotFound            = fmt.Errorf("this seat has no agent channel")
-	ErrWebData                 = fmt.Errorf("failed to parse the web session data")
+	ErrFirewallBlock           = errors.New("you cannot connect to this device because a firewall rule block your connection")
+	ErrFirewallUnknown         = errors.New("failed to evaluate the firewall rule")
+	ErrHost                    = errors.New("failed to get the device address")
+	ErrFindDevice              = errors.New("failed to find the device")
+	ErrDial                    = errors.New("failed to connect to device agent, please check the device connection")
+	ErrInvalidVersion          = errors.New("failed to parse device version")
+	ErrUnsuportedPublicKeyAuth = errors.New("connections using public keys are not permitted when the agent version is 0.5.x or earlier")
+	ErrUnexpectedAuthMethod    = errors.New("failed to authenticate the session due to a unexpected method")
+	ErrEvaluatePublicKey       = errors.New("failed to evaluate the provided public key")
+	ErrSeatAlreadySet          = errors.New("this seat was already set")
+	ErrSeatNotFound            = errors.New("this seat has no agent channel")
+	ErrWebData                 = errors.New("failed to parse the web session data")
 	ErrLicenseBlock            = fmt.Errorf("Connection blocked: your ShellHub instance has exceeded the maximum number of devices allowed by your license. Please contact support or remove unused devices.") //nolint:all
 )

--- a/server/ssh/session/session.go
+++ b/server/ssh/session/session.go
@@ -1042,7 +1042,7 @@ func (s *Session) Finish() (err error) {
 		s.Events.Close() //nolint:errcheck
 
 		if s.agent.conn != nil {
-			request, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("/ssh/close/%s", s.UID), nil)
+			request, _ := http.NewRequest(http.MethodDelete, "/ssh/close/"+s.UID, nil)
 
 			if err = request.Write(s.agent.conn); err != nil {
 				log.WithError(err).

--- a/server/ssh/web/errors.go
+++ b/server/ssh/web/errors.go
@@ -2,25 +2,24 @@ package web
 
 import (
 	"errors"
-	"fmt"
 )
 
 var (
-	ErrPublicKey               = fmt.Errorf("failed to get the parsed public key")
-	ErrConnect                 = fmt.Errorf("failed to connect to device")
-	ErrSession                 = fmt.Errorf("failed to create a session between the server to the agent")
-	ErrGetAuth                 = fmt.Errorf("failed to get auth data from key")
-	ErrWebData                 = fmt.Errorf("failed to get the data to connect to device")
-	ErrFindDevice              = fmt.Errorf("failed to find the device")
-	ErrFindPublicKey           = fmt.Errorf("failed to get the public key from the server")
-	ErrEvaluatePublicKey       = fmt.Errorf("failed to evaluate the public key in the server")
-	ErrForbiddenPublicKey      = fmt.Errorf("failed to use the public key for this action")
-	ErrDataPublicKey           = fmt.Errorf("failed to parse the public key data")
-	ErrPty                     = fmt.Errorf("failed to request the pty to agent")
-	ErrShell                   = fmt.Errorf("failed to get the shell to agent")
-	ErrAuthentication          = fmt.Errorf("failed to authenticate to device")
-	ErrInvalidVersion          = fmt.Errorf("failed to parse device version")
-	ErrUnsuportedPublicKeyAuth = fmt.Errorf("connections using public keys are not permitted when the agent version is 0.5.x or earlier")
+	ErrPublicKey               = errors.New("failed to get the parsed public key")
+	ErrConnect                 = errors.New("failed to connect to device")
+	ErrSession                 = errors.New("failed to create a session between the server to the agent")
+	ErrGetAuth                 = errors.New("failed to get auth data from key")
+	ErrWebData                 = errors.New("failed to get the data to connect to device")
+	ErrFindDevice              = errors.New("failed to find the device")
+	ErrFindPublicKey           = errors.New("failed to get the public key from the server")
+	ErrEvaluatePublicKey       = errors.New("failed to evaluate the public key in the server")
+	ErrForbiddenPublicKey      = errors.New("failed to use the public key for this action")
+	ErrDataPublicKey           = errors.New("failed to parse the public key data")
+	ErrPty                     = errors.New("failed to request the pty to agent")
+	ErrShell                   = errors.New("failed to get the shell to agent")
+	ErrAuthentication          = errors.New("failed to authenticate to device")
+	ErrInvalidVersion          = errors.New("failed to parse device version")
+	ErrUnsuportedPublicKeyAuth = errors.New("connections using public keys are not permitted when the agent version is 0.5.x or earlier")
 )
 
 var (

--- a/server/ssh/web/session.go
+++ b/server/ssh/web/session.go
@@ -168,12 +168,12 @@ func (s *Signer) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
 
 	var msg Message
 	if _, err := s.conn.ReadMessage(&msg); err != nil {
-		return nil, fmt.Errorf("invalid signature response")
+		return nil, errors.New("invalid signature response")
 	}
 
 	signed, ok := msg.Data.(string)
 	if !ok {
-		return nil, fmt.Errorf("data isn't a signed string")
+		return nil, errors.New("data isn't a signed string")
 	}
 
 	blob, err := base64.StdEncoding.DecodeString(signed)

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -51,13 +52,13 @@ func NewAgentContainerWithIdentity(identity string) NewAgentContainerOption {
 
 func NewAgentContainerWithConnectionVersion(version int) NewAgentContainerOption {
 	return func(envs map[string]string) {
-		envs["SHELLHUB_TRANSPORT_VERSION"] = fmt.Sprintf("%d", version)
+		envs["SHELLHUB_TRANSPORT_VERSION"] = strconv.Itoa(version)
 	}
 }
 
 func NewAgentContainer(ctx context.Context, port string, opts ...NewAgentContainerOption) (testcontainers.Container, error) {
 	envs := map[string]string{
-		"SHELLHUB_SERVER_ADDRESS":     fmt.Sprintf("http://localhost:%s", port),
+		"SHELLHUB_SERVER_ADDRESS":     "http://localhost:" + port,
 		"SHELLHUB_TENANT_ID":          "00000000-0000-4000-0000-000000000000",
 		"SHELLHUB_PRIVATE_KEY":        "/tmp/shellhub.key",
 		"SHELLHUB_LOG_FORMAT":         "json",
@@ -109,7 +110,7 @@ func TestSSHIdentityMode(t *testing.T) {
 	_, device := startAcceptedAgent(t, ctx, compose)
 
 	sshid := fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name)
-	addr := fmt.Sprintf("localhost:%s", compose.Env("SHELLHUB_SSH_PORT"))
+	addr := "localhost:" + compose.Env("SHELLHUB_SSH_PORT")
 
 	t.Run("password authentication is not offered", func(t *testing.T) {
 		config := &ssh.ClientConfig{
@@ -197,7 +198,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					resp, err := environment.services.R(ctx).
 						SetResult(&model).
-						Get(fmt.Sprintf("/api/devices/%s", device.UID))
+						Get("/api/devices/" + device.UID)
 					assert.Equal(tt, 200, resp.StatusCode())
 					assert.NoError(tt, err)
 
@@ -224,7 +225,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					resp, err := environment.services.R(ctx).
 						SetResult(&model).
-						Get(fmt.Sprintf("/api/devices/%s", device.UID))
+						Get("/api/devices/" + device.UID)
 					assert.Equal(tt, 200, resp.StatusCode())
 					assert.NoError(tt, err)
 
@@ -248,7 +249,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -266,7 +267,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				_, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				_, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.Error(t, err)
 			},
 		},
@@ -289,7 +290,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -333,7 +334,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 
 				conn.Close()
@@ -356,7 +357,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				_, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				_, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.Error(t, err)
 			},
 		},
@@ -376,7 +377,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -413,7 +414,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -464,7 +465,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -496,7 +497,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -535,7 +536,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -568,7 +569,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -604,7 +605,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -643,7 +644,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -678,7 +679,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.EventuallyWithT(t, func(tt *assert.CollectT) {
 					var err error
 
-					conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+					conn, err = ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 					assert.NoError(tt, err)
 				}, 30*time.Second, 1*time.Second)
 
@@ -708,7 +709,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", env.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+env.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 
 				type Data struct {
@@ -778,7 +779,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 
 				sess, err := conn.NewSession()
@@ -805,7 +806,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -819,7 +820,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				_, err = rand.Read(randomData)
 				require.NoError(t, err)
 
-				tempFile, err := os.CreateTemp("", "large-file-test-*.bin")
+				tempFile, err := os.CreateTemp(t.TempDir(), "large-file-test-*.bin")
 				require.NoError(t, err)
 				defer os.Remove(tempFile.Name())
 
@@ -862,7 +863,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -894,7 +895,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -933,7 +934,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -979,7 +980,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1022,7 +1023,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1065,7 +1066,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1120,7 +1121,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				addr := fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT"))
+				addr := "localhost:" + environment.services.Env("SHELLHUB_SSH_PORT")
 
 				dialed, err := net.DialTimeout("tcp", addr, 30*time.Second)
 				require.NoError(t, err)
@@ -1181,7 +1182,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1216,7 +1217,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1312,7 +1313,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1339,7 +1340,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1387,7 +1388,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					},
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1420,7 +1421,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					go func(id int) {
 						defer wg.Done()
 
-						conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+						conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 						if err != nil {
 							errors <- fmt.Errorf("connection %d failed: %w", id, err)
 
@@ -1474,7 +1475,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					},
 				}
 
-				conn1, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config1)
+				conn1, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config1)
 				require.NoError(t, err)
 				conn1.Close()
 
@@ -1485,14 +1486,14 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					},
 					HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 						if !bytes.Equal(key.Marshal(), learnedKey.Marshal()) {
-							return fmt.Errorf("host key mismatch")
+							return errors.New("host key mismatch")
 						}
 
 						return nil
 					},
 				}
 
-				conn2, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config2)
+				conn2, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config2)
 				require.NoError(t, err)
 				defer conn2.Close()
 			},
@@ -1509,7 +1510,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					Timeout:         10 * time.Second,
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1549,7 +1550,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1588,7 +1589,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1636,7 +1637,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
 				}
 
-				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				conn, err := ssh.Dial("tcp", "localhost:"+environment.services.Env("SHELLHUB_SSH_PORT"), config)
 				require.NoError(t, err)
 				defer conn.Close()
 
@@ -1770,7 +1771,7 @@ func startAcceptedAgent(t *testing.T, ctx context.Context, compose *environment.
 	require.EventuallyWithT(t, func(tt *assert.CollectT) {
 		resp, err := compose.R(ctx).
 			SetResult(&device).
-			Get(fmt.Sprintf("/api/devices/%s", devices[0].UID))
+			Get("/api/devices/" + devices[0].UID)
 		assert.Equal(tt, 200, resp.StatusCode())
 		assert.NoError(tt, err)
 


### PR DESCRIPTION
## What

Enables `perfsprint` and `usetesting`, and applies the ~200 rewrites they report.

## Why

Third step of the lint expansion, after #6980 and #6981. Both linters carry autofixes, so almost every hunk here was written by the tool rather than by hand — review the diff, not the reasoning behind each line.

- **`perfsprint`** — `fmt.Sprintf` used where concatenation or `strconv` does the job, `fmt.Errorf` with no format verbs where `errors.New` belongs, and `fmt.Sprintf("%x", b)` where `hex.EncodeToString` is both clearer and faster.
- **`usetesting`** — `t.Setenv`, `t.Context()` and `t.TempDir()` over the hand-rolled equivalents.

## Changes

One file needed hands. `pkg/envs/envs_test.go` set the environment through a `before` closure and undid it through a matching `after`, neither of which takes a `*testing.T`, so the fix could not be mechanical. Those cases now take one and call `t.Setenv`, which restores the previous value when the subtest ends. That is exactly what the `after` closures did by hand, so they are gone — 4 test tables, ~40 lines of teardown deleted.

Everything else is the linter's output, plus one tidy-up: `perfsprint` left five `"/api/devices/" + "3a47..."` pairs of adjacent literals, which I merged.

## Not included

**`dupword` was in this group and is deliberately left out.** Its autofix corrupts test fixtures, because in fixture data the repetition *is* the data. Applied to this tree it:

- rewrote a `/proc/self/mountinfo` sample in `pkg/dockerutils/utils_test.go`, stripping the filesystem type where the format legitimately repeats it (`- overlay overlay rw,...` became `- overlay rw,...`)
- turned `VALUES (..., now(), now(), ...)` into `now()` in three `migrations_test.go` inserts, changing the statement's column count, and mangled a string concatenation into `,"+ownerID+`' in the process

Both would have compiled. Neither is a change anyone would approve on purpose.

## Testing

Under `golang:1.26.7-alpine3.24`:

- `golangci-lint run ./...` reports `0 issues` for all six modules
- `go build ./...` clean everywhere, plus `agent` under `-tags docker` and `-tags native`
- `go test ./...` passes for root, `server`, and `agent` under `-tags docker`
- `go mod tidy` is a no-op

https://claude.ai/code/session_01D4BSojj4fmh3ZQSZWkGbD8