### PR TITLE
fix(agent): keep passwd file content out of parse errors

### DIFF
--- a/agent/pkg/osauth/auth.go
+++ b/agent/pkg/osauth/auth.go
@@ -115,14 +115,14 @@ func parseGroupLine(line string) (Group, error) {
 	result := Group{}
 	parts := strings.Split(strings.TrimSpace(line), ":")
 	if len(parts) != 4 {
-		return result, fmt.Errorf("group line had wrong number of parts %d != 4", len(parts))
+		return result, fmt.Errorf("wrong number of fields: %d != 4", len(parts))
 	}
 	result.Name = strings.TrimSpace(parts[0])
 	result.Password = strings.TrimSpace(parts[1])
 
 	gid, err := parseUint32(parts[2])
 	if err != nil {
-		return result, fmt.Errorf("group line had badly formatted gid %s", parts[2])
+		return result, errMalformedGID
 	}
 	result.GID = gid
 
@@ -139,7 +139,7 @@ func parseGroupLine(line string) (Group, error) {
 func parseGroupReader(r io.Reader) (map[string]Group, error) {
 	lines := bufio.NewReader(r)
 	entries := make(map[string]Group)
-	for {
+	for lineno := 1; ; lineno++ {
 		line, _, err := lines.ReadLine()
 		if err != nil {
 			break
@@ -151,7 +151,7 @@ func parseGroupReader(r io.Reader) (map[string]Group, error) {
 
 		entry, err := parseGroupLine(string(line))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("group line %d: %w", lineno, err)
 		}
 
 		entries[entry.Name] = entry
@@ -292,7 +292,7 @@ func parseShadowReader(r io.Reader) (map[string]shadowEntry, error) {
 	lines := bufio.NewReader(r)
 	entries := make(map[string]shadowEntry)
 
-	for {
+	for lineno := 1; ; lineno++ {
 		line, _, err := lines.ReadLine()
 		if err != nil {
 			break
@@ -304,7 +304,7 @@ func parseShadowReader(r io.Reader) (map[string]shadowEntry, error) {
 
 		entry, err := parseShadowLine(string(line))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("shadow line %d: %w", lineno, err)
 		}
 
 		entries[entry.Username] = entry
@@ -317,7 +317,7 @@ func parseShadowLine(line string) (shadowEntry, error) {
 	result := shadowEntry{}
 	parts := strings.Split(strings.TrimSpace(line), ":")
 	if len(parts) != 9 {
-		return result, fmt.Errorf("shadow line had wrong number of parts %d != 9", len(parts))
+		return result, fmt.Errorf("wrong number of fields: %d != 9", len(parts))
 	}
 
 	result.Username = strings.TrimSpace(parts[0])
@@ -383,7 +383,7 @@ func singleUser() *User {
 func parsePasswdReader(r io.Reader) (map[string]User, error) {
 	lines := bufio.NewReader(r)
 	entries := make(map[string]User)
-	for {
+	for lineno := 1; ; lineno++ {
 		line, _, err := lines.ReadLine()
 		if err != nil {
 			break
@@ -395,7 +395,7 @@ func parsePasswdReader(r io.Reader) (map[string]User, error) {
 
 		entry, err := parsePasswdLine(string(line))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("passwd line %d: %w", lineno, err)
 		}
 
 		entries[entry.Username] = entry
@@ -408,20 +408,20 @@ func parsePasswdLine(line string) (User, error) {
 	result := User{}
 	parts := strings.Split(strings.TrimSpace(line), ":")
 	if len(parts) != 7 {
-		return result, fmt.Errorf("passwd line had wrong number of parts %d != 7", len(parts))
+		return result, fmt.Errorf("wrong number of fields: %d != 7", len(parts))
 	}
 	result.Username = strings.TrimSpace(parts[0])
 	result.Password = strings.TrimSpace(parts[1])
 
 	uid, err := parseUint32(parts[2])
 	if err != nil {
-		return result, fmt.Errorf("passwd line had badly formatted uid %s", parts[2])
+		return result, errMalformedUID
 	}
 	result.UID = uid
 
 	gid, err := parseUint32(parts[3])
 	if err != nil {
-		return result, fmt.Errorf("passwd line had badly formatted gid %s", parts[3])
+		return result, errMalformedGID
 	}
 	result.GID = gid
 

--- a/agent/pkg/osauth/auth_freebsd.go
+++ b/agent/pkg/osauth/auth_freebsd.go
@@ -105,7 +105,7 @@ func LookupUserFromPasswd(username string, passwd io.Reader) (*User, error) {
 func parseMasterPasswdReader(r io.Reader) (map[string]User, error) {
 	lines := bufio.NewReader(r)
 	entries := make(map[string]User)
-	for {
+	for lineno := 1; ; lineno++ {
 		line, _, err := lines.ReadLine()
 		if err != nil {
 			break
@@ -117,7 +117,7 @@ func parseMasterPasswdReader(r io.Reader) (map[string]User, error) {
 
 		entry, err := parseMasterPasswdLine(string(line))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("master.passwd line %d: %w", lineno, err)
 		}
 
 		entries[entry.Username] = entry
@@ -130,20 +130,20 @@ func parseMasterPasswdLine(line string) (User, error) {
 	result := User{}
 	parts := strings.Split(strings.TrimSpace(line), ":")
 	if len(parts) != 10 {
-		return result, fmt.Errorf("passwd line had wrong number of parts %d != 10", len(parts))
+		return result, fmt.Errorf("wrong number of fields: %d != 10", len(parts))
 	}
 	result.Username = strings.TrimSpace(parts[0])
 	result.Password = strings.TrimSpace(parts[1])
 
 	uid, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return result, fmt.Errorf("passwd line had badly formatted uid %s", parts[2])
+		return result, errMalformedUID
 	}
 	result.UID = uint32(uid)
 
 	gid, err := strconv.Atoi(parts[3])
 	if err != nil {
-		return result, fmt.Errorf("passwd line had badly formatted gid %s", parts[3])
+		return result, errMalformedGID
 	}
 	result.GID = uint32(gid)
 

--- a/agent/pkg/osauth/auth_test.go
+++ b/agent/pkg/osauth/auth_test.go
@@ -3,6 +3,7 @@
 package osauth
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -394,6 +395,78 @@ func TestParseUint32(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseErrorsDoNotEchoFileContent(t *testing.T) {
+	const poison = "SUPERSECRET-injected-by-a-hostile-image"
+
+	tests := []struct {
+		name     string
+		data     string
+		parse    func(io.Reader) error
+		wantLine string
+	}{
+		{
+			name: "passwd uid field",
+			data: "root:x:0:0:root:/root:/bin/bash\nbad:x:" + poison + ":0::/:/bin/sh\n",
+			parse: func(r io.Reader) error {
+				_, err := parsePasswdReader(r)
+
+				return err
+			},
+			wantLine: "passwd line 2",
+		},
+		{
+			name: "passwd gid field",
+			data: "bad:x:0:" + poison + "::/:/bin/sh\n",
+			parse: func(r io.Reader) error {
+				_, err := parsePasswdReader(r)
+
+				return err
+			},
+			wantLine: "passwd line 1",
+		},
+		{
+			name: "passwd field count",
+			data: "bad:x:0:0:" + poison + "\n",
+			parse: func(r io.Reader) error {
+				_, err := parsePasswdReader(r)
+
+				return err
+			},
+			wantLine: "passwd line 1",
+		},
+		{
+			name: "group gid field",
+			data: "root:x:0:root\nbad:x:" + poison + ":member\n",
+			parse: func(r io.Reader) error {
+				_, err := parseGroupReader(r)
+
+				return err
+			},
+			wantLine: "group line 2",
+		},
+		{
+			name: "shadow field count",
+			data: "bad:" + poison + "\n",
+			parse: func(r io.Reader) error {
+				_, err := parseShadowReader(r)
+
+				return err
+			},
+			wantLine: "shadow line 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.parse(strings.NewReader(tt.data))
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), poison)
+			assert.Contains(t, err.Error(), tt.wantLine)
 		})
 	}
 }

--- a/agent/pkg/osauth/errors.go
+++ b/agent/pkg/osauth/errors.go
@@ -4,3 +4,8 @@ import "errors"
 
 // ErrUserNotFound is returned when the user is not found in the passwd file.
 var ErrUserNotFound = errors.New("user not found")
+
+var (
+	errMalformedUID = errors.New("malformed uid field")
+	errMalformedGID = errors.New("malformed gid field")
+)

--- a/agent/server/modes/connector/authenticator.go
+++ b/agent/server/modes/connector/authenticator.go
@@ -100,7 +100,7 @@ func (a *Authenticator) Password(ctx gliderssh.Context, username string, passwor
 				"container": *a.container,
 				"username":  username,
 			},
-		).WithError(err).Error("user passwd is empty, so the authentication via password is blocked")
+		).Error("user passwd is empty, so the authentication via password is blocked")
 
 		return false
 	}
@@ -123,7 +123,7 @@ func (a *Authenticator) Password(ctx gliderssh.Context, username string, passwor
 				"container": *a.container,
 				"username":  username,
 			},
-		).WithError(err).Error("failed to authenticate the user on the device")
+		).Error("failed to authenticate the user on the device")
 
 		return false
 	}


### PR DESCRIPTION
Closes code scanning alerts #195, #196, #198, #240, #300 (`go/clear-text-logging`).

## The leak

`parsePasswdLine`, `parseGroupLine` and the FreeBSD `parseMasterPasswdLine` built their errors by interpolating the field they had just failed to parse:

```go
return result, fmt.Errorf("passwd line had badly formatted uid %s", parts[2])
```

Every caller logs that error with `WithError(err)`, so a field that doesn't parse as a number is copied verbatim into the agent's log.

In **host mode** the file is the host's own `/etc/passwd` — untidy, no more. In **connector mode** it is `/etc/passwd` read out of the container being attached to (`getPasswd` → `docker cp`), which the image author controls. A uid field of `$(...)\n level=fatal msg=...` lands in the log as written. Whoever ships those logs onward — anything parsing logfmt, anything rendering them in a browser — pays for it.

No password ever reached a log; CodeQL's "sensitive data" is the passwd bytes themselves. The reachable problem is log injection from a hostile image, which is why this is worth fixing rather than dismissing.

## The fix

The field's content was never the useful part of the message — its position was. Line parsers now return `errMalformedUID` / `errMalformedGID`, and the readers wrap with the line number they already track:

```
passwd line 12: malformed uid field
```

Field-count mismatches keep their counts: `len(parts)` is a number the parser derived, not bytes from the file.

## Also

Two log calls in the connector authenticator passed `WithError(err)` where `err` is provably nil — both sit after an `if err != nil { ...; return false }`, so they only ever recorded `error: null`. One of them is the sink CodeQL reports as **#300**, meaning the reported leak was of a nil. Dropped both.

## Testing

`TestParseErrorsDoNotEchoFileContent` feeds a marker through the uid, gid and field-count paths of the passwd, group and shadow readers, asserting the error names the line but not the content. Mutation-checked — restoring one interpolation turns it red:

```
"passwd line 2: badly formatted uid SUPERSECRET-injected-by-a-hostile-image"
  should not contain "SUPERSECRET-injected-by-a-hostile-image"
```

Full `agent` suite green under `-tags docker -race`; `gofmt` and `golangci-lint` clean.

## One thing I could not verify

`GOOS=freebsd` does not build on `master` either, for an unrelated pre-existing reason — `backend.ListGroups` returns `[]string` where `Backend` wants `[]uint32` (`auth_freebsd.go:45`). FreeBSD isn't in the CI matrix, so nothing catches it. `auth_freebsd.go` is changed here to match the other parsers, but it could not be compiled to prove it. Happy to open a separate issue for the FreeBSD backend.