### PR TITLE
chore(lint): enable errorlint and make error identity survive wrapping

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -68,6 +68,8 @@ linters:
     - usetesting
     - errname
     - intrange
+    # Error identity survives wrapping: errors.Is/As over == and type assertions.
+    - errorlint
     # Tests that fail for the reason they claim, and report the caller's line.
     - testifylint
     - thelper

--- a/agent/pkg/agentd/handlers.go
+++ b/agent/pkg/agentd/handlers.go
@@ -145,7 +145,7 @@ func httpProxyHandlerV2(agent *Agent) tunnel.HandlerFunc {
 			defer done()
 			defer wg.Done()
 
-			if _, err := io.Copy(in, rwc); err != nil && err != io.EOF {
+			if _, err := io.Copy(in, rwc); err != nil && !errors.Is(err, io.EOF) {
 				logger.WithError(err).Error("proxy handler copy from rwc to in failed")
 			}
 		}()
@@ -155,7 +155,7 @@ func httpProxyHandlerV2(agent *Agent) tunnel.HandlerFunc {
 			defer done()
 			defer wg.Done()
 
-			if _, err := io.Copy(rwc, in); err != nil && err != io.EOF {
+			if _, err := io.Copy(rwc, in); err != nil && !errors.Is(err, io.EOF) {
 				logger.WithError(err).Error("proxy handler copy from in to rwc failed")
 			}
 		}()

--- a/agent/server/modes/connector/sessioner.go
+++ b/agent/server/modes/connector/sessioner.go
@@ -66,7 +66,7 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 			session.Exit(code) //nolint:errcheck
 		}()
 
-		if _, err := io.Copy(session, resp.Conn); err != nil && err != io.EOF {
+		if _, err := io.Copy(session, resp.Conn); err != nil && !errors.Is(err, io.EOF) {
 			fmt.Println(err)
 		}
 	})
@@ -74,7 +74,7 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 	wg.Go(func() {
 		defer resp.Close()
 
-		if _, err := io.Copy(resp.Conn, session); err != nil && err != io.EOF {
+		if _, err := io.Copy(resp.Conn, session); err != nil && !errors.Is(err, io.EOF) {
 			fmt.Println(err)
 		}
 	})
@@ -119,11 +119,11 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 		//
 		// [Docker]: https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerAttach
 		if isPty {
-			if _, err := io.Copy(session, resp.Reader); err != nil && err != io.EOF {
+			if _, err := io.Copy(session, resp.Reader); err != nil && !errors.Is(err, io.EOF) {
 				fmt.Println(err)
 			}
 		} else {
-			if _, err := stdcopy.StdCopy(session, session.Stderr(), resp.Reader); err != nil && err != io.EOF {
+			if _, err := stdcopy.StdCopy(session, session.Stderr(), resp.Reader); err != nil && !errors.Is(err, io.EOF) {
 				fmt.Println(err)
 			}
 		}
@@ -132,7 +132,7 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 	wg.Go(func() {
 		defer resp.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(resp.Conn, session); err != nil && err != io.EOF {
+		if _, err := io.Copy(resp.Conn, session); err != nil && !errors.Is(err, io.EOF) {
 			fmt.Println(err)
 		}
 	})
@@ -174,7 +174,7 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 			session.Exit(code) //nolint:errcheck
 		}()
 
-		if _, err := stdcopy.StdCopy(session, session.Stderr(), resp.Reader); err != nil && err != io.EOF {
+		if _, err := stdcopy.StdCopy(session, session.Stderr(), resp.Reader); err != nil && !errors.Is(err, io.EOF) {
 			fmt.Println(err)
 		}
 	})
@@ -182,7 +182,7 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 	wg.Go(func() {
 		defer resp.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(resp.Conn, session); err != nil && err != io.EOF {
+		if _, err := io.Copy(resp.Conn, session); err != nil && !errors.Is(err, io.EOF) {
 			fmt.Println(err)
 		}
 	})

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -494,7 +494,7 @@ func (s *Sessioner) SFTP(session gliderssh.Session) error {
 			"user": session.Context().User(),
 		}).Trace("copying input to session")
 
-		if _, err := io.Copy(input, session); err != nil && err != io.EOF {
+		if _, err := io.Copy(input, session); err != nil && !errors.Is(err, io.EOF) {
 			log.WithError(err).WithFields(log.Fields{
 				"user": session.Context().User(),
 			}).Error("Failed to copy stdin to command")

--- a/agent/sftp.go
+++ b/agent/sftp.go
@@ -99,7 +99,7 @@ func NewSFTPServer(mode command.SFTPServerMode) {
 		return
 	}
 
-	if err := server.Serve(); err != io.EOF {
+	if err := server.Serve(); !errors.Is(err, io.EOF) {
 		fmt.Fprintln(os.Stderr, err)
 	}
 

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -99,7 +99,8 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 	// proxies and request binders handle far more predictably.
 	client.http.SetContentLength(true)
 	client.http.AddRetryCondition(func(r *resty.Response, err error) bool {
-		if _, ok := err.(net.Error); ok {
+		var netErr net.Error
+		if errors.As(err, &netErr) {
 			log.WithFields(log.Fields{
 				"url": r.Request.URL,
 			}).WithError(err).Error("network error")

--- a/pkg/cache/cache_redis.go
+++ b/pkg/cache/cache_redis.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"math"
 	"strconv"
 	"time"
@@ -51,7 +52,7 @@ func NewRedisCache(uri string, pool int) (Cache, error) {
 // NOTE: missing key is not an error.
 func (c *redisCache) Get(ctx context.Context, key string, value any) error {
 	err := c.cache.Get(ctx, key, value)
-	if err == rediscache.ErrCacheMiss {
+	if errors.Is(err, rediscache.ErrCacheMiss) {
 		return nil
 	}
 
@@ -73,7 +74,7 @@ func (c *redisCache) SetNX(ctx context.Context, key string, value any, ttl time.
 
 // Delete deletes cached value by given key.
 func (c *redisCache) Delete(ctx context.Context, key string) error {
-	if err := c.cache.Get(ctx, key, nil); err == rediscache.ErrCacheMiss {
+	if err := c.cache.Get(ctx, key, nil); errors.Is(err, rediscache.ErrCacheMiss) {
 		return nil
 	}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -36,7 +36,8 @@ func WithData(parent error, data Data) error {
 		return nil
 	}
 
-	if err, ok := parent.(Error); ok {
+	var err Error
+	if errors.As(parent, &err) {
 		err.Data = data
 
 		return err

--- a/pkg/revdial/revdial.go
+++ b/pkg/revdial/revdial.go
@@ -456,7 +456,7 @@ func (ln *Listener) Accept() (net.Conn, error) {
 		err, closed := ln.readErr, ln.closed
 		ln.mu.Unlock()
 		if err != nil && !closed {
-			return nil, fmt.Errorf("revdial: Listener closed; %v", err)
+			return nil, fmt.Errorf("revdial: Listener closed; %w", err)
 		}
 
 		return nil, ErrListenerClosed

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -194,10 +194,12 @@ func (v *Validator) StructWithFields(structure any) (bool, map[string]any, error
 	if err := v.Validate.Struct(structure); err != nil {
 		fields := make(map[string]any, 0)
 
-		errs := err.(validator.ValidationErrors)
-
-		for _, e := range errs {
-			fields[e.Field()] = e.Tag()
+		// A non-struct argument yields InvalidValidationError instead, which carries no fields.
+		var errs validator.ValidationErrors
+		if errors.As(err, &errs) {
+			for _, e := range errs {
+				fields[e.Field()] = e.Tag()
+			}
 		}
 
 		return false, fields, ErrStructureInvalid

--- a/server/api/services/auth.go
+++ b/server/api/services/auth.go
@@ -296,7 +296,7 @@ func (s *service) authDevice(ctx context.Context, req requests.DeviceAuth, paire
 
 	device, err := s.store.DeviceResolve(ctx, sc, store.DeviceUIDResolver, uid)
 	if err != nil {
-		if err != store.ErrNoDocuments {
+		if !errors.Is(err, store.ErrNoDocuments) {
 			return nil, err
 		}
 

--- a/server/api/services/sshkeys.go
+++ b/server/api/services/sshkeys.go
@@ -137,7 +137,7 @@ func (s *service) CreatePublicKey(ctx context.Context, req requests.PublicKeyCre
 	req.Fingerprint = ssh.FingerprintLegacyMD5(pubKey)
 
 	returnedKey, err := s.store.PublicKeyResolve(ctx, sc, store.PublicKeyFingerprintResolver, req.Fingerprint)
-	if err != nil && err != store.ErrNoDocuments {
+	if err != nil && !errors.Is(err, store.ErrNoDocuments) {
 		return nil, NewErrPublicKeyNotFound(req.Fingerprint, err)
 	}
 

--- a/server/api/store/pg/options/internal/logrusbun.go
+++ b/server/api/store/pg/options/internal/logrusbun.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -114,16 +115,18 @@ func (h *QueryHook) BeforeQuery(ctx context.Context, event *bun.QueryEvent) cont
 	return ctx
 }
 
+// isQuiet reports whether the query outcome is one the non-verbose hook stays silent about.
+func isQuiet(err error) bool {
+	return err == nil || errors.Is(err, sql.ErrNoRows) || errors.Is(err, sql.ErrTxDone)
+}
+
 func (h *QueryHook) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
 	if !h.enabled {
 		return
 	}
 
-	if !h.verbose {
-		switch event.Err {
-		case nil, sql.ErrNoRows, sql.ErrTxDone:
-			return
-		}
+	if !h.verbose && isQuiet(event.Err) {
+		return
 	}
 
 	var level logrus.Level
@@ -133,8 +136,8 @@ func (h *QueryHook) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
 	now := time.Now()
 	dur := now.Sub(event.StartTime)
 
-	switch event.Err {
-	case nil, sql.ErrNoRows:
+	switch {
+	case event.Err == nil, errors.Is(event.Err, sql.ErrNoRows):
 		isError = false
 		if h.opts.LogSlow > 0 && dur >= h.opts.LogSlow {
 			level = h.opts.SlowLevel

--- a/server/api/store/pg/utils.go
+++ b/server/api/store/pg/utils.go
@@ -45,10 +45,10 @@ const (
 const constraintSystemsInstanceTenantIDFkey = "systems_instance_tenant_id_fkey"
 
 func fromSQLError(err error) error {
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return nil
-	case sql.ErrNoRows, io.EOF:
+	case errors.Is(err, sql.ErrNoRows), errors.Is(err, io.EOF):
 		return store.ErrNoDocuments
 	default:
 		var pgErr *pgconn.PgError

--- a/server/ssh/server/channels/tcpip.go
+++ b/server/ssh/server/channels/tcpip.go
@@ -1,6 +1,7 @@
 package channels
 
 import (
+	"errors"
 	"io"
 	"net"
 	"strconv"
@@ -108,7 +109,7 @@ func directTCPIPChannel(ctx gliderssh.Context, sess Session, newChan gossh.NewCh
 	wg.Go(func() {
 		logger.Trace("copying data from client to agent")
 
-		if _, err := io.Copy(client, &deadReadGuard{r: agent}); err != nil && err != io.EOF {
+		if _, err := io.Copy(client, &deadReadGuard{r: agent}); err != nil && !errors.Is(err, io.EOF) {
 			logger.WithError(err).Error("failed to copy data from agent to client")
 
 			// Close both ends so the peer goroutine unblocks and wg.Wait can return.
@@ -122,7 +123,7 @@ func directTCPIPChannel(ctx gliderssh.Context, sess Session, newChan gossh.NewCh
 	wg.Go(func() {
 		logger.Trace("copying data from agent to client")
 
-		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && !errors.Is(err, io.EOF) {
 			logger.WithError(err).Error("failed to copy data from client to agent")
 
 			_ = agent.Close()

--- a/server/ssh/server/channels/utils.go
+++ b/server/ssh/server/channels/utils.go
@@ -127,7 +127,7 @@ func pipe(sess Session, client gossh.Channel, agent gossh.Channel, seat int, don
 		go func() {
 			defer fromAgent.Done()
 
-			if _, err := io.Copy(multi, &deadReadGuard{r: agent}); err != nil && err != io.EOF {
+			if _, err := io.Copy(multi, &deadReadGuard{r: agent}); err != nil && !errors.Is(err, io.EOF) {
 				log.WithError(err).Error("failed on coping data from agent to client")
 
 				// Close both ends so the other copy goroutine unblocks and pipe can return.
@@ -139,7 +139,7 @@ func pipe(sess Session, client gossh.Channel, agent gossh.Channel, seat int, don
 		go func() {
 			defer fromAgent.Done()
 
-			if _, err := io.Copy(client.Stderr(), &deadReadGuard{r: agent.Stderr()}); err != nil && err != io.EOF {
+			if _, err := io.Copy(client.Stderr(), &deadReadGuard{r: agent.Stderr()}); err != nil && !errors.Is(err, io.EOF) {
 				log.WithError(err).Error("failed on coping stderr from agent to client")
 
 				_ = agent.Close()
@@ -158,7 +158,7 @@ func pipe(sess Session, client gossh.Channel, agent gossh.Channel, seat int, don
 			sess.CloseAgentWrite(seat) //nolint:errcheck
 		}()
 
-		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && !errors.Is(err, io.EOF) {
 			log.WithError(err).Error("failed on coping data from client to agent")
 
 			// Close both ends so the other copy goroutine unblocks and pipe can return.
@@ -186,7 +186,7 @@ func hose(logger *log.Entry, agent gossh.Channel, client gossh.Channel) {
 		defer wg.Done()
 		defer agent.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && !errors.Is(err, io.EOF) {
 			log.WithError(err).Error("failed on coping data from client to agent")
 
 			// Close the agent so the other copy goroutine unblocks.
@@ -200,7 +200,7 @@ func hose(logger *log.Entry, agent gossh.Channel, client gossh.Channel) {
 		defer wg.Done()
 		defer client.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(client, &deadReadGuard{r: agent}); err != nil && err != io.EOF {
+		if _, err := io.Copy(client, &deadReadGuard{r: agent}); err != nil && !errors.Is(err, io.EOF) {
 			log.WithError(err).Error("failed on coping data from agent to client")
 
 			// Close the client so the other copy goroutine unblocks.


### PR DESCRIPTION
## What

Enables `errorlint` and fixes the 29 sites it reports. It catches the three ways an error check silently stops working once anything in the chain wraps the error: `==`/`!=` comparison against a sentinel, a type assertion on `error`, and `%v` where `fmt.Errorf` should use `%w`.

## Why

Task 5 of the linting ledger. This is the last batch in the series with real semantic weight rather than mechanical rewrites: `%v` versus `%w` decides what `errors.Is` can reach, and a bare `==` against a sentinel is a check that passes review and then quietly stops matching the first time a caller wraps.

## Changes

Most of the 29 are one pattern: the `err != nil && err != io.EOF` guard after `io.Copy` in the SSH channel plumbing and the agent's session modes. Those are mechanical.

Three are not:

- **`pkg/validator`**: `StructWithFields` did an unchecked `err.(validator.ValidationErrors)`. `Validate.Struct` returns `*InvalidValidationError` when handed a non-struct, so that assertion **panicked**. It now reports the structure invalid with an empty field map.
- **`pkg/errors`**: `WithData` matched its parent with a bare type assertion and returned `nil` for anything else, dropping the error entirely. `errors.As` finds a wrapped `Error` instead of swallowing it. All eight callers pass a bare sentinel, so nothing changes today — this only removes a way to lose an error later.
- **`pkg/revdial`**: the listener-closed error formatted its cause with `%v`, so `errors.Is` could not reach it. It wraps now.

`server/api/store/pg/utils.go` and the bun query hook switched on the error value; both are `errors.Is` chains now.

## Testing

`fromSQLError` has the table in `server/api/store/pg/utils_test.go` covering the wrapped and joined cases, including that `context.Canceled` still passes through unwrapped.

Verified locally: lint clean across all six modules plus the agent under both `docker` and `native` tags; builds clean; unit tests pass for every touched package. The `enrollment_e2e` tests fail in my container for want of a Docker socket and fail identically on `master`.