### PR TITLE
fix(ui): run astro dev server with `--force` flag

### DIFF
--- a/ui/apps/docs/package.json
+++ b/ui/apps/docs/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "astro dev",
+    "dev": "astro dev --force",
     "build": "astro build",
     "shots": "./scripts/capture-shots.sh",
     "preview": "astro preview",


### PR DESCRIPTION
## What 

Add `--force` flag to the `dev` script in Docs.

## Why 

Astro 7 added a lock file to the dev server, that is kept in `node_modules` and keeps track of running servers. If it already has an active one, it refuses to start a new one. Since it's kept in the disk's `node_modules`, it survives the `ui` container restart and, when going up again, it fails. Running with `--force` forces Astro to kill the old server and start a brand new one.
