### PR TITLE
docs: stop a portrait screenshot taking the whole page

### DIFF
--- a/ui/apps/docs/src/components/Shot.astro
+++ b/ui/apps/docs/src/components/Shot.astro
@@ -60,9 +60,14 @@ const label = alt ?? id;
     outline-offset: 2px;
   }
 
+  /* Same ceiling the prose puts on an image: a tall screenshot should not cost a screenful. */
   .shot-frame img {
     display: block;
-    width: 100%;
+    max-width: 100%;
+    max-height: 30rem;
+    width: auto;
+    height: auto;
+    margin-inline: auto;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/ui/apps/docs/src/styles/global.css
+++ b/ui/apps/docs/src/styles/global.css
@@ -624,6 +624,14 @@ html {
    own frame, so its image is excluded rather than framed twice. */
 .prose img:not([data-shot-zoom] img) {
   display: block;
+  /* A portrait screenshot at column width is a screenful of dialog. Cap the height and let the
+     width follow, so every picture takes about as much of the page as it is worth; clicking one
+     still opens it at full size. */
+  max-width: 100%;
+  max-height: 30rem;
+  width: auto;
+  height: auto;
+  margin-inline: auto;
   background: rgb(var(--c-surface));
   border: 1px solid rgb(var(--c-border));
   border-radius: 0.5rem;


### PR DESCRIPTION
An image in the prose was given the column's width, which is right for a screenshot of a table and wrong for a tall one. The MFA dialogs are phone-shaped panels, so they rendered near a thousand pixels high to show a small dialog, and the reader scrolled through a screenful of picture to get to the next sentence.

The cap is on height now, with width following in proportion and the image centred, so a picture takes about as much of the page as it is worth: the device list still fills the column, the MFA dialogs come down from 696x996 to 336x480. Clicking one still opens it at full size, which is where somebody goes to read the detail.

The same ceiling applies inside a `<Shot>`, so a captured screenshot that happens to be tall behaves the same way.