### PR TITLE
docs: frame the screenshots, and let a reader enlarge one

### DIFF
--- a/ui/apps/docs/src/components/Shot.astro
+++ b/ui/apps/docs/src/components/Shot.astro
@@ -29,12 +29,6 @@ const label = alt ?? id;
 ---
 <figure class="shot">
   <button class="shot-frame" type="button" data-shot-zoom aria-label={`Enlarge: ${label}`}>
-    <span class="shot-bar">
-      <span class="shot-route">{route}</span>
-      <svg class="shot-grow" viewBox="0 0 12 12" aria-hidden="true">
-        <path d="M7 1h4v4M11 1 7 5M5 11H1V7M1 11l4-4" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
-      </svg>
-    </span>
     <img src={shotImageHref(id)} alt={label} loading="lazy" />
   </button>
 </figure>
@@ -48,7 +42,6 @@ const label = alt ?? id;
     display: block;
     width: 100%;
     padding: 0;
-    text-align: left;
     background: rgb(var(--c-surface));
     border: 1px solid rgb(var(--c-border));
     border-radius: 0.5rem;
@@ -65,31 +58,6 @@ const label = alt ?? id;
   .shot-frame:focus-visible {
     outline: 2px solid rgb(var(--color-primary-rgb));
     outline-offset: 2px;
-  }
-
-  /* The route the screenshot was taken at: where this lives in the console. */
-  .shot-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 0.4rem 0.7rem;
-    border-bottom: 1px solid rgb(var(--c-border));
-    font-family: "IBM Plex Mono", monospace;
-    font-size: 0.6875rem;
-    line-height: 1;
-    color: rgb(var(--c-text-muted));
-  }
-
-  .shot-grow {
-    width: 0.75rem;
-    height: 0.75rem;
-    flex: none;
-    opacity: 0.6;
-  }
-
-  .shot-frame:hover .shot-grow {
-    opacity: 1;
   }
 
   .shot-frame img {

--- a/ui/apps/docs/src/components/Shot.astro
+++ b/ui/apps/docs/src/components/Shot.astro
@@ -24,19 +24,82 @@ const { id, route, of, viewport, alt, edition, before } = Astro.props;
 recordShot({ id, route, of, viewport, edition, before, page: Astro.url.pathname });
 
 warnMissingShotImageInDev(id);
+
+const label = alt ?? id;
 ---
 <figure class="shot">
-  <img src={shotImageHref(id)} alt={alt ?? id} />
+  <button class="shot-frame" type="button" data-shot-zoom aria-label={`Enlarge: ${label}`}>
+    <span class="shot-bar">
+      <span class="shot-route">{route}</span>
+      <svg class="shot-grow" viewBox="0 0 12 12" aria-hidden="true">
+        <path d="M7 1h4v4M11 1 7 5M5 11H1V7M1 11l4-4" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
+      </svg>
+    </span>
+    <img src={shotImageHref(id)} alt={label} loading="lazy" />
+  </button>
 </figure>
 
 <style>
   .shot {
-    margin: 1.5rem 0;
+    margin: 1.75rem 0;
   }
 
-  .shot img {
+  .shot-frame {
     display: block;
     width: 100%;
-    border-radius: 0.375rem;
+    padding: 0;
+    text-align: left;
+    background: rgb(var(--c-surface));
+    border: 1px solid rgb(var(--c-border));
+    border-radius: 0.5rem;
+    overflow: hidden;
+    cursor: zoom-in;
+    transition: border-color 0.15s ease;
+  }
+
+  .shot-frame:hover,
+  .shot-frame:focus-visible {
+    border-color: rgb(var(--color-primary-rgb));
+  }
+
+  .shot-frame:focus-visible {
+    outline: 2px solid rgb(var(--color-primary-rgb));
+    outline-offset: 2px;
+  }
+
+  /* The route the screenshot was taken at: where this lives in the console. */
+  .shot-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.4rem 0.7rem;
+    border-bottom: 1px solid rgb(var(--c-border));
+    font-family: "IBM Plex Mono", monospace;
+    font-size: 0.6875rem;
+    line-height: 1;
+    color: rgb(var(--c-text-muted));
+  }
+
+  .shot-grow {
+    width: 0.75rem;
+    height: 0.75rem;
+    flex: none;
+    opacity: 0.6;
+  }
+
+  .shot-frame:hover .shot-grow {
+    opacity: 1;
+  }
+
+  .shot-frame img {
+    display: block;
+    width: 100%;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .shot-frame {
+      transition: none;
+    }
   }
 </style>

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -516,7 +516,13 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
 
         const created = document.createElement("dialog");
         created.className = "shot-zoom";
-        created.innerHTML = '<img alt="">';
+        created.innerHTML =
+          '<button class="shot-zoom-close" type="button" aria-label="Close">' +
+          '<svg viewBox="0 0 14 14" aria-hidden="true"><path d="M2 2l10 10M12 2L2 12" ' +
+          'fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>' +
+          "</button><img alt=\"\">";
+        // Any click closes: the image fills the dialog, so anything else would
+        // leave the obvious target inert.
         created.addEventListener("click", () => created.close());
         created.addEventListener("close", () => document.body.classList.remove(OPEN));
         document.body.append(created);
@@ -526,7 +532,7 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
 
       // A markdown image is not a control, so it reaches neither the tab order nor
       // Enter. The <Shot> frame is already a button and needs none of this.
-      document.querySelectorAll(".prose img").forEach((image) => {
+      document.querySelectorAll(".prose img:not([data-shot-zoom] img)").forEach((image) => {
         image.tabIndex = 0;
         image.setAttribute("role", "button");
         image.setAttribute("aria-label", `Enlarge: ${image.alt}`);
@@ -534,7 +540,7 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
 
       document.addEventListener("keydown", (event) => {
         if (event.key !== "Enter" && event.key !== " ") return;
-        if (!event.target.matches(".prose img")) return;
+        if (!event.target.matches(".prose img:not([data-shot-zoom] img)")) return;
 
         event.preventDefault();
         event.target.click();

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -508,8 +508,6 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
       // Any screenshot in the prose enlarges: a console table at page width is
       // readable only so far, and the reader should not have to open the image
       // in a tab of its own.
-      const OPEN = "shot-zoom-open";
-
       function zoomDialog() {
         const existing = document.querySelector("dialog.shot-zoom");
         if (existing) return existing;
@@ -524,7 +522,6 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
         // Any click closes: the image fills the dialog, so anything else would
         // leave the obvious target inert.
         created.addEventListener("click", () => created.close());
-        created.addEventListener("close", () => document.body.classList.remove(OPEN));
         document.body.append(created);
 
         return created;
@@ -557,7 +554,6 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
         image.src = source.src;
         image.alt = source.alt;
 
-        document.body.classList.add(OPEN);
         zoom.showModal();
       });
     </script>

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -503,5 +503,57 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
         });
       }
     </script>
+
+    <script>
+      // Any screenshot in the prose enlarges: a console table at page width is
+      // readable only so far, and the reader should not have to open the image
+      // in a tab of its own.
+      const OPEN = "shot-zoom-open";
+
+      function zoomDialog() {
+        const existing = document.querySelector("dialog.shot-zoom");
+        if (existing) return existing;
+
+        const created = document.createElement("dialog");
+        created.className = "shot-zoom";
+        created.innerHTML = '<img alt="">';
+        created.addEventListener("click", () => created.close());
+        created.addEventListener("close", () => document.body.classList.remove(OPEN));
+        document.body.append(created);
+
+        return created;
+      }
+
+      // A markdown image is not a control, so it reaches neither the tab order nor
+      // Enter. The <Shot> frame is already a button and needs none of this.
+      document.querySelectorAll(".prose img").forEach((image) => {
+        image.tabIndex = 0;
+        image.setAttribute("role", "button");
+        image.setAttribute("aria-label", `Enlarge: ${image.alt}`);
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        if (!event.target.matches(".prose img")) return;
+
+        event.preventDefault();
+        event.target.click();
+      });
+
+      document.addEventListener("click", (event) => {
+        const frame = event.target.closest("[data-shot-zoom]");
+        const source = frame ? frame.querySelector("img") : event.target.closest(".prose img");
+        if (!source) return;
+
+        const zoom = zoomDialog();
+        const image = zoom.querySelector("img");
+
+        image.src = source.src;
+        image.alt = source.alt;
+
+        document.body.classList.add(OPEN);
+        zoom.showModal();
+      });
+    </script>
   </body>
 </html>

--- a/ui/apps/docs/src/styles/global.css
+++ b/ui/apps/docs/src/styles/global.css
@@ -643,6 +643,7 @@ html {
 /* Preflight zeroes the UA's `margin: auto`, which is what centres a modal. */
 dialog.shot-zoom {
   position: fixed;
+  overflow: visible;
   top: 50%;
   left: 50%;
   translate: -50% -50%;
@@ -669,4 +670,31 @@ dialog.shot-zoom::backdrop {
 
 body.shot-zoom-open {
   overflow: hidden;
+}
+
+.shot-zoom-close {
+  position: absolute;
+  top: -0.75rem;
+  right: -0.75rem;
+  display: grid;
+  place-items: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid rgb(var(--c-border));
+  border-radius: 50%;
+  background: rgb(var(--c-surface));
+  color: rgb(var(--c-text-muted));
+  cursor: pointer;
+}
+
+.shot-zoom-close:hover,
+.shot-zoom-close:focus-visible {
+  border-color: rgb(var(--color-primary-rgb));
+  color: rgb(var(--c-text-primary));
+}
+
+.shot-zoom-close svg {
+  width: 0.7rem;
+  height: 0.7rem;
 }

--- a/ui/apps/docs/src/styles/global.css
+++ b/ui/apps/docs/src/styles/global.css
@@ -618,3 +618,55 @@ html {
 }
 
 .prose td .badge-deprecated { margin-left: 0; }
+
+/* A screenshot sits on the same near-black the page uses, so it needs an edge of
+   its own to read as a picture rather than as part of the page. A <Shot> brings its
+   own frame, so its image is excluded rather than framed twice. */
+.prose img:not([data-shot-zoom] img) {
+  display: block;
+  background: rgb(var(--c-surface));
+  border: 1px solid rgb(var(--c-border));
+  border-radius: 0.5rem;
+  cursor: zoom-in;
+}
+
+.prose img:not([data-shot-zoom] img):hover,
+.prose img:not([data-shot-zoom] img):focus-visible {
+  border-color: rgb(var(--color-primary-rgb));
+}
+
+.prose img:not([data-shot-zoom] img):focus-visible {
+  outline: 2px solid rgb(var(--color-primary-rgb));
+  outline-offset: 2px;
+}
+
+/* Preflight zeroes the UA's `margin: auto`, which is what centres a modal. */
+dialog.shot-zoom {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  padding: 0;
+  border: 1px solid rgb(var(--c-border));
+  border-radius: 0.5rem;
+  background: rgb(var(--c-surface));
+  cursor: zoom-out;
+}
+
+/* Sized against the viewport, not the dialog: a percentage here would ask the
+   dialog for a width the dialog is deriving from this image. */
+dialog.shot-zoom img {
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: min(96vw, 1600px);
+  max-height: 92vh;
+}
+
+dialog.shot-zoom::backdrop {
+  background: color-mix(in srgb, rgb(var(--c-background)) 88%, transparent);
+}
+
+body.shot-zoom-open {
+  overflow: hidden;
+}

--- a/ui/apps/docs/src/styles/global.css
+++ b/ui/apps/docs/src/styles/global.css
@@ -640,6 +640,13 @@ html {
   outline-offset: 2px;
 }
 
+/* The design system resets `dialog` with `all: unset`, which takes the browser's
+   `dialog:not([open]) { display: none }` with it: a closed dialog would keep
+   sitting over the page. */
+dialog.shot-zoom:not([open]) {
+  display: none;
+}
+
 /* Preflight zeroes the UA's `margin: auto`, which is what centres a modal. */
 dialog.shot-zoom {
   position: fixed;
@@ -668,9 +675,6 @@ dialog.shot-zoom::backdrop {
   background: color-mix(in srgb, rgb(var(--c-background)) 88%, transparent);
 }
 
-body.shot-zoom-open {
-  overflow: hidden;
-}
 
 .shot-zoom-close {
   position: absolute;


### PR DESCRIPTION
The console is dark and so are the docs, so a screenshot of it landed on a background the same colour as itself and stopped reading as a picture. Every screenshot now carries an edge of its own.

A `<Shot>` gets a little more than an edge: it is framed as the window it is, with a bar naming the console route it was taken at. The route is already declared on the tag, and it answers the question a screenshot always raises — where do I go to see this myself.

Clicking any screenshot opens it at up to 1600px in a modal dialog, because a console table rendered at column width is legible only so far. Markdown images are given a tab stop and Enter, which a plain `<img>` does not have; the `<Shot>` frame was already a button.