### PR TITLE
fix(agent): do not hand a pty to a wrapped owner id

### DIFF
--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"strings"
@@ -55,8 +56,13 @@ func refuseIfCredentialSwitchDenied(session gliderssh.Session) error {
 func ptyStartOptions(uid uint32) []gliderssh.PtyStartOption {
 	opts := []gliderssh.PtyStartOption{gliderssh.WithJobControl()}
 
-	if geteuidFn() == 0 {
-		opts = append(opts, gliderssh.WithOwner(int(uid))) //nolint:gosec // uid_t is 32-bit; os.Chown takes an int
+	// WithOwner takes an int because that is what os.Chown takes, but uid_t is
+	// unsigned 32-bit. On a 32-bit build (the agent ships for ARM) an id above
+	// MaxInt32 wraps negative, and os.Chown reads a negative id as "leave it
+	// alone", so the pty would silently stay owned by the agent. Such an id is
+	// not a real account, so skip the hand-over rather than pass a wrapped one.
+	if geteuidFn() == 0 && uid <= math.MaxInt32 {
+		opts = append(opts, gliderssh.WithOwner(int(uid)))
 	}
 
 	return opts

--- a/agent/server/modes/host/sessioner_test.go
+++ b/agent/server/modes/host/sessioner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"sync/atomic"
 	"syscall"
@@ -181,4 +182,59 @@ func TestPtyFailureHint(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPtyStartOptionsBoundsTheOwnerID(t *testing.T) {
+	original := geteuidFn
+	t.Cleanup(func() { geteuidFn = original })
+
+	geteuidFn = func() int { return 0 }
+
+	cases := []struct {
+		description string
+		uid         uint32
+		wantOwner   bool
+	}{
+		{
+			description: "hands the pty over for an ordinary account",
+			uid:         1000,
+			wantOwner:   true,
+		},
+		{
+			description: "hands it over at the largest id an int can hold everywhere",
+			uid:         math.MaxInt32,
+			wantOwner:   true,
+		},
+		{
+			description: "skips the hand-over rather than wrap the id negative",
+			uid:         math.MaxInt32 + 1,
+			wantOwner:   false,
+		},
+		{
+			description: "skips (uid_t)-1, which is not an account",
+			uid:         math.MaxUint32,
+			wantOwner:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			// WithJobControl is always present, so an owner option makes it two.
+			opts := ptyStartOptions(tc.uid)
+			if tc.wantOwner {
+				assert.Len(t, opts, 2)
+			} else {
+				assert.Len(t, opts, 1)
+			}
+		})
+	}
+}
+
+func TestPtyStartOptionsSkipsTheHandOverWhenNotRoot(t *testing.T) {
+	original := geteuidFn
+	t.Cleanup(func() { geteuidFn = original })
+
+	geteuidFn = func() int { return 1000 }
+
+	assert.Len(t, ptyStartOptions(1000), 1)
 }


### PR DESCRIPTION
## What

`ptyStartOptions` converted a `uint32` uid to `int` for `gliderssh.WithOwner`, which hands it to `os.Chown`. The conversion is now bounded.

## Why

`int` is 32 bits on a 32-bit build, and the agent ships for ARM. An id above `MaxInt32` wraps negative, and `os.Chown` reads a negative id as **"leave this alone"** — so the pty would quietly stay owned by the agent while the code read as though it had been handed over. A silent no-op is the worst shape for this: the failure looks like success.

No real account has such an id, and `(uid_t)-1` is explicitly not one, so the hand-over is skipped rather than attempted with a wrapped value.

## How it was found

CodeQL (`go/incorrect-integer-conversion`) has been reporting it, behind a `//nolint:gosec` that suppressed nothing — gosec does not raise G115 here, so the directive silenced a linter that was never speaking. `nolintlint` flagged the directive as unused in shellhub-io/shellhub#6986, which is what surfaced the finding.

Two tools, two answers, and the suppression named the one that had nothing to say. Worth remembering when a `//nolint` looks like it documents a decision.

## Testing

`TestPtyStartOptionsBoundsTheOwnerID` covers 1000, `MaxInt32`, `MaxInt32+1` and `MaxUint32`, plus a non-root case. Verified it fails without the bound: widening the check to `MaxUint32` fails exactly the two cases that should wrap.

Agent lints and tests clean under both `docker` and `native`.