### PR TITLE
docs: answer 404 for a page that is not there

### DIFF
--- a/ui/apps/docs/src/data/sidebar.ts
+++ b/ui/apps/docs/src/data/sidebar.ts
@@ -40,7 +40,11 @@ export interface SidebarSection {
  * superseded pages stay on disk and are retired from navigation here instead. Their content lives
  * on, reorganized, under the journey-shaped tree the sidebar actually exposes.
  */
-export const PAGES_NOT_IN_NAV: string[] = ["/"];
+export const PAGES_NOT_IN_NAV: string[] = [
+  "/",
+  // Served when nothing matches, so it is reached by mistake rather than by navigation.
+  "/404",
+];
 
 /**
  * Flattens a nested item tree to the entries that actually resolve to a page, dropping the group

--- a/ui/apps/docs/src/pages/404.astro
+++ b/ui/apps/docs/src/pages/404.astro
@@ -1,0 +1,17 @@
+---
+import DocsLayout from "../layouts/DocsLayout.astro";
+---
+<DocsLayout title="Page not found" description="That page is not here.">
+  <h1>Page not found</h1>
+
+  <p>
+    Whatever was at this address is not here. The documentation was reorganized, so a link from an
+    older page or an old bookmark can land nowhere.
+  </p>
+
+  <p>
+    Press <kbd>Ctrl</kbd> <kbd>K</kbd> to search, or start from
+    <a href="/introduction">Introduction</a>, <a href="/get-started">Onboarding Guide</a> or
+    <a href="/help/troubleshooting">Troubleshooting</a>.
+  </p>
+</DocsLayout>


### PR DESCRIPTION
The site ships no 404 page, so the host falls back to the home page. A mistyped address, a link from the documentation this one replaced, or a page since retired all answer 200 with the front page: the reader is told nothing went wrong and left to work out why the page looks unrelated, and a crawler records the home page under a second address.

There is a page now, in the documentation's own layout, saying what happened and offering the search and three places to start.