### PR TITLE
fix(server): validate the filter and sort fields the list endpoints accept

### DIFF
--- a/openapi/spec/paths/api@namespaces@api-key.yaml
+++ b/openapi/spec/paths/api@namespaces@api-key.yaml
@@ -55,7 +55,9 @@ get:
       required: false
       in: query
     - name: sort_by
-      description: The property to sort of.
+      description: |
+        The property to sort by. Accepts `name`, `created_at`, `updated_at` and `expires_in`;
+        any other value is rejected with 400.
       schema:
         type: string
         example: name

--- a/openapi/spec/paths/api@namespaces@install-key.yaml
+++ b/openapi/spec/paths/api@namespaces@install-key.yaml
@@ -55,7 +55,9 @@ get:
       required: false
       in: query
     - name: sort_by
-      description: The property to sort of.
+      description: |
+        The property to sort by. Accepts `name`, `mode`, `type`, `used_times`, `last_used_at`,
+        `created_at`, `updated_at` and `expires_at`; any other value is rejected with 400.
       schema:
         type: string
         example: name

--- a/openapi/spec/paths/api@namespaces@install-key@{id}@history.yaml
+++ b/openapi/spec/paths/api@namespaces@install-key@{id}@history.yaml
@@ -31,7 +31,9 @@ get:
       required: false
       in: query
     - name: sort_by
-      description: The property to sort of.
+      description: |
+        The property to sort by. Accepts `hostname`, `source_ip`, `decided_status`, `decided_at`
+        and `created_at`; any other value is rejected with 400.
       schema:
         type: string
         example: created_at

--- a/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
@@ -17,6 +17,8 @@ get:
         Membership invitations filter.
 
         Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
+
+        Filterable fields are `status` and `role`, each with the `eq` and `ne` operators. Naming any other field is rejected with 400.
       schema:
         type: string
       required: false

--- a/openapi/spec/paths/api@users@invitations.yaml
+++ b/openapi/spec/paths/api@users@invitations.yaml
@@ -16,6 +16,8 @@ get:
         Membership invitations filter.
 
         Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
+
+        Filterable fields are `status` and `role`, each with the `eq` and `ne` operators. Naming any other field is rejected with 400.
       schema:
         type: string
       required: false

--- a/server/api/routes/api-key.go
+++ b/server/api/routes/api-key.go
@@ -4,8 +4,10 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/server/api/services"
 )
 
 // The API key routes, relative to the API's base path.
@@ -53,6 +55,10 @@ func (h *Handler) ListAPIKeys(c *gateway.Context) error {
 
 	if req.Sorter.Order == "" {
 		req.Sorter.Order = "desc"
+	}
+
+	if err := query.ValidateSorter(&req.Sorter, services.APIKeySortFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
 	}
 
 	if err := c.Validate(req); err != nil {

--- a/server/api/routes/install-key.go
+++ b/server/api/routes/install-key.go
@@ -4,9 +4,11 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/api/responses"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/server/api/services"
 )
 
 // The install key routes, relative to the API's base path.
@@ -58,6 +60,10 @@ func (h *Handler) ListInstallKeys(c *gateway.Context) error {
 
 	if req.Sorter.Order == "" {
 		req.Sorter.Order = "desc"
+	}
+
+	if err := query.ValidateSorter(&req.Sorter, services.InstallKeySortFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
 	}
 
 	if err := c.Validate(req); err != nil {
@@ -149,6 +155,10 @@ func (h *Handler) HistoryInstallKey(c *gateway.Context) error {
 
 	if req.Sorter.Order == "" {
 		req.Sorter.Order = "desc"
+	}
+
+	if err := query.ValidateSorter(&req.Sorter, services.InstallKeyEventSortFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
 	}
 
 	if err := c.Validate(req); err != nil {

--- a/server/api/routes/invitation.go
+++ b/server/api/routes/invitation.go
@@ -4,8 +4,10 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/server/api/services"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -124,6 +126,14 @@ func (h *Handler) GetUserMembershipInvitationList(c *gateway.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
+	if err := query.ValidateFilters(&req.Filters, services.MembershipInvitationFilterFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	if err := query.ValidateSorter(&req.Sorter, services.MembershipInvitationSortFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
+
 	if err := c.Validate(req); err != nil {
 		return err
 	}
@@ -152,6 +162,14 @@ func (h *Handler) GetNamespaceMembershipInvitationList(c *gateway.Context) error
 	if err := req.Filters.Unmarshal(); err != nil {
 		log.WithError(err).WithField("filter", req.Filters.Raw).Warn("failed to decode namespace membership invitation list filter")
 
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	if err := query.ValidateFilters(&req.Filters, services.MembershipInvitationFilterFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	if err := query.ValidateSorter(&req.Sorter, services.MembershipInvitationSortFields); err != nil {
 		return c.NoContent(http.StatusBadRequest)
 	}
 

--- a/server/api/routes/list_query_rejection_test.go
+++ b/server/api/routes/list_query_rejection_test.go
@@ -1,0 +1,126 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	servicemock "github.com/shellhub-io/shellhub/server/api/services/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListEndpointsRejectAnUnapprovedFilterField(t *testing.T) {
+	cases := []struct {
+		description  string
+		path         string
+		filter       string
+		uncalledFunc string
+	}{
+		{
+			description:  "refuses to filter a user's invitations by the invite signature",
+			path:         "/api/users/invitations",
+			filter:       "sig",
+			uncalledFunc: "UserMembershipInvitationList",
+		},
+		{
+			description:  "refuses to filter a user's invitations by an unexposed column",
+			path:         "/api/users/invitations",
+			filter:       "invited_by",
+			uncalledFunc: "UserMembershipInvitationList",
+		},
+		{
+			description:  "refuses to filter a namespace's invitations by the invite signature",
+			path:         "/api/namespaces/00000000-0000-4000-0000-000000000000/invitations",
+			filter:       "sig",
+			uncalledFunc: "NamespaceMembershipInvitationList",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := servicemock.NewMockService(t)
+
+			values := url.Values{}
+			values.Set("filter", encodeFilter(t, []query.Filter{
+				{
+					Type:   query.FilterTypeProperty,
+					Params: &query.FilterProperty{Name: tc.filter, Operator: "contains", Value: "A"},
+				},
+			}))
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.path+"?"+values.Encode(), nil)
+			req.Header.Set("X-ID", "000000000000000000000000")
+			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+			req.Header.Set("X-Role", "owner")
+
+			rec := httptest.NewRecorder()
+			NewRouter(svcMock).ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+			svcMock.AssertNotCalled(t, tc.uncalledFunc)
+		})
+	}
+}
+
+func TestListEndpointsRejectAnUnapprovedSortField(t *testing.T) {
+	cases := []struct {
+		description  string
+		path         string
+		sortBy       string
+		uncalledFunc string
+	}{
+		{
+			description:  "refuses to order install keys by the webhook signing secret",
+			path:         "/api/namespaces/install-key",
+			sortBy:       "webhook_secret",
+			uncalledFunc: "ListInstallKeys",
+		},
+		{
+			description:  "refuses to order install keys by the key ciphertext",
+			path:         "/api/namespaces/install-key",
+			sortBy:       "key_encrypted",
+			uncalledFunc: "ListInstallKeys",
+		},
+		{
+			description:  "refuses to order install key history by an unexposed column",
+			path:         "/api/namespaces/install-key/abc/history",
+			sortBy:       "public_key",
+			uncalledFunc: "ListInstallKeyEvents",
+		},
+		{
+			description:  "refuses to order API keys by the key digest",
+			path:         "/api/namespaces/api-key",
+			sortBy:       "key_digest",
+			uncalledFunc: "ListAPIKeys",
+		},
+		{
+			description:  "refuses to order a user's invitations by the invite signature",
+			path:         "/api/users/invitations",
+			sortBy:       "sig",
+			uncalledFunc: "UserMembershipInvitationList",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := servicemock.NewMockService(t)
+
+			values := url.Values{}
+			values.Set("sort_by", tc.sortBy)
+			values.Set("order_by", "asc")
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tc.path+"?"+values.Encode(), nil)
+			req.Header.Set("X-ID", "000000000000000000000000")
+			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+			req.Header.Set("X-Role", "owner")
+
+			rec := httptest.NewRecorder()
+			NewRouter(svcMock).ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+			svcMock.AssertNotCalled(t, tc.uncalledFunc)
+		})
+	}
+}

--- a/server/api/routes/list_validation_test.go
+++ b/server/api/routes/list_validation_test.go
@@ -1,0 +1,171 @@
+package routes
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const requestsPkgDir = "../../../pkg/api/requests"
+
+type queryEmbeds struct {
+	filters bool
+	sorter  bool
+}
+
+func parsePackage(t *testing.T, dir string) []*ast.File {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	files := make([]*ast.File, 0, len(entries))
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		require.NoError(t, err)
+
+		files = append(files, file)
+	}
+
+	return files
+}
+
+func selectorPath(expr ast.Expr) string {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+
+	return pkg.Name + "." + sel.Sel.Name
+}
+
+func embeddedQueryTypes(t *testing.T) map[string]queryEmbeds {
+	t.Helper()
+
+	embeds := make(map[string]queryEmbeds)
+
+	for _, file := range parsePackage(t, requestsPkgDir) {
+		ast.Inspect(file, func(n ast.Node) bool {
+			spec, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+
+			structType, ok := spec.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+
+			var found queryEmbeds
+			for _, field := range structType.Fields.List {
+				if len(field.Names) > 0 {
+					continue
+				}
+
+				switch selectorPath(field.Type) {
+				case "query.Filters":
+					found.filters = true
+				case "query.Sorter":
+					found.sorter = true
+				}
+			}
+
+			if found.filters || found.sorter {
+				embeds[spec.Name.Name] = found
+			}
+
+			return true
+		})
+	}
+
+	return embeds
+}
+
+func isHandler(fn *ast.FuncDecl) bool {
+	if fn.Recv == nil || fn.Body == nil {
+		return false
+	}
+
+	for _, param := range fn.Type.Params.List {
+		if star, ok := param.Type.(*ast.StarExpr); ok && selectorPath(star.X) == "gateway.Context" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func handlerQueryUsage(fn *ast.FuncDecl, embeds map[string]queryEmbeds) (queryEmbeds, map[string]bool) {
+	var needs queryEmbeds
+	calls := make(map[string]bool)
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			if pkg, ok := node.X.(*ast.Ident); ok && pkg.Name == "requests" {
+				if e, ok := embeds[node.Sel.Name]; ok {
+					needs.filters = needs.filters || e.filters
+					needs.sorter = needs.sorter || e.sorter
+				}
+			}
+		case *ast.CallExpr:
+			if path := selectorPath(node.Fun); path != "" {
+				calls[path] = true
+			}
+		}
+
+		return true
+	})
+
+	return needs, calls
+}
+
+func TestListHandlersValidateEveryQueryFieldTheyAccept(t *testing.T) {
+	embeds := embeddedQueryTypes(t)
+	require.NotEmpty(t, embeds)
+
+	for _, file := range parsePackage(t, ".") {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || !isHandler(fn) {
+				continue
+			}
+
+			needs, calls := handlerQueryUsage(fn, embeds)
+
+			if needs.filters && !calls["query.ValidateFilters"] {
+				t.Errorf(
+					"%s binds a request carrying a client filter but never calls query.ValidateFilters: "+
+						"the filter then names any column on the table, including ones the response omits",
+					fn.Name.Name,
+				)
+			}
+
+			if needs.sorter && !calls["query.ValidateSorter"] {
+				t.Errorf(
+					"%s binds a request carrying a client sort_by but never calls query.ValidateSorter: "+
+						"the sort then orders by any column on the table, including ones the response omits",
+					fn.Name.Name,
+				)
+			}
+		}
+	}
+}

--- a/server/api/services/api-key.go
+++ b/server/api/services/api-key.go
@@ -6,12 +6,23 @@ import (
 	"encoding/hex"
 	"errors"
 
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/api/responses"
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/uuid"
 	"github.com/shellhub-io/shellhub/server/api/store"
+)
+
+// APIKeySortFields is the set of field names accepted in the sort_by query parameter when listing
+// API keys. The row also holds the key's digest, which the response omits and a sort must not
+// order by.
+var APIKeySortFields = query.NewFieldSet(
+	"name",
+	"created_at",
+	"updated_at",
+	"expires_in",
 )
 
 // APIKeyService manages the keys that authenticate a namespace rather than a person. A key's

--- a/server/api/services/install-key.go
+++ b/server/api/services/install-key.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/shellhub-io/shellhub/pkg/api/jwttoken"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/api/responses"
 	"github.com/shellhub-io/shellhub/pkg/clock"
@@ -25,6 +26,30 @@ import (
 
 const (
 	installKeyMaxEphemeralTimeout = 10
+)
+
+// InstallKeySortFields is the set of field names accepted in the sort_by query parameter when
+// listing install keys. The row also holds the key ciphertext and the webhook signing secret,
+// neither of which the response carries and neither of which a sort must order by.
+var InstallKeySortFields = query.NewFieldSet(
+	"name",
+	"mode",
+	"type",
+	"used_times",
+	"last_used_at",
+	"created_at",
+	"updated_at",
+	"expires_at",
+)
+
+// InstallKeyEventSortFields is the set of field names accepted in the sort_by query parameter
+// when listing an install key's history.
+var InstallKeyEventSortFields = query.NewFieldSet(
+	"hostname",
+	"source_ip",
+	"decided_status",
+	"decided_at",
+	"created_at",
 )
 
 func installKeyExpiry(days *int) *time.Time {

--- a/server/api/services/invitation.go
+++ b/server/api/services/invitation.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
 	"github.com/shellhub-io/shellhub/pkg/clock"
@@ -13,6 +14,24 @@ import (
 	"github.com/shellhub-io/shellhub/server/api/pkg/responses"
 	"github.com/shellhub-io/shellhub/server/api/store"
 	log "github.com/sirupsen/logrus"
+)
+
+// MembershipInvitationFilterFields maps each filter field the invitation list endpoints accept to
+// the set of operators valid for it. It names only fields the response already carries: the row
+// also holds the invitation's signature, which the response omits and a filter must not reach.
+var MembershipInvitationFilterFields = query.NewFieldConstraints(map[string][]string{
+	"status": {"eq", "ne"},
+	"role":   {"eq", "ne"},
+})
+
+// MembershipInvitationSortFields is the set of field names accepted in the sort_by query
+// parameter when listing invitations.
+var MembershipInvitationSortFields = query.NewFieldSet(
+	"status",
+	"role",
+	"created_at",
+	"updated_at",
+	"expires_at",
 )
 
 // InvitationService owns membership invitations, from issuing an invite code through to the

--- a/server/api/store/pg/query-options.go
+++ b/server/api/store/pg/query-options.go
@@ -3,7 +3,6 @@ package pg
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
@@ -39,6 +38,14 @@ func (*queryOptions) Paginate(page *query.Paginator) store.QueryOption {
 	}
 }
 
+func sortDirection(order string) bun.Safe {
+	if order == query.OrderAsc {
+		return bun.Safe("ASC")
+	}
+
+	return bun.Safe("DESC")
+}
+
 func (*queryOptions) Sort(sorter *query.Sorter) store.QueryOption {
 	return func(ctx context.Context) error {
 		if sorter.By == "" {
@@ -58,10 +65,12 @@ func (*queryOptions) Sort(sorter *query.Sorter) store.QueryOption {
 			return bun.Ident(col)
 		}
 
+		direction := sortDirection(sorter.Order)
+
 		if sorter.Tiebreak != "" {
-			wrapper.query = wrapper.query.OrderExpr("? ?, ? DESC", qualifyCol(sorter.By), bun.Safe(strings.ToUpper(sorter.Order)), qualifyCol(sorter.Tiebreak))
+			wrapper.query = wrapper.query.OrderExpr("? ?, ? DESC", qualifyCol(sorter.By), direction, qualifyCol(sorter.Tiebreak))
 		} else {
-			wrapper.query = wrapper.query.OrderExpr("? ?", qualifyCol(sorter.By), bun.Safe(strings.ToUpper(sorter.Order)))
+			wrapper.query = wrapper.query.OrderExpr("? ?", qualifyCol(sorter.By), direction)
 		}
 
 		return nil


### PR DESCRIPTION
## What

Every list endpoint that accepts a `filter` or `sort_by` now validates the field name against an
allowlist before it reaches the query builder. Five handlers did not, so a client-supplied name
bound to any column on the underlying table — including columns the response deliberately omits.

## Why

Reported as GHSA-cc2j-gp8q-jq4m by @Edu0x01. Every filterable handler paired `Unmarshal()` with
`ValidateFilters()` except the two invitation handlers, and only two of the five handlers taking
`sort_by` called `ValidateSorter()`.

Two consequences are worth naming:

- A filter on `sig` turned `GET /api/users/invitations` into a boolean oracle over the invitation
  signature. The reporter recovered a 12-character code in 229 requests against a live stack.
- `sort_by=webhook_secret` on the install key list is a lexicographic oracle over the plaintext
  HMAC signing secret, which is `json:"-"` and has no reveal endpoint.

**This is a bug fix, not a security advisory, and the advisory is being closed as Informative.**
Neither case crosses a privilege boundary. The invitation belongs to the caller, and `AcceptInvite`
takes no signature — it resolves by tenant and the caller's own user ID — so the recovered `sig`
grants nothing. Every role holding `InstallKeyList` also holds `InstallKeyCreate` and
`InstallKeyUpdate`, so the webhook secret it can read is one it can already set. What is fixed here
is a field the API declines to return becoming readable by someone who already has authority over
it.

Two of the reporter's negatives were confirmed and are worth recording, because they bound the
blast radius: there is no SQL injection (the field is passed as a `bun.Ident`), and the oracle does
not cross users. The second is structural rather than incidental — `Match` wraps every filter in
`WhereGroup(" AND ", …)`, so an `or` node cannot unpin the `user_id` guard.

## Changes

- **routes**: `ValidateFilters` + `ValidateSorter` on both invitation handlers; `ValidateSorter` on
  `ListAPIKeys`, `ListInstallKeys` and `HistoryInstallKey`.
- **services**: allowlists (`MembershipInvitationFilterFields`, `APIKeySortFields`,
  `InstallKeySortFields`, …) naming only fields the matching response already carries, so admitting
  a new filterable field is a deliberate act rather than a side effect of a column existing.
- **store/pg**: `bun.Safe(strings.ToUpper(sorter.Order))` replaced by a switch yielding the
  constant. The `oneof=asc desc` tag already rejected a hostile `order_by`, but it was one tag on a
  field three handlers never `Normalize`, guarding an unescaped interpolation two packages away.
- **tests**: `TestListHandlersValidateEveryQueryFieldTheyAccept` walks the routes package AST and
  fails any handler that binds a request embedding `query.Filters` or `query.Sorter` without
  calling the matching validator.
- **openapi**: documented the accepted values in the parameter descriptions rather than as an
  `enum`, which would have changed the generated client's types.

## Testing

The AST guard is the part worth a second look. It replaces the reporter's suggestion of a runtime
check that refuses an unapproved filter at the point of use. That version was tried and rejected:
`task.go` and `session.go` build filters and sorters internally and legitimately never validate, as
does the whole `storetest` suite, so failing closed there breaks correct callers. A build-time check
has no runtime blast radius. To confirm it bites, delete any one of the `Validate*` calls this PR
adds and run `go test ./api/routes/` — it names the handler and fails.

Postgres store suites were run against real containers so the sort-direction change is exercised,
not just compiled. `golangci-lint v2.11.3` is clean. Four pre-existing prettier warnings under
`openapi/spec/components/schemas/` are untouched by this branch and also fail on `master`.

A companion PR fixes the same missing pairing in `shellhub-io/cloud`, which the advisory did not
cover.
