### PR TITLE
fix(pkg): treat a successful response with no body as an error

### DIFF
--- a/agent/pkg/agentd/agent.go
+++ b/agent/pkg/agentd/agent.go
@@ -453,9 +453,13 @@ func (a *Agent) loadDeviceInfo() error {
 
 func (a *Agent) probeServerInfo() error {
 	info, err := a.cli.GetInfo(a.config.Version)
+	if err != nil {
+		return err
+	}
+
 	a.serverInfo = info
 
-	return err
+	return nil
 }
 
 // ErrNoIdentityAndHostname is returned when the device can name itself neither by MAC nor by

--- a/agent/pkg/agentd/agent_test.go
+++ b/agent/pkg/agentd/agent_test.go
@@ -341,6 +341,57 @@ func TestAgent_GetInfo(t *testing.T) {
 	}
 }
 
+func TestAgent_probeServerInfo(t *testing.T) {
+	type expected struct {
+		serverInfo *models.Info
+		err        error
+	}
+
+	failure := errors.New("the server could not be reached")
+
+	tests := []struct {
+		description   string
+		requiredMocks func(cli *client_mocks.MockClient)
+		expected      expected
+	}{
+		{
+			description: "leaves the server info unset when the probe fails",
+			requiredMocks: func(cli *client_mocks.MockClient) {
+				cli.On("GetInfo", "latest").Return(nil, failure).Once()
+			},
+			expected: expected{
+				serverInfo: nil,
+				err:        failure,
+			},
+		},
+		{
+			description: "stores the server info when the probe succeeds",
+			requiredMocks: func(cli *client_mocks.MockClient) {
+				cli.On("GetInfo", "latest").Return(&models.Info{Version: "latest"}, nil).Once()
+			},
+			expected: expected{
+				serverInfo: &models.Info{Version: "latest"},
+				err:        nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			cli := new(client_mocks.MockClient)
+			test.requiredMocks(cli)
+
+			agent := &Agent{
+				cli:    cli,
+				config: &Config{Version: "latest"},
+			}
+
+			require.ErrorIs(t, agent.probeServerInfo(), test.expected.err)
+			assert.Equal(t, test.expected.serverInfo, agent.serverInfo)
+		})
+	}
+}
+
 // TestAgent_generatePrivateKey_PathContainment verifies that the production
 // generatePrivateKey method rejects PrivateKey paths that contain raw ".."
 // traversal sequences.  The raw path is what an operator would supply via

--- a/gateway/Caddyfile.tmpl
+++ b/gateway/Caddyfile.tmpl
@@ -191,6 +191,25 @@
 	}
 }
 
+{{- if .TLS }}
+# Automatic HTTPS redirects port 80 to the site above, but for a name it manages a
+# certificate for it writes a rule per name, and for the rest a single blanket one
+# at the end of the list -- which the fallback below shadows. A supplied
+# certificate is the case that has only the blanket rule, so say this name's
+# redirect here and let neither depend on the other.
+http://{{ $cfg.Domain }} {
+	redir https://{host}{uri} 308
+}
+
+{{ end }}
+# The fallback, and the reason it is here at all: a request whose Host is none of
+# the names above reaches Caddy's own default otherwise, which answers 200 with an
+# empty body. An agent reading that as ShellHub's /info gets no server info and no
+# error, so what should say "you are pointed at the wrong place" says nothing.
+http:// {
+	respond 404
+}
+
 # The container healthcheck. Written http:// so automatic HTTPS cannot redirect
 # it, and given a name of its own so it can share port 80 with the site above:
 # the probe runs inside this container, where every other name available to it is

--- a/gateway/caddy_test.go
+++ b/gateway/caddy_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -215,6 +217,110 @@ func TestHealthcheckAnswersOnEveryConfiguration(t *testing.T) {
 				"the healthcheck site must not depend on how TLS is configured")
 		})
 	}
+}
+
+// TestCaddyfileRefusesAHostItDoesNotServe pins the fallback site. Without it a
+// request arriving with any other Host reaches Caddy's own default, which
+// answers 200 with an empty body -- indistinguishable from a healthy ShellHub
+// until whatever asked tries to read the reply.
+func TestCaddyfileRefusesAHostItDoesNotServe(t *testing.T) {
+	for description, cfg := range configurations() {
+		t.Run(description, func(t *testing.T) {
+			rendered, err := Caddyfile(cfg)
+			require.NoError(t, err)
+
+			assert.Contains(t, string(rendered), "http:// {",
+				"a Host this proxy does not serve must not fall through to Caddy's default")
+		})
+	}
+}
+
+// TestTheFallbackIsTheLastRouteOnPortEighty is the other half of that fallback:
+// it matches every Host, so anything ordered after it is unreachable. Automatic
+// HTTPS appends its redirect for a name it holds no certificate for -- a supplied
+// certificate is exactly that name -- and the site would answer 404 on port 80
+// instead of redirecting.
+func TestTheFallbackIsTheLastRouteOnPortEighty(t *testing.T) {
+	for description, cfg := range configurations() {
+		t.Run(description, func(t *testing.T) {
+			rendered, err := Caddyfile(cfg)
+			require.NoError(t, err)
+
+			adapted, _, err := caddyconfig.GetAdapter("caddyfile").Adapt(rendered, nil)
+			require.NoError(t, err)
+
+			for name, server := range httpServers(t, adapted) {
+				if !slices.Contains(server.Listen, ":80") {
+					continue
+				}
+
+				require.NotEmpty(t, server.Routes, "%s serves port 80 with no route at all", name)
+
+				for i, route := range server.Routes[:len(server.Routes)-1] {
+					assert.NotEmpty(t, hosts(route),
+						"route %d of %s matches every Host, so the fallback is not the only one that does", i, name)
+				}
+
+				assert.Empty(t, hosts(server.Routes[len(server.Routes)-1]),
+					"the fallback must be the last route of %s", name)
+			}
+		})
+	}
+}
+
+// TestCaddyfileRedirectsItsOwnNameToHTTPS pins the redirect the fallback would
+// otherwise shadow. Caddy writes one per name it manages a certificate for and a
+// single blanket one for the rest, and the blanket one is what a deployment
+// serving a supplied certificate has.
+func TestCaddyfileRedirectsItsOwnNameToHTTPS(t *testing.T) {
+	rendered, err := Caddyfile(configurations()["supplied certificate"])
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "http://shellhub.example {")
+	assert.Contains(t, string(rendered), "redir https://{host}{uri} 308")
+
+	withoutTLS, err := Caddyfile(configurations()["community"])
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(withoutTLS), "redir ",
+		"there is nothing to redirect to when the site is served over plain HTTP")
+}
+
+type httpRoute struct {
+	Match []struct {
+		Host []string `json:"host"`
+	} `json:"match"`
+}
+
+type httpServer struct {
+	Listen []string    `json:"listen"`
+	Routes []httpRoute `json:"routes"`
+}
+
+func httpServers(t *testing.T, adapted []byte) map[string]httpServer {
+	t.Helper()
+
+	var config struct {
+		Apps struct {
+			HTTP struct {
+				Servers map[string]httpServer `json:"servers"`
+			} `json:"http"`
+		} `json:"apps"`
+	}
+
+	require.NoError(t, json.Unmarshal(adapted, &config))
+
+	return config.Apps.HTTP.Servers
+}
+
+func hosts(route httpRoute) []string {
+	var names []string
+
+	for _, match := range route.Match {
+		names = append(names, match.Host...)
+	}
+
+	return names
 }
 
 // TestCaddyfileStoresCertificatesOnTheVolume guards a mistake that is invisible

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -70,6 +70,8 @@ func TestMain_smoke(t *testing.T) {
 		req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+"/internal/whatever", nil)
 		require.NoError(t, reqErr)
 
+		req.Host = "localhost"
+
 		resp, err = client.Do(req)
 		if err == nil {
 			break
@@ -89,4 +91,17 @@ func TestMain_smoke(t *testing.T) {
 	defer resp.Body.Close() //nolint:errcheck
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	unknown, err := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+"/info", nil)
+	require.NoError(t, err)
+
+	unknown.Host = "a.name.this.gateway.does.not.serve"
+
+	refused, err := client.Do(unknown)
+	require.NoError(t, err)
+
+	defer refused.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusNotFound, refused.StatusCode,
+		"an unserved Host must be refused rather than answered with an empty 200, which an agent reads as ShellHub")
 }

--- a/pkg/api/client/client_common.go
+++ b/pkg/api/client/client_common.go
@@ -35,5 +35,5 @@ func (c *client) GetDevice(uid string) (*models.Device, error) {
 		return nil, err
 	}
 
-	return device, nil
+	return requireBody(device)
 }

--- a/pkg/api/client/client_common_test.go
+++ b/pkg/api/client/client_common_test.go
@@ -229,6 +229,17 @@ func TestGetDevice(t *testing.T) {
 				err:    errors.Join(ErrUnknown, errors.New("418")),
 			},
 		},
+		{
+			description: "failed when the response succeeds with an empty body",
+			uid:         "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
+			requiredMocks: func() {
+				httpmock.RegisterResponder("GET", "/api/devices/3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117", httpmock.NewStringResponder(200, ""))
+			},
+			expected: Expected{
+				device: nil,
+				err:    ErrEmptyResponse,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/api/client/client_public.go
+++ b/pkg/api/client/client_public.go
@@ -30,7 +30,7 @@ func (c *client) GetInfo(agentVersion string) (*models.Info, error) {
 		return nil, err
 	}
 
-	return info, nil
+	return requireBody(info)
 }
 
 func (c *client) AuthDevice(req *models.DeviceAuthRequest) (*models.DeviceAuthResponse, error) {
@@ -70,7 +70,7 @@ func (c *client) AuthDevice(req *models.DeviceAuthRequest) (*models.DeviceAuthRe
 		return nil, err
 	}
 
-	return res, nil
+	return requireBody(res)
 }
 
 func (c *client) Endpoints() (*models.Endpoints, error) {
@@ -87,7 +87,7 @@ func (c *client) Endpoints() (*models.Endpoints, error) {
 		return nil, err
 	}
 
-	return endpoints, nil
+	return requireBody(endpoints)
 }
 
 func (c *client) AuthPublicKey(req *models.PublicKeyAuthRequest, token string) (*models.PublicKeyAuthResponse, error) {
@@ -106,7 +106,7 @@ func (c *client) AuthPublicKey(req *models.PublicKeyAuthRequest, token string) (
 		return nil, err
 	}
 
-	return res, nil
+	return requireBody(res)
 }
 
 func (c *client) CreateDeviceLoginCode(token string) (*models.DeviceLoginCode, error) {
@@ -124,7 +124,7 @@ func (c *client) CreateDeviceLoginCode(token string) (*models.DeviceLoginCode, e
 		return nil, err
 	}
 
-	return res, nil
+	return requireBody(res)
 }
 
 func (c *client) CreateDevicePairing(req *models.DevicePairingRequest) (*models.DevicePairing, error) {
@@ -142,7 +142,7 @@ func (c *client) CreateDevicePairing(req *models.DevicePairingRequest) (*models.
 		return nil, err
 	}
 
-	return res, nil
+	return requireBody(res)
 }
 
 func (c *client) GetDevicePairingStatus(code string) (*models.DevicePairingStatus, error) {
@@ -159,7 +159,7 @@ func (c *client) GetDevicePairingStatus(code string) (*models.DevicePairingStatu
 		return nil, err
 	}
 
-	return res, nil
+	return requireBody(res)
 }
 
 func (c *client) GetDeviceAuthStatus(token string) (*models.DeviceAuthStatus, error) {
@@ -177,7 +177,7 @@ func (c *client) GetDeviceAuthStatus(token string) (*models.DeviceAuthStatus, er
 		return nil, err
 	}
 
-	return res, nil
+	return requireBody(res)
 }
 
 // NewReverseListener creates a new reverse listener connection to ShellHub's server. This listener receives the SSH

--- a/pkg/api/client/client_public_test.go
+++ b/pkg/api/client/client_public_test.go
@@ -122,6 +122,17 @@ func TestGetInfo(t *testing.T) {
 				err:  errors.Join(ErrUnknown, errors.New("418")),
 			},
 		},
+		{
+			description: "failed when the response succeeds with an empty body",
+			version:     "v0.13.0",
+			requiredMocks: func() {
+				mock.RegisterResponder("GET", "/info?agent_version=v0.13.0", mock.NewStringResponder(200, ""))
+			},
+			expected: Expected{
+				info: nil,
+				err:  ErrEmptyResponse,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -236,6 +247,33 @@ func TestAuthDevice(t *testing.T) {
 					Namespace: "00000000-0000-4000-0000-000000000000",
 				},
 				err: nil,
+			},
+		},
+		{
+			description: "failed when the response succeeds with an empty body",
+			request: &models.DeviceAuthRequest{
+				Info: &models.DeviceInfo{
+					ID:         "manjaro",
+					PrettyName: "Manjaro",
+					Version:    "latest",
+					Arch:       "amd64",
+					Platform:   "docker",
+				},
+				DeviceAuth: &models.DeviceAuth{
+					Hostname: "83-18-77-25-78-0d",
+					Identity: &models.DeviceIdentity{
+						MAC: "83:18:77:25:78:0d",
+					},
+					TenantID:  "00000000-0000-4000-0000-000000000000",
+					PublicKey: "",
+				},
+			},
+			requiredMocks: func() {
+				mock.RegisterResponder("POST", "/api/devices/auth", mock.NewStringResponder(200, ""))
+			},
+			expected: Expected{
+				response: nil,
+				err:      ErrEmptyResponse,
 			},
 		},
 	}

--- a/pkg/api/client/errors.go
+++ b/pkg/api/client/errors.go
@@ -35,6 +35,9 @@ var (
 	ErrTooManyRequests = errors.New("too many requests")
 	// ErrInternalServerError is returned when the server has cannot response to the request due an error.
 	ErrInternalServerError = errors.New("internal server error")
+	// ErrEmptyResponse is returned when a successful response carries no body for the client to
+	// decode, so there is no value to hand the caller.
+	ErrEmptyResponse = errors.New("empty response")
 )
 
 // ErrorFromResponse returns an error based on the response status code.
@@ -66,4 +69,12 @@ func ErrorFromResponse(response Response) error {
 	default:
 		return errors.Join(ErrUnknown, fmt.Errorf("%d", response.StatusCode()))
 	}
+}
+
+func requireBody[T any](result *T) (*T, error) {
+	if result == nil {
+		return nil, ErrEmptyResponse
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
## What

An agent whose `SHELLHUB_SERVER_ADDRESS` points at something that answers `GET /info` with `200` and an empty body crashed on a nil dereference before it connected. The API client now reports that as an error, and the gateway no longer produces such a reply in the first place.

## Why

`resty` decodes into the `**models.Info` handed to `SetResult`. With a success status and a zero-length body there is nothing to unmarshal, so the pointer stays nil and no error is raised; `ErrorFromResponse` reads only the status, so `GetInfo` returned `(nil, nil)`. `probeServerInfo` stored that nil, `Setup` carried on, and `Authorize` dereferenced `a.serverInfo.Endpoints.SSH` while building its log fields — a segfault, exit 2, and under a supervisor a restart loop.

The reply is easy to arrive at by accident. The gateway's site block matches on `SHELLHUB_DOMAIN`, so a request with any other Host fell through to Caddy's own default, which answers `200` with an empty body rather than a 404. A reverse proxy fronting the wrong vhost, a load-balancer health stub or a captive portal all do the same. What the operator got was a stack trace instead of "cannot reach the server".

## Changes

- **`pkg/api/client`**: `requireBody` turns a nil decode target into the new `ErrEmptyResponse`, and every method that decodes into a pointer returns through it. The guard sits at the seam the nine methods share rather than at `/info` alone — `AuthDevice` had the identical hazard, and `Authorize` dereferences its response on the very next lines. `ListDevices` is untouched: a slice result cannot nil-deref.
- **`agent/pkg/agentd`**: `probeServerInfo` checks the error before it stores, instead of storing first and returning the error unwrapped.
- **`gateway`**: a fallback site answers 404 for a Host the proxy does not serve, so a misdirected agent gets an unambiguous signal.
- **`gateway`**: an explicit `http://<domain>` redirect when TLS is on. The fallback matches every name, which shadows automatic HTTPS's blanket redirect — and a deployment serving `SHELLHUB_TLS_CERT_FILE` manages no certificate for its domain, so that blanket rule was the only redirect it had. Without this block, `http://<domain>` would answer 404 instead of redirecting.

## Testing

The fallback's ordering is the part worth probing. It matches every Host, so anything after it is unreachable; `TestTheFallbackIsTheLastRouteOnPortEighty` asserts that on the adapted JSON across every configuration shape, because the template cannot show it. `TestMain_smoke` now sends an unserved Host to the real binary and expects 404.

Checked by hand against a running Caddy in four shapes — supplied certificate, automatic SSL, plain HTTP, and web endpoints on an internal certificate. In each: the site redirects (308) or proxies, a tunnel subdomain redirects, `healthcheck.internal` answers 200, and an unknown Host gets 404. The supplied-certificate shape is the one that regressed on the fallback alone, and the one to re-check if the redirect block is ever touched.

Thanks to @Edu0x01, who reported the crash and its trigger.
