### PR TITLE
fix(ui): clear Astro's dev lockfile instead of forcing dep re-optimization

### DIFF
--- a/ui/apps/docs/package.json
+++ b/ui/apps/docs/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "astro dev --force",
+    "dev": "astro dev",
     "build": "astro build",
     "shots": "./scripts/capture-shots.sh",
     "preview": "astro preview",

--- a/ui/scripts/entrypoint-dev.sh
+++ b/ui/scripts/entrypoint-dev.sh
@@ -21,6 +21,10 @@ SHELL=/bin/sh npx -y chokidar-cli@3.0.0 '/openapi/spec/**/*.yaml' --debounce 500
 # alongside the console. They share the workspace node_modules installed above
 # and are routed by the gateway via the website.* and docs.* subdomains in dev.
 npm run dev -w @shellhub/website &
+# Astro 7 writes a dev lockfile (.astro/dev.json) that survives container
+# restarts. A libuv thread in the console can reuse the stale PID, making
+# Astro think the old server is still running.
+rm -f apps/docs/.astro/dev.json
 npm run dev -w @shellhub/docs &
 
 npm run dev:console


### PR DESCRIPTION
## What
Replaces the `--force` flag on `astro dev` with a targeted lockfile cleanup in the dev entrypoint, fixing non-deterministic startup failures where one or more dev servers would silently hang.

## Why
Astro 7 writes `.astro/dev.json` with the running server's PID. When the container restarts, the file survives (bind-mounted source tree) and a libuv worker thread in the console's Vite process can reuse the stale PID. `process.kill(pid, 0)` matches Linux thread IDs, so Astro's liveness check sees the old PID as alive and refuses to start.

The `--force` flag (b9b67a7b8) bypassed this check, but it also forced Vite to re-optimize every dependency on every start. Three concurrent Vite instances all re-scanning the shared hoisted `node_modules` created a race that non-deterministically hung one or more of the dev servers.

## Changes
- **`entrypoint-dev.sh`**: delete `.astro/dev.json` before launching the docs dev server, so the stale lockfile never reaches Astro's liveness check
- **`docs/package.json`**: revert `astro dev --force` back to `astro dev`, restoring cached dep optimization and eliminating the concurrent re-optimization race