### PR TITLE
docs(pkg): state what the gorilla upgrader's default origin check does

### DIFF
--- a/pkg/websocket/websocket.go
+++ b/pkg/websocket/websocket.go
@@ -46,9 +46,9 @@ type Upgrader interface {
 	Upgrade(res http.ResponseWriter, req *http.Request) (Conn, error)
 }
 
-// GorillaUpgrader implements [Upgrader] using Gorilla's WebSocket implementation.
-// GorillaUpgrader is the gorilla/websocket implementation of Upgrader. It is exported so a caller
-// can reach the embedded upgrader's settings; everything else goes through the interface.
+// GorillaUpgrader is the gorilla/websocket implementation of [Upgrader]. The embedded upgrader is
+// unexported, so its settings are fixed at construction: build one with
+// [NewGorillaWebSocketUpgrader] and reach it through the interface.
 type GorillaUpgrader struct {
 	upgrader *websocket.Upgrader
 }
@@ -59,7 +59,10 @@ func (u *GorillaUpgrader) Upgrade(res http.ResponseWriter, req *http.Request) (C
 	return u.upgrader.Upgrade(res, req, nil)
 }
 
-// NewGorillaWebSocketUpgrader returns an upgrader with gorilla's defaults, which accept any origin.
+// NewGorillaWebSocketUpgrader returns an upgrader with gorilla's defaults. Leaving CheckOrigin nil
+// selects gorilla's same-origin check: a request carrying no Origin header is accepted, and one
+// carrying it is accepted only when its host equals the request's Host. A browser page on another
+// origin is therefore rejected with 403, while a non-browser client is not.
 func NewGorillaWebSocketUpgrader() Upgrader {
 	return &GorillaUpgrader{
 		upgrader: new(websocket.Upgrader),

--- a/pkg/websocket/websocket_test.go
+++ b/pkg/websocket/websocket_test.go
@@ -1,0 +1,80 @@
+package websocket
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGorillaWebSocketUpgraderChecksSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	upgrader := NewGorillaWebSocketUpgrader()
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		conn, err := upgrader.Upgrade(res, req)
+		if err != nil {
+			return
+		}
+
+		conn.Close() //nolint:errcheck
+	}))
+	t.Cleanup(server.Close)
+
+	url := "ws" + strings.TrimPrefix(server.URL, "http")
+	host := strings.TrimPrefix(server.URL, "http://")
+
+	cases := []struct {
+		name    string
+		origin  string
+		upgrade bool
+	}{
+		{
+			name:    "no origin header is accepted",
+			origin:  "",
+			upgrade: true,
+		},
+		{
+			name:    "matching origin is accepted",
+			origin:  "http://" + host,
+			upgrade: true,
+		},
+		{
+			name:    "foreign origin is rejected",
+			origin:  "http://evil.example.com",
+			upgrade: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			header := http.Header{}
+			if tc.origin != "" {
+				header.Set("Origin", tc.origin)
+			}
+
+			conn, res, err := websocket.DefaultDialer.Dial(url, header)
+			if res != nil {
+				defer res.Body.Close() //nolint:errcheck
+			}
+
+			if !tc.upgrade {
+				require.ErrorIs(t, err, websocket.ErrBadHandshake)
+				assert.Equal(t, http.StatusForbidden, res.StatusCode)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusSwitchingProtocols, res.StatusCode)
+			conn.Close() //nolint:errcheck
+		})
+	}
+}


### PR DESCRIPTION
## What

`NewGorillaWebSocketUpgrader`'s doc comment claimed it returns "gorilla's defaults, **which accept any origin**". The first half is right; the second is backwards.

With `CheckOrigin` left nil, gorilla v1.5.3 uses `checkSameOrigin` (`server.go:89`):

```go
func checkSameOrigin(r *http.Request) bool {
	origin := r.Header["Origin"]
	if len(origin) == 0 {
		return true
	}
	u, err := url.Parse(origin[0])
	if err != nil {
		return false
	}
	return equalASCIIFold(u.Host, r.Host)
}
```

A mismatch is refused with `403 websocket: request origin not allowed by Upgrader.CheckOrigin` before the handshake. So a browser page on another origin is rejected; a non-browser client, which sends no `Origin`, is not.

## Why it matters

Semgrep flags this constructor under `websocket-missing-origin-check` (code scanning alert #302), and the comment read as confirmation — finding and code agreeing that the endpoint takes any origin. Whoever came to close that alert would either have added a `CheckOrigin` duplicating what gorilla already does, or judged the alert real and gone hunting for an exposure that isn't there.

## Making the claim executable

`websocket_test.go` drives a real handshake against an `httptest` server for the three cases the comment names:

| Origin header | Expected |
|---|---|
| absent | upgrade (101) |
| matches `Host` | upgrade (101) |
| `http://evil.example.com` | `ErrBadHandshake`, 403 |

Mutation-checked: swapping the constructor's body for `&websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}` turns the foreign-origin case red, so the test pins the behaviour instead of restating it.

## Also

`GorillaUpgrader`'s doc comment had two openings stitched together, the second offering "the embedded upgrader's settings" to callers — the field is unexported with no accessor. Replaced with one sentence that matches the type.

## Testing

`go vet`, `go test -race`, `gofmt -s -l` and `golangci-lint run` are clean on `pkg/websocket`. No behaviour change: the constructor body is untouched.