### PR TITLE
fix(server/ssh): verify the web bridge's host key and bound the terminal size

### DIFF
--- a/server/app/server.go
+++ b/server/app/server.go
@@ -310,7 +310,9 @@ func (s *Server) setupSSH(service services.Service) error {
 	// the loopback dial claims it.
 	handoff := webhandoff.NewStore()
 
-	web.NewSSHServerBridge(s.router, s.authn, service, handoff)
+	if err := web.NewSSHServerBridge(s.router, s.authn, service, handoff, &web.Config{HostKeyFile: env.HostKeyFile}); err != nil {
+		return err
+	}
 
 	if envs.IsDevelopment() {
 		runtime.SetBlockProfileRate(1)

--- a/server/ssh/web/errors.go
+++ b/server/ssh/web/errors.go
@@ -36,7 +36,10 @@ var (
 	ErrWebSocketGetIP         = errors.New("failed to get IP from query")
 )
 
-var ErrBridgeCredentialsNotFound = errors.New("failed to find the credentials")
+var (
+	ErrBridgeCredentialsNotFound = errors.New("failed to find the credentials")
+	ErrBridgeReadHostKey         = errors.New("failed to read the SSH server's host key")
+)
 
 var (
 	ErrGetToken      = errors.New("token not found on request query")

--- a/server/ssh/web/session.go
+++ b/server/ssh/web/session.go
@@ -187,7 +187,7 @@ func (s *Signer) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
 	}, nil
 }
 
-func newSession(ctx context.Context, service services.Service, handoff *webhandoff.Store, conn *Conn, creds *Credentials, dim Dimensions, info Info) error {
+func newSession(ctx context.Context, service services.Service, handoff *webhandoff.Store, conn *Conn, creds *Credentials, dim Dimensions, info Info, hostKey ssh.PublicKey) error {
 	logger := log.WithFields(log.Fields{
 		"user":   creds.Username,
 		"device": creds.Device,
@@ -222,7 +222,7 @@ func newSession(ctx context.Context, service services.Service, handoff *webhando
 	connection, err := ssh.Dial("tcp", "localhost:2222", &ssh.ClientConfig{ //nolint:exhaustruct
 		User:            user,
 		Auth:            auth,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		HostKeyCallback: ssh.FixedHostKey(hostKey),
 		BannerCallback:  bannerCallback(conn),
 	})
 	if err != nil {

--- a/server/ssh/web/utils.go
+++ b/server/ssh/web/utils.go
@@ -6,6 +6,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"os"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type Credentials struct {
@@ -75,11 +78,30 @@ func (c *Credentials) isPassword() bool {
 }
 
 // Dimensions represents a web SSH terminal dimensions.
+//
+// The sizes are 16 bits wide because that is what a pty can allocate; the width also makes
+// the conversion to the int the pty request takes exact on any platform.
 type Dimensions struct {
-	Cols uint32 `json:"cols"`
-	Rows uint32 `json:"rows"`
+	Cols uint16 `json:"cols"`
+	Rows uint16 `json:"rows"`
 }
 
 type Info struct {
 	IP string `json:"ip"`
+}
+
+// readHostKey loads the public half of the SSH server's host key, which the bridge pins its
+// loopback connection to.
+func readHostKey(path string) (ssh.PublicKey, error) {
+	pem, err := os.ReadFile(path) //nolint:gosec // path comes from the server's own configuration, not user input.
+	if err != nil {
+		return nil, errors.Join(ErrBridgeReadHostKey, err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(pem)
+	if err != nil {
+		return nil, errors.Join(ErrBridgeReadHostKey, err)
+	}
+
+	return signer.PublicKey(), nil
 }

--- a/server/ssh/web/web.go
+++ b/server/ssh/web/web.go
@@ -49,11 +49,26 @@ func exitLogLevel(err error) log.Level {
 	}
 }
 
+// Config is what the bridge needs to reach the SSH server it dials over the loopback.
+type Config struct {
+	// HostKeyFile is the path to that server's host key. The bridge pins its connection to
+	// the key's public half, so nothing else answering on the loopback port is accepted.
+	HostKeyFile string
+}
+
 // NewSSHServerBridge creates routes into a [echo.Router] to connect a webscoket to SSH using Shell session.
 //
 // authn is the API's authenticator, used to declare the WebSocket upgrade as
 // reachable without a credential. It may be nil in tests.
-func NewSSHServerBridge(router *echo.Echo, authn *routesmiddleware.Authenticator, service services.Service, handoff *webhandoff.Store) {
+//
+// It fails when the SSH server's host key cannot be read, since without it the bridge has
+// nothing to pin its connection to.
+func NewSSHServerBridge(router *echo.Echo, authn *routesmiddleware.Authenticator, service services.Service, handoff *webhandoff.Store, config *Config) error {
+	hostKey, err := readHostKey(config.HostKeyFile)
+	if err != nil {
+		return err
+	}
+
 	manager := newManager(30 * time.Second)
 
 	// The upgrade is token-gated rather than authenticated: a browser cannot set
@@ -176,10 +191,13 @@ func NewSSHServerBridge(router *echo.Echo, authn *routesmiddleware.Authenticator
 			creds,
 			Dimensions{cols, rows},
 			Info{IP: ip},
+			hostKey,
 		); err != nil {
 			exit(wsconn, err)
 
 			return
 		}
 	})))
+
+	return nil
 }

--- a/server/ssh/web/web_test.go
+++ b/server/ssh/web/web_test.go
@@ -1,8 +1,13 @@
 package web
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
+	"encoding/pem"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,8 +16,25 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/websocket"
 )
+
+// writeHostKey writes a throwaway host key for the bridge to pin to, and returns its path.
+func writeHostKey(t *testing.T) string {
+	t.Helper()
+
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	block, err := ssh.MarshalPrivateKey(key, "")
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "ssh.key")
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(block), 0o600))
+
+	return path
+}
 
 // TestExitLogLevel verifies that exitLogLevel returns logrus.WarnLevel for
 // expected/banner-derived errors and logrus.ErrorLevel for genuine server faults.
@@ -111,7 +133,7 @@ func TestNewSSHServerBridge_CredentialsNotFound(t *testing.T) {
 
 	// The token is never found, so the request fails before either dependency is
 	// reached.
-	NewSSHServerBridge(e, nil, nil, webhandoff.NewStore())
+	require.NoError(t, NewSSHServerBridge(e, nil, nil, webhandoff.NewStore(), &Config{HostKeyFile: writeHostKey(t)}))
 
 	server := httptest.NewServer(e)
 	defer server.Close()
@@ -141,4 +163,10 @@ func TestNewSSHServerBridge_CredentialsNotFound(t *testing.T) {
 		require.True(t, ok)
 		assert.Contains(t, data, ErrBridgeCredentialsNotFound.Error())
 	}, "handler must not panic when credentials are not found")
+}
+
+func TestNewSSHServerBridge_MissingHostKey(t *testing.T) {
+	err := NewSSHServerBridge(echo.New(), nil, nil, webhandoff.NewStore(), &Config{HostKeyFile: filepath.Join(t.TempDir(), "absent.key")})
+
+	assert.ErrorIs(t, err, ErrBridgeReadHostKey)
 }

--- a/server/ssh/web/websocket.go
+++ b/server/ssh/web/websocket.go
@@ -16,28 +16,27 @@ func getToken(req *http.Request) (string, error) {
 	return token, nil
 }
 
-func getDimensions(req *http.Request) (uint32, uint32, error) {
-	toUint32 := func(text string) (uint64, error) {
-		integer, err := strconv.ParseUint(text, 10, 32)
+func getDimensions(req *http.Request) (uint16, uint16, error) {
+	toUint16 := func(text string) (uint16, error) {
+		integer, err := strconv.ParseUint(text, 10, 16)
 		if err != nil {
 			return 0, err
 		}
 
-		return integer, nil
+		return uint16(integer), nil
 	}
 
-	cols, err := toUint32(req.URL.Query().Get("cols"))
+	cols, err := toUint16(req.URL.Query().Get("cols"))
 	if err != nil {
 		return 0, 0, errors.Join(ErrGetDimensions, err)
 	}
 
-	rows, err := toUint32(req.URL.Query().Get("rows"))
+	rows, err := toUint16(req.URL.Query().Get("rows"))
 	if err != nil {
 		return 0, 0, errors.Join(ErrGetDimensions, err)
 	}
 
-	//nolint:gosec // cols and rows are uint32, so we can safely convert them.
-	return uint32(cols), uint32(rows), nil
+	return cols, rows, nil
 }
 
 func getIP(req *http.Request) (string, error) {

--- a/server/ssh/web/websocket_test.go
+++ b/server/ssh/web/websocket_test.go
@@ -59,8 +59,8 @@ func TestGetToken(t *testing.T) {
 
 func TestGetDimensions(t *testing.T) {
 	type Expected struct {
-		cols uint32
-		rows uint32
+		cols uint16
+		rows uint16
 		err  error
 	}
 
@@ -124,8 +124,8 @@ func TestGetDimensions(t *testing.T) {
 			},
 		},
 		{
-			description: "fail when cols or rows exceed the uint32 limit",
-			uri:         "http://localhost?cols=4294967296&rows=4294967296",
+			description: "fail when cols or rows exceed the uint16 limit",
+			uri:         "http://localhost?cols=65536&rows=65536",
 			expected: Expected{
 				cols: 0,
 				rows: 0,
@@ -133,11 +133,11 @@ func TestGetDimensions(t *testing.T) {
 			},
 		},
 		{
-			description: "success to get the cols and rows uint32 limit",
-			uri:         "http://localhost?cols=4294967295&rows=4294967295",
+			description: "success to get the cols and rows uint16 limit",
+			uri:         "http://localhost?cols=65535&rows=65535",
 			expected: Expected{
-				cols: math.MaxUint32,
-				rows: math.MaxUint32,
+				cols: math.MaxUint16,
+				rows: math.MaxUint16,
 				err:  nil,
 			},
 		},


### PR DESCRIPTION
CodeQL fails on any pull request whose diff is large enough to sweep these lines
in — most recently on #6990, where none of the flagged code was touched. They are
pre-existing findings in the web terminal bridge, so they are fixed here on their
own rather than inside an unrelated branch.

## Host key verification

The bridge dials the SSH server over the loopback with `InsecureIgnoreHostKey`,
so whatever answers on port 2222 is accepted as the server. Both ends live in the
same process and read the same host key file, so there is a key to pin to:
`NewSSHServerBridge` now takes the path through a `web.Config`, reads the public
half once at startup, and returns an error when it cannot — the bridge does not
start without something to verify against.

## Terminal size

`cols` and `rows` came off the query as `uint32` and were converted to the `int`
the pty request takes, which truncates on a 32-bit build. A pty allocates 16-bit
dimensions, so they are parsed and carried as `uint16` and the conversion is exact
on every platform. A browser asking for more than 65535 columns now gets the same
rejection it already got for a negative one.

## Not covered

`server/ssh/session/session.go` dials the device agent with
`InsecureIgnoreHostKey` too, and CodeQL flags it in the same run. Fixing it means
pinning to the agent's registered public key, which is a behaviour change for
existing fleets — it is left for a separate decision.

## Testing

- `go test ./ssh/web/...` and `golangci-lint run ./ssh/web/... ./app/...` pass.
- The dimension table gained the uint16 boundary cases; the bridge gained a test
  that it refuses to start without a readable host key.