### PR TITLE
fix(agent): render UIDs and GIDs as unsigned in the nsenter command

### DIFF
--- a/agent/server/modes/host/command/command_docker.go
+++ b/agent/server/modes/host/command/command_docker.go
@@ -58,16 +58,16 @@ func NewCmd(u *osauth.User, shell, term, host string, envs []string, command ...
 func getWrappedCommand(nsArgs []string, uid, gid uint32, groups []uint32, home string) []string {
 	gids := []string{}
 	for _, g := range groups {
-		gids = append(gids, strconv.Itoa(int(g)))
+		gids = append(gids, strconv.FormatUint(uint64(g), 10))
 	}
 
 	setPrivCmd := []string{
 		"/bin/setpriv",
 		"--groups=" + strings.Join(gids, ","),
 		"--ruid",
-		strconv.Itoa(int(uid)),
+		strconv.FormatUint(uint64(uid), 10),
 		"--regid",
-		strconv.Itoa(int(gid)),
+		strconv.FormatUint(uint64(gid), 10),
 	}
 
 	nsenterCmd := append([]string{
@@ -80,7 +80,7 @@ func getWrappedCommand(nsArgs []string, uid, gid uint32, groups []uint32, home s
 		nsenterCmd,
 		[]string{
 			"-S",
-			strconv.Itoa(int(uid)),
+			strconv.FormatUint(uint64(uid), 10),
 			"--wdns=" + home,
 		}...,
 	)

--- a/agent/server/modes/host/command/command_docker_test.go
+++ b/agent/server/modes/host/command/command_docker_test.go
@@ -161,3 +161,34 @@ func TestNsenterArgs(t *testing.T) {
 		assert.Empty(t, args)
 	})
 }
+
+//nolint:paralleltest
+func TestNsenterCommandWrapperIDsAboveMaxInt32(t *testing.T) {
+	origStatFn := statFn
+
+	t.Cleanup(func() {
+		statFn = origStatFn
+	})
+
+	statFn = func(path string) (os.FileInfo, error) {
+		if path == "/usr/bin/nsenter" {
+			return nil, nil
+		}
+
+		return nil, os.ErrNotExist
+	}
+
+	const (
+		uid = uint32(4294967294)
+		gid = uint32(4294967293)
+		sup = uint32(2147483648)
+	)
+
+	cmd, err := nsenterCommandWrapper(uid, gid, []uint32{gid, sup}, "/home/user", "/bin/sh")
+	require.NoError(t, err)
+
+	assert.Equal(t, "4294967294", cmd[indexOf(cmd, "--ruid")+1])
+	assert.Equal(t, "4294967293", cmd[indexOf(cmd, "--regid")+1])
+	assert.Equal(t, "4294967294", cmd[indexOf(cmd, "-S")+1])
+	assert.Contains(t, cmd, "--groups=4294967293,2147483648")
+}


### PR DESCRIPTION
## What

`getWrappedCommand` in `agent/server/modes/host/command/command_docker.go` built the `setpriv`/`nsenter` argv with `strconv.Itoa(int(id))`, converting a `uint32` read from `/etc/passwd` through the platform's `int`. This replaces the four call sites with `strconv.FormatUint(uint64(id), 10)`.

## Why

`int` is 64 bits on amd64, so the value survives there. On the 32-bit targets the agent ships for — `arm/v6`, `arm/v7`, `386` — `int` is 32 bits signed, and any ID above 2^31-1 wraps negative:

```
/bin/setpriv --groups=-3,-2147483648 --ruid -2 --regid -3 /usr/bin/nsenter -t 1 -S -2 ...
```

`uid_t` is unsigned 32-bit on Linux and the kernel accepts everything below `(uid_t)-1`, so the upper half of the range is legal. Directory-backed ID mapping (SSSD, Winbind) and user-namespace remapping both hand out IDs from it. `setpriv` rejects the negative form, so the session fails to start.

This also clears code scanning alerts #190, #191, #297 and #301 (`go/incorrect-integer-conversion`).

## Testing

`TestNsenterCommandWrapperIDsAboveMaxInt32` pins the unsigned rendering. It passes on amd64 **with or without** the fix — the bug needs a 32-bit `int` to appear — so it was verified under `linux/386`:

| | `linux/386` result |
|---|---|
| master | FAIL — `expected "4294967294", actual "-2"` |
| this branch | ok |

`go vet`, `go test` and `golangci-lint run --build-tags docker` are clean on the package.