### PR TITLE
fix(ui): fix issues in Docs

### DIFF
--- a/ui/apps/docs/astro.config.mjs
+++ b/ui/apps/docs/astro.config.mjs
@@ -7,4 +7,5 @@ export default defineConfig({
   server: { port: 8083, host: true, allowedHosts: true },
   devToolbar: { enabled: false },
   integrations: [mdx(), react(), shots()],
+  compressHTML: true,
 });

--- a/ui/apps/docs/src/components/LegacyBanner.astro
+++ b/ui/apps/docs/src/components/LegacyBanner.astro
@@ -10,10 +10,5 @@ import Callout from "./Callout.astro";
     label: "Migrating from the legacy model",
   }}
 >
-  <slot>
-    Namespaces created today start in identity mode, where access is decided by
-    <a href="/manage/access-control/ssh-identities">SSH identities</a> and
-    <a href="/manage/access-control/access-policies">access policies</a>. In identity mode
-    this page describes something that is not running.
-  </slot>
+  <slot></slot>
 </Callout>

--- a/ui/apps/docs/src/data/links.ts
+++ b/ui/apps/docs/src/data/links.ts
@@ -1,0 +1,5 @@
+/**
+ * URL of the public website used by the docs app.
+ * Uses a local development host when running in DEV mode, otherwise the production URL.
+ */
+export const websiteUrl = import.meta.env.DEV ? "http://website.localhost" : "https://shellhub.io";

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -7,6 +7,7 @@ import {
   MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
 import { sidebar, flattenItems } from "../data/sidebar";
+import { websiteUrl } from "../data/links";
 
 interface Props {
   title: string;
@@ -14,8 +15,6 @@ interface Props {
 }
 
 const { title, description } = Astro.props;
-// Hardcoded to the local dev URL for now (no prod deploy yet).
-const websiteUrl = "http://website.localhost";
 
 const defaultCollapsed = new Set<string>();
 

--- a/ui/apps/docs/src/pages/index.astro
+++ b/ui/apps/docs/src/pages/index.astro
@@ -7,9 +7,7 @@ import {
   MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
 import { sidebar, flattenItems } from "../data/sidebar";
-
-// Hardcoded to the local dev URL for now (no prod deploy yet).
-const websiteUrl = "http://website.localhost";
+import { websiteUrl } from "../data/links";
 
 const sections = sidebar.map(section => ({
   label: section.label,

--- a/ui/apps/docs/src/pages/manage/access-control/public-keys.mdx
+++ b/ui/apps/docs/src/pages/manage/access-control/public-keys.mdx
@@ -8,7 +8,12 @@ import LegacyBanner from "../../../components/LegacyBanner.astro";
 
 # Public Keys
 
-<LegacyBanner />
+<LegacyBanner>
+  Namespaces created today start in identity mode, where access is decided by
+  <a href="/manage/access-control/ssh-identities">SSH identities</a> and
+  <a href="/manage/access-control/access-policies">access policies</a>. In identity mode
+  this page describes something that is not running.
+</LegacyBanner>
 
 In the legacy model, a public key registered in the namespace *is* the access. Whoever holds the
 matching private key connects.


### PR DESCRIPTION
## What

Fix three independent issues in the Docs UI.

## Changes

- **set `compressHTML` to `true`:** prevent the new default `jsx` compression, which removes whitespaces between links, line breaks, etc., breaking some points of the documentation.
- **remove default `LegacyBanner` slot value:** move the default to the only page that uses it and ensure any content passed as a slot to `LegacyBanner` receives a wrapper `<p>`, keeping the style from the rest of the application.
- **add conditional `websiteUrl` in `links.ts`:** resolve `websiteUrl` based in the `dev` env, setting to `website.localhost` if true, falling back to the landing page domain if false (`prod`).
