### PR TITLE
fix(server): match access rule patterns against the whole value

### DIFF
--- a/pkg/models/pattern.go
+++ b/pkg/models/pattern.go
@@ -1,0 +1,19 @@
+package models
+
+import "regexp"
+
+// MatchPattern reports whether value satisfies an access rule's pattern. The pattern is a regular
+// expression that must match value in full, so the rule "staging" selects the device named
+// "staging" and neither "notstaging" nor "staging-db"; an empty pattern imposes no restriction and
+// matches any value. It returns an error when the pattern does not compile.
+//
+// It is the shared matcher for every administrator-written selector that decides access — device
+// filters, public-key username restrictions and firewall rules — so that all of them read the way
+// their author wrote them.
+func MatchPattern(pattern, value string) (bool, error) {
+	if pattern == "" {
+		return true, nil
+	}
+
+	return regexp.MatchString(`\A(?:`+pattern+`)\z`, value)
+}

--- a/pkg/models/pattern_test.go
+++ b/pkg/models/pattern_test.go
@@ -1,0 +1,105 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchPattern(t *testing.T) {
+	cases := []struct {
+		description   string
+		pattern       string
+		value         string
+		expectedMatch bool
+		expectedErr   bool
+	}{
+		{
+			description:   "an empty pattern imposes no restriction",
+			pattern:       "",
+			value:         "anything",
+			expectedMatch: true,
+		},
+		{
+			description:   "a literal pattern matches the whole value",
+			pattern:       "staging",
+			value:         "staging",
+			expectedMatch: true,
+		},
+		{
+			description:   "a literal pattern does not match a value that only contains it",
+			pattern:       "staging",
+			value:         "notstaging",
+			expectedMatch: false,
+		},
+		{
+			description:   "a literal pattern does not match a value it only prefixes",
+			pattern:       "staging",
+			value:         "staging-db",
+			expectedMatch: false,
+		},
+		{
+			description:   "a literal pattern does not match a value it sits inside",
+			pattern:       "staging",
+			value:         "prod-staging-mirror",
+			expectedMatch: false,
+		},
+		{
+			description:   "an alternation is anchored as a whole, not only its first branch",
+			pattern:       "web|db",
+			value:         "notdb",
+			expectedMatch: false,
+		},
+		{
+			description:   "an alternation still matches each of its branches in full",
+			pattern:       "web|db",
+			value:         "db",
+			expectedMatch: true,
+		},
+		{
+			description:   "a wildcard pattern still matches every value",
+			pattern:       ".*",
+			value:         "web-01",
+			expectedMatch: true,
+		},
+		{
+			description:   "a pattern the author already anchored keeps its meaning",
+			pattern:       "^web-[0-9]+$",
+			value:         "web-01",
+			expectedMatch: true,
+		},
+		{
+			description:   "a multiline anchor cannot match one line of a multiline value",
+			pattern:       "(?m)^root$",
+			value:         "root\nevil",
+			expectedMatch: false,
+		},
+		{
+			description:   "an inline flag group keeps applying to the pattern",
+			pattern:       "(?i)web-01",
+			value:         "WEB-01",
+			expectedMatch: true,
+		},
+		{
+			description:   "a pattern that does not compile returns an error",
+			pattern:       "[",
+			value:         "web-01",
+			expectedMatch: false,
+			expectedErr:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			matched, err := MatchPattern(tc.pattern, tc.value)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedMatch, matched)
+		})
+	}
+}

--- a/pkg/models/publickey.go
+++ b/pkg/models/publickey.go
@@ -11,16 +11,17 @@ import (
 // PublicKeyFilter contains the filter rule of a Public Key.
 //
 // A PublicKeyFilter can contain either Hostname, string, or Tags, slice of strings never both.
+// Hostname is a regexp matched against the whole device name; see MatchPattern.
 type PublicKeyFilter struct {
 	Hostname string `json:"hostname,omitempty" validate:"required_without=Tags,excluded_with=Tags,regexp"`
 	Taggable `json:",inline"`
 }
 
 // Matches reports whether the given device satisfies the filter. A filter is
-// either a hostname regexp matched against the device name, or a tag set matched
-// by intersection against the device's tag ids; an empty filter matches every
-// device. It is the shared device-selector matcher used by both the public-key
-// ACL and Access Policies.
+// either a hostname pattern matched against the whole device name (see
+// MatchPattern), or a tag set matched by intersection against the device's tag
+// ids; an empty filter matches every device. It is the shared device-selector
+// matcher used by both the public-key ACL and Access Policies.
 //
 // The device must already carry its tag ids (Taggable.TagIDs) for the tag
 // branch; callers resolving a device from an agent-sent payload must populate
@@ -28,7 +29,7 @@ type PublicKeyFilter struct {
 func (f PublicKeyFilter) Matches(device *Device) (bool, error) {
 	switch {
 	case f.Hostname != "":
-		return regexp.MatchString(f.Hostname, device.Name)
+		return MatchPattern(f.Hostname, device.Name)
 	case len(f.TagIDs) > 0:
 		for _, tagID := range f.TagIDs {
 			if slices.Contains(device.TagIDs, tagID) {
@@ -53,7 +54,7 @@ type PublicKeyFields struct {
 
 // Validate checks the fields, including that Username and the filter's Hostname compile as regular
 // expressions — they are patterns, not literals, and an uncompilable one would silently match
-// nothing.
+// nothing. It does not require them to be anchored: MatchPattern anchors them at match time.
 func (p *PublicKeyFields) Validate() error {
 	v := validator.New()
 

--- a/pkg/models/publickey_test.go
+++ b/pkg/models/publickey_test.go
@@ -34,6 +34,24 @@ func TestPublicKeyFilterMatches(t *testing.T) {
 			expectedMatch: false,
 		},
 		{
+			description:   "hostname regexp does not match a device name that merely contains it",
+			filter:        PublicKeyFilter{Hostname: "staging"},
+			device:        &Device{Name: "notstaging"},
+			expectedMatch: false,
+		},
+		{
+			description:   "hostname regexp does not match a device name it only prefixes",
+			filter:        PublicKeyFilter{Hostname: "staging"},
+			device:        &Device{Name: "staging-db"},
+			expectedMatch: false,
+		},
+		{
+			description:   "hostname regexp matches the device name it names in full",
+			filter:        PublicKeyFilter{Hostname: "staging"},
+			device:        &Device{Name: "staging"},
+			expectedMatch: true,
+		},
+		{
 			description:   "invalid hostname regexp returns an error",
 			filter:        PublicKeyFilter{Hostname: "["},
 			device:        &Device{Name: "web-01"},

--- a/server/api/services/access-policy_test.go
+++ b/server/api/services/access-policy_test.go
@@ -902,6 +902,71 @@ func TestNormalizeSourceIPs(t *testing.T) {
 	}
 }
 
+func TestPolicyAppliesDeviceFilter(t *testing.T) {
+	cases := []struct {
+		description string
+		hostname    string
+		deviceName  string
+		expected    bool
+	}{
+		{
+			description: "an allow policy applies to the device it names",
+			hostname:    "staging",
+			deviceName:  "staging",
+			expected:    true,
+		},
+		{
+			description: "an allow policy does not reach a device whose name merely contains the filter",
+			hostname:    "staging",
+			deviceName:  "notstaging",
+			expected:    false,
+		},
+		{
+			description: "an allow policy does not reach a device the filter only prefixes",
+			hostname:    "staging",
+			deviceName:  "staging-db",
+			expected:    false,
+		},
+		{
+			description: "an allow policy does not reach a device the filter sits inside",
+			hostname:    "staging",
+			deviceName:  "prod-staging-mirror",
+			expected:    false,
+		},
+		{
+			description: "a filter written as a regexp still selects the devices it describes",
+			hostname:    "staging-.*",
+			deviceName:  "staging-db",
+			expected:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			policy := models.AccessPolicy{
+				Name:    "policy",
+				Action:  models.PolicyActionAllow,
+				Subject: models.PolicySubject{Type: models.PolicySubjectAllMembers},
+				Filter:  models.PublicKeyFilter{Hostname: tc.hostname},
+				Logins:  []string{"*"},
+			}
+
+			applies, err := policyApplies(
+				policy,
+				&models.Device{UID: "uid", Name: tc.deviceName},
+				"user-id",
+				authorizer.RoleObserver,
+				models.UserTypeHuman,
+				"ubuntu",
+				"203.0.113.5",
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, applies)
+		})
+	}
+}
+
 func TestSubjectMatches(t *testing.T) {
 	const saID = "00000000-0000-0000-0000-00000000000a"
 

--- a/server/api/services/sshkeys.go
+++ b/server/api/services/sshkeys.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"regexp"
 
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
@@ -62,16 +61,7 @@ func (s *service) EvaluateKeyFilter(ctx context.Context, key *models.PublicKey, 
 }
 
 func (s *service) EvaluateKeyUsername(_ context.Context, key *models.PublicKey, username string) (bool, error) {
-	if key.Username == "" {
-		return true, nil
-	}
-
-	ok, err := regexp.MatchString(key.Username, username)
-	if err != nil {
-		return false, err
-	}
-
-	return ok, nil
+	return models.MatchPattern(key.Username, username)
 }
 
 func (s *service) GetPublicKey(ctx context.Context, fingerprint, tenant string) (*models.PublicKey, error) {

--- a/server/api/services/sshkeys_test.go
+++ b/server/api/services/sshkeys_test.go
@@ -16,6 +16,7 @@ import (
 	storemock "github.com/shellhub-io/shellhub/server/api/store/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -173,6 +174,73 @@ func TestEvaluateKeyFilter(t *testing.T) {
 	}
 
 	storeMock.AssertExpectations(t)
+}
+
+func TestEvaluateKeyUsername(t *testing.T) {
+	ctx := context.TODO()
+
+	cases := []struct {
+		description string
+		username    string
+		login       string
+		expected    bool
+	}{
+		{
+			description: "an unrestricted key authorizes any login",
+			username:    "",
+			login:       "root",
+			expected:    true,
+		},
+		{
+			description: "a restricted key authorizes the login it names",
+			username:    "root",
+			login:       "root",
+			expected:    true,
+		},
+		{
+			description: "a restricted key refuses a login that merely contains its rule",
+			username:    "root",
+			login:       "notroot",
+			expected:    false,
+		},
+		{
+			description: "a restricted key refuses a login its rule only prefixes",
+			username:    "deploy",
+			login:       "deployer",
+			expected:    false,
+		},
+		{
+			description: "a restricted key refuses a login trailing past its rule",
+			username:    "root",
+			login:       "root\nevil",
+			expected:    false,
+		},
+		{
+			description: "a rule listing alternatives authorizes each of them in full",
+			username:    "root|admin",
+			login:       "admin",
+			expected:    true,
+		},
+		{
+			description: "a rule listing alternatives refuses a login extending one of them",
+			username:    "root|admin",
+			login:       "administrator",
+			expected:    false,
+		},
+	}
+
+	storeMock := storemock.NewMockStore(t)
+	service := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache())
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			key := &models.PublicKey{PublicKeyFields: models.PublicKeyFields{Username: tc.username}}
+
+			ok, err := service.EvaluateKeyUsername(ctx, key, tc.login)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, ok)
+		})
+	}
 }
 
 func TestListPublicKeys(t *testing.T) {


### PR DESCRIPTION
The public-key device filter, the public-key username restriction and the Access Policy device
filter all selected with `regexp.MatchString(pattern, value)`, which succeeds on any substring. A
filter written as `staging` reached `notstaging`, `staging-db` and `prod-staging-mirror`; a key
restricted to `root` also authorized the login `notroot`.

These fields are regexps and are documented as regexps, so this was the semantics they carried
rather than a break in them. It is still the wrong default for a field that decides access: the
operator types a hostname and gets a substring rule, and the surprise runs in the permissive
direction. Within a single policy the inconsistency is visible — `logins: ["ubuntu"]` refused
`ubuntu2` while `filter.hostname: "staging"` accepted `notstaging`.

## What changes

`models.MatchPattern` wraps the pattern as `\A(?:pattern)\z` and every matcher goes through it:

- `PublicKeyFilter.Matches` — the device selector shared by the public-key ACL and Access Policies
- `EvaluateKeyUsername` — the public-key username restriction

The non-capturing group is load-bearing: anchoring `a|b` without it yields `\Aa|b\z`, which means
something else. `\A`/`\z` rather than `^`/`$` so a `(?m)` pattern cannot pass one line of a
multiline value off as a whole match.

An empty pattern still matches anything, and `.*` — the value the console stores for "all devices"
— still matches every name.

## Breaking change

This narrows every stored pattern that relied on substring reach. A filter written as `staging` now
selects only the device named `staging`; an operator who depended on the wider reach needs
`staging.*` or a tag filter. It wants a release note.

## Notes

Cloud carries the same matcher in its firewall rule evaluator; shellhub-io/cloud#2530 moves those
three call sites onto `MatchPattern` and is blocked on this landing.

Documentation and console copy are updated separately, in the companion PR, so the wording change
can be read on its own.

Reported by Eduardo Barbosa (@Edu0x01).