### PR TITLE
feat(server): instance-admin-scoped API keys for the /admin/api surface

### DIFF
--- a/openapi/spec/cloud-openapi.yaml
+++ b/openapi/spec/cloud-openapi.yaml
@@ -60,6 +60,15 @@ tags:
     description: Routes related to announcements resource
   - name: mfa
     description: Routes related to MFA
+  - name: instance-api-keys
+    description: |
+      An instance API key authenticates as an instance administrator rather than as a member of a
+      namespace. It carries no namespace and no role, is accepted only under `/admin/api`, and its
+      plaintext is prefixed with `sh_admin_`.
+
+      A key always expires, and it stops working as soon as the administrator who created it is no
+      longer an instance administrator. Instance API key routes cannot themselves be authenticated
+      with an API key.
   - name: api-keys
     description: |
       An API key is a unique identifier used to access protected endpoints. It
@@ -185,6 +194,10 @@ paths:
     $ref: paths/admin@api@stats.yaml
   /admin/api/license:
     $ref: paths/admin@api@license.yaml
+  /admin/api/instance-api-keys:
+    $ref: paths/admin@api@instance-api-keys.yaml
+  /admin/api/instance-api-keys/{name}:
+    $ref: paths/admin@api@instance-api-keys@{name}.yaml
   /admin/api/auth/token/{id}:
     $ref: paths/admin@api@auth@token@{id}.yaml
   /admin/api/export/namespaces:

--- a/openapi/spec/components/schemas/instanceAPIKey.yaml
+++ b/openapi/spec/components/schemas/instanceAPIKey.yaml
@@ -1,0 +1,38 @@
+type: object
+properties:
+  name:
+    type: string
+    description: |
+      The name of the instance API key. This serves as an "external ID" since the plaintext key is
+      never returned after creation. It is unique across the instance.
+    example: billing-export
+  created_by:
+    description: |
+      The ID of the instance administrator who created the key. The key stops authenticating when
+      that user is no longer an instance administrator.
+    type: string
+    format: uuid
+    example: 3dd0d1f8-8246-4519-b11a-a3dd33717f65
+  created_at:
+    type: string
+    description: The UTC date when the key was created.
+    format: date-time
+    example: '2026-05-01T00:00:00Z'
+  updated_at:
+    type: string
+    description: The UTC date when the key was last updated.
+    format: date-time
+    example: '2026-05-01T00:00:00Z'
+  expires_at:
+    type: string
+    description: |
+      The UTC date when the key expires. Always set: an instance API key cannot be created without
+      an expiration date.
+    format: date-time
+    example: '2026-05-31T00:00:00Z'
+required:
+  - name
+  - created_by
+  - created_at
+  - updated_at
+  - expires_at

--- a/openapi/spec/components/schemas/instanceAPIKeyCreated.yaml
+++ b/openapi/spec/components/schemas/instanceAPIKeyCreated.yaml
@@ -1,0 +1,12 @@
+allOf:
+  - type: object
+    properties:
+      id:
+        type: string
+        description: |
+          The plaintext key, prefixed with `sh_admin_`. It is returned here and nowhere else: the
+          server stores only its digest, so a key that is lost must be revoked and replaced.
+        example: sh_admin_cdfd3cb0-c44e-4e54-b931-6d57713ad159
+    required:
+      - id
+  - $ref: ./instanceAPIKey.yaml

--- a/openapi/spec/components/schemas/security.yaml
+++ b/openapi/spec/components/schemas/security.yaml
@@ -8,6 +8,21 @@ api-key:
   in: header
   name: X-API-KEY
   description: |
-    Send your API key in the `X-API-KEY` header. An API key belongs to a single
-    namespace and is not tied to a user. Create one in the ShellHub console under
-    **Namespace → API Keys**.
+    Send your API key in the `X-API-KEY` header. A namespace API key belongs to a
+    single namespace and is not tied to a user, and is never accepted on the admin
+    surface. Create one in the ShellHub console under **Namespace → API Keys**.
+
+    For automating the admin surface, see `instance-api-key` instead.
+instance-api-key:
+  type: apiKey
+  in: header
+  name: X-API-KEY
+  description: |
+    Send your instance API key in the `X-API-KEY` header. An instance API key
+    authenticates as an instance administrator, carries no namespace and no role,
+    and is accepted only under `/admin/api`. Its plaintext is prefixed with
+    `sh_admin_`.
+
+    A key stops working when it expires or when the administrator who created it
+    is no longer an instance administrator. Create one in the admin panel under
+    **Instance API Keys**.

--- a/openapi/spec/enterprise-openapi.yaml
+++ b/openapi/spec/enterprise-openapi.yaml
@@ -62,6 +62,15 @@ tags:
     description: Routes provide by ShellHub Admin API.
   - name: license
     description: Routes related to license resource.
+  - name: instance-api-keys
+    description: |
+      An instance API key authenticates as an instance administrator rather than as a member of a
+      namespace. It carries no namespace and no role, is accepted only under `/admin/api`, and its
+      plaintext is prefixed with `sh_admin_`.
+
+      A key always expires, and it stops working as soon as the administrator who created it is no
+      longer an instance administrator. Instance API key routes cannot themselves be authenticated
+      with an API key.
   - name: api-keys
     description: |
       An API key is a unique identifier used to access protected endpoints. It
@@ -158,6 +167,10 @@ paths:
     $ref: paths/admin@api@stats.yaml
   /admin/api/license:
     $ref: paths/admin@api@license.yaml
+  /admin/api/instance-api-keys:
+    $ref: paths/admin@api@instance-api-keys.yaml
+  /admin/api/instance-api-keys/{name}:
+    $ref: paths/admin@api@instance-api-keys@{name}.yaml
   /admin/api/auth/token/{id}:
     $ref: paths/admin@api@auth@token@{id}.yaml
   /admin/api/export/namespaces:

--- a/openapi/spec/openapi.yaml
+++ b/openapi/spec/openapi.yaml
@@ -29,6 +29,14 @@ components:
       description: |
         An API key is an alternative to the standard JWT authentication.
         Authentication with this method is namespace-related and is not tied to any user.
+    instance-api-key:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+      description: |
+        An instance API key authenticates as an instance administrator. It carries no namespace
+        and no role, is accepted only under `/admin/api`, and its plaintext is prefixed with
+        `sh_admin_`.
 tags:
   - name: internal
     description: Requests executed internally by ShellHub server.
@@ -54,6 +62,15 @@ tags:
     description: Routes related to enrolled SSH key identities (identity access mode).
   - name: service-accounts
     description: Routes related to service accounts (non-human SSH principals).
+  - name: instance-api-keys
+    description: |
+      An instance API key authenticates as an instance administrator rather than as a member of a
+      namespace. It carries no namespace and no role, is accepted only under `/admin/api`, and its
+      plaintext is prefixed with `sh_admin_`.
+
+      A key always expires, and it stops working as soon as the administrator who created it is no
+      longer an instance administrator. Instance API key routes cannot themselves be authenticated
+      with an API key.
   - name: api-keys
     description: |
       An API key is a unique identifier used to access protected endpoints. It
@@ -366,6 +383,10 @@ paths:
     $ref: paths/admin@api@stats.yaml
   /admin/api/license:
     $ref: paths/admin@api@license.yaml
+  /admin/api/instance-api-keys:
+    $ref: paths/admin@api@instance-api-keys.yaml
+  /admin/api/instance-api-keys/{name}:
+    $ref: paths/admin@api@instance-api-keys@{name}.yaml
   /admin/api/auth/token/{id}:
     $ref: paths/admin@api@auth@token@{id}.yaml
   /admin/api/export/namespaces:

--- a/openapi/spec/paths/admin@api@announcements.yaml
+++ b/openapi/spec/paths/admin@api@announcements.yaml
@@ -8,7 +8,7 @@ get:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/query/pageQuery.yaml
     - $ref: ../components/parameters/query/perPageQuery.yaml
@@ -49,7 +49,7 @@ post:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:

--- a/openapi/spec/paths/admin@api@announcements@{uuid}.yaml
+++ b/openapi/spec/paths/admin@api@announcements@{uuid}.yaml
@@ -8,7 +8,7 @@ get:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/path/announcementUUID.yaml
   responses:
@@ -32,7 +32,7 @@ put:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/path/announcementUUID.yaml
   requestBody:
@@ -66,7 +66,7 @@ delete:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/path/announcementUUID.yaml
   responses:

--- a/openapi/spec/paths/admin@api@auth@token@{id}.yaml
+++ b/openapi/spec/paths/admin@api@auth@token@{id}.yaml
@@ -8,7 +8,7 @@ get:
     - users
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - name: id
       description: User's ID

--- a/openapi/spec/paths/admin@api@devices.yaml
+++ b/openapi/spec/paths/admin@api@devices.yaml
@@ -8,7 +8,7 @@ get:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - name: filter
       description: |

--- a/openapi/spec/paths/admin@api@devices@{uid}.yaml
+++ b/openapi/spec/paths/admin@api@devices@{uid}.yaml
@@ -10,7 +10,7 @@ get:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to get a device.
@@ -34,7 +34,7 @@ delete:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to delete a device.
@@ -54,7 +54,7 @@ patch:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:

--- a/openapi/spec/paths/admin@api@devices@{uid}@{status}.yaml
+++ b/openapi/spec/paths/admin@api@devices@{uid}@{status}.yaml
@@ -8,7 +8,7 @@ patch:
     - enterprise
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/path/deviceUIDPath.yaml
     - $ref: ../components/parameters/path/deviceStatusPath.yaml

--- a/openapi/spec/paths/admin@api@export@namespaces.yaml
+++ b/openapi/spec/paths/admin@api@export@namespaces.yaml
@@ -10,7 +10,7 @@ get:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - name: filter
       description: |

--- a/openapi/spec/paths/admin@api@firewall@rules.yaml
+++ b/openapi/spec/paths/admin@api@firewall@rules.yaml
@@ -8,7 +8,7 @@ post:
     - firewall
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:
@@ -41,7 +41,7 @@ get:
     - firewall
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/query/pageQuery.yaml
     - $ref: ../components/parameters/query/perPageQuery.yaml

--- a/openapi/spec/paths/admin@api@firewall@rules@{id}.yaml
+++ b/openapi/spec/paths/admin@api@firewall@rules@{id}.yaml
@@ -15,7 +15,7 @@ get:
     - firewall
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to get firewall rule.
@@ -37,7 +37,7 @@ put:
     - firewall
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:
@@ -70,7 +70,7 @@ delete:
     - firewall
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to delete a firewall rule.

--- a/openapi/spec/paths/admin@api@instance-api-keys.yaml
+++ b/openapi/spec/paths/admin@api@instance-api-keys.yaml
@@ -1,0 +1,105 @@
+get:
+  operationId: listInstanceAPIKeys
+  summary: List instance API keys
+  description: |
+    List every instance API key. The plaintext key is never returned: a key is identified by its
+    name alone once created.
+  tags:
+    - admin
+    - instance-api-keys
+    - cloud
+    - enterprise
+  security:
+    - jwt: []
+  parameters:
+    - $ref: ../components/parameters/query/pageQuery.yaml
+    - $ref: ../components/parameters/query/perPageQuery.yaml
+    - name: order_by
+      schema:
+        description: Instance API keys' list order.
+        type: string
+        enum:
+          - asc
+          - desc
+        example: asc
+        default: desc
+      required: false
+      in: query
+  responses:
+    '200':
+      description: Success to get the instance API keys.
+      headers:
+        X-Total-Count:
+          $ref: ../components/headers/XTotalCount.yaml
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/instanceAPIKey.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '500':
+      $ref: ../components/responses/500.yaml
+post:
+  operationId: createInstanceAPIKey
+  summary: Create an instance API key
+  description: |
+    Mint an instance API key. The response carries the plaintext key, which is the only time it is
+    available: the server keeps only its digest.
+
+    This route cannot be authenticated with an API key, so a leaked instance key cannot mint
+    successors that would outlive its revocation.
+  tags:
+    - admin
+    - instance-api-keys
+    - cloud
+    - enterprise
+  security:
+    - jwt: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - name
+            - expires_at
+          properties:
+            name:
+              description: |
+                The key's name, unique across the instance. Between 3 and 20 characters, letters,
+                numbers, `-` and `_`.
+              type: string
+              example: billing-export
+            expires_at:
+              description: |
+                Days until the key expires. Unlike a namespace API key, an instance API key must
+                expire.
+              type: integer
+              enum:
+                - 30
+                - 60
+                - 90
+                - 365
+              example: 30
+  responses:
+    '200':
+      description: Success to create the instance API key.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/instanceAPIKeyCreated.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '409':
+      $ref: ../components/responses/409.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/admin@api@instance-api-keys@{name}.yaml
+++ b/openapi/spec/paths/admin@api@instance-api-keys@{name}.yaml
@@ -1,0 +1,34 @@
+delete:
+  operationId: deleteInstanceAPIKey
+  summary: Revoke an instance API key
+  description: |
+    Revoke an instance API key. It takes effect immediately: anything still presenting the key
+    starts receiving `401`.
+
+    This route cannot be authenticated with an API key.
+  tags:
+    - admin
+    - instance-api-keys
+    - cloud
+    - enterprise
+  security:
+    - jwt: []
+  parameters:
+    - name: name
+      description: The instance API key's name.
+      schema:
+        type: string
+        example: billing-export
+      required: true
+      in: path
+  responses:
+    '200':
+      description: Success to revoke the instance API key.
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/admin@api@license.yaml
+++ b/openapi/spec/paths/admin@api@license.yaml
@@ -8,7 +8,7 @@ get:
     - license
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to get data.
@@ -402,7 +402,7 @@ post:
     - license
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       multipart/form-data:

--- a/openapi/spec/paths/admin@api@namespaces-update@{tenantID}.yaml
+++ b/openapi/spec/paths/admin@api@namespaces-update@{tenantID}.yaml
@@ -15,7 +15,7 @@ put:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:

--- a/openapi/spec/paths/admin@api@namespaces.yaml
+++ b/openapi/spec/paths/admin@api@namespaces.yaml
@@ -8,7 +8,7 @@ get:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - name: filter
       description: |

--- a/openapi/spec/paths/admin@api@namespaces@{tenant}.yaml
+++ b/openapi/spec/paths/admin@api@namespaces@{tenant}.yaml
@@ -10,7 +10,7 @@ get:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to get a namespace.

--- a/openapi/spec/paths/admin@api@sessions.yaml
+++ b/openapi/spec/paths/admin@api@sessions.yaml
@@ -8,7 +8,7 @@ get:
     - sessions
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/query/pageQuery.yaml
     - $ref: ../components/parameters/query/perPageQuery.yaml

--- a/openapi/spec/paths/admin@api@sessions@{uid}.yaml
+++ b/openapi/spec/paths/admin@api@sessions@{uid}.yaml
@@ -10,7 +10,7 @@ get:
     - sessions
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to get a session.
@@ -32,7 +32,7 @@ post:
     - sessions
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:

--- a/openapi/spec/paths/admin@api@sshkeys@public-keys.yaml
+++ b/openapi/spec/paths/admin@api@sshkeys@public-keys.yaml
@@ -7,7 +7,7 @@ get:
     - public-keys
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/query/filterQuery.yaml
     - $ref: ../components/parameters/query/pageQuery.yaml
@@ -35,7 +35,7 @@ post:
     - public-keys
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:

--- a/openapi/spec/paths/admin@api@stats.yaml
+++ b/openapi/spec/paths/admin@api@stats.yaml
@@ -8,7 +8,7 @@ get:
     - stats
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to get stats about the ShellHub instance

--- a/openapi/spec/paths/admin@api@users.yaml
+++ b/openapi/spec/paths/admin@api@users.yaml
@@ -8,7 +8,7 @@ post:
     - users
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:
@@ -40,7 +40,7 @@ get:
     - users
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   parameters:
     - $ref: ../components/parameters/query/filterQuery.yaml
     - $ref: ../components/parameters/query/pageQuery.yaml

--- a/openapi/spec/paths/admin@api@users@{id}.yaml
+++ b/openapi/spec/paths/admin@api@users@{id}.yaml
@@ -16,7 +16,7 @@ delete:
     - users
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       $ref: ../components/responses/200.yaml
@@ -34,7 +34,7 @@ put:
     - users
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   requestBody:
     content:
       application/json:
@@ -76,7 +76,7 @@ get:
     - users
   security:
     - jwt: []
-    - api-key: []
+    - instance-api-key: []
   responses:
     '200':
       description: Success to get a user.

--- a/pkg/api/requests/instance-api-key.go
+++ b/pkg/api/requests/instance-api-key.go
@@ -1,0 +1,24 @@
+package requests
+
+import "github.com/shellhub-io/shellhub/pkg/api/query"
+
+// CreateInstanceAPIKey is the request to mint an instance API key.
+//
+// The acting user is identified by username rather than by ID because the admin surface strips
+// X-ID from the request: an admin-panel call carries no user scope.
+type CreateInstanceAPIKey struct {
+	Username  string `header:"X-Username"`
+	Name      string `json:"name" validate:"required,api-key_name"`
+	ExpiresAt int    `json:"expires_at" validate:"required,instance-api-key_expires-at"`
+}
+
+// ListInstanceAPIKey is the request to list every instance API key.
+type ListInstanceAPIKey struct {
+	query.Paginator
+	query.Sorter
+}
+
+// DeleteInstanceAPIKey is the request to revoke the named instance API key.
+type DeleteInstanceAPIKey struct {
+	Name string `param:"name" validate:"required"`
+}

--- a/pkg/api/responses/instance-api-key.go
+++ b/pkg/api/responses/instance-api-key.go
@@ -1,0 +1,32 @@
+package responses
+
+import (
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+// CreateInstanceAPIKey is the response to minting an instance API key. ID carries the plaintext
+// key, which is returned here and nowhere else; the server keeps only its digest.
+type CreateInstanceAPIKey struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// CreateInstanceAPIKeyFromModel projects a stored instance API key into its creation response.
+// The plaintext key is a separate argument because the model carries only its digest: passing it
+// explicitly is what stops the digest being returned to the caller by omission.
+func CreateInstanceAPIKeyFromModel(m *models.InstanceAPIKey, plaintext string) *CreateInstanceAPIKey {
+	return &CreateInstanceAPIKey{
+		ID:        plaintext,
+		Name:      m.Name,
+		CreatedBy: m.CreatedBy,
+		CreatedAt: m.CreatedAt,
+		UpdatedAt: m.UpdatedAt,
+		ExpiresAt: m.ExpiresAt,
+	}
+}

--- a/pkg/models/instance_api_key.go
+++ b/pkg/models/instance_api_key.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/clock"
+)
+
+// InstanceAPIKeyPrefix marks a plaintext key as an instance API key. Authentication branches on it
+// before reaching a store, so the credential itself states which kind of key it is instead of the
+// server inferring it from a failed namespace lookup.
+const InstanceAPIKeyPrefix = "sh_admin_"
+
+// InstanceAPIKey authenticates a request as an instance administrator. Unlike [APIKey] it carries
+// neither a namespace nor a role, and it is honoured only on the admin surface.
+//
+// The ID is a SHA256 digest of the plaintext key and is never returned to the end user, so a key is
+// identified externally by its name alone. A key stops authenticating when it expires or when the
+// user in CreatedBy is no longer an instance administrator; use [InstanceAPIKey.IsValid] for the
+// former.
+type InstanceAPIKey struct {
+	// ID is the unique identifier of the key. It is a SHA256 hash of the prefixed plaintext key.
+	ID string `json:"-"`
+	// Name is an external identifier for a given key. It is unique across the instance.
+	Name string `json:"name"`
+	// CreatedBy is the ID of the instance administrator who created the key.
+	CreatedBy string `json:"created_by"`
+	// CreatedAt is the creation date of the key.
+	CreatedAt time.Time `json:"created_at"`
+	// UpdatedAt is the last update date of the key.
+	UpdatedAt time.Time `json:"updated_at"`
+	// ExpiresAt is the expiration date of the key. Unlike [APIKey], it is always set: an instance
+	// key cannot be created without one.
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// IsValid reports whether the key has not expired yet.
+func (a *InstanceAPIKey) IsValid() bool {
+	return clock.Now().Before(a.ExpiresAt)
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -49,6 +49,9 @@ const (
 	APIKeyNameTag = "api-key_name"
 	// APIKeyExpiresAtTag contains the rule to validate an API key's expiration value.
 	APIKeyExpiresAtTag = "api-key_expires-at" //nolint:gosec // G101: not a credential, this is a validator tag name
+	// InstanceAPIKeyExpiresAtTag contains the rule to validate an instance API key's expiration
+	// value. It is the API key rule without -1: an instance key must always expire.
+	InstanceAPIKeyExpiresAtTag = "instance-api-key_expires-at"
 	// MemberRoleTag contains the rule to validate a namespace member's role.
 	MemberRoleTag = "member_role"
 )
@@ -118,6 +121,19 @@ var Rules = []Rule{
 			return expiresAt == -1 || expiresAt == 30 || expiresAt == 60 || expiresAt == 90 || expiresAt == 365
 		},
 		Error: errors.New("expires_at must be in [ -1 30 60 90 365 ]"),
+	},
+	{
+		Tag: InstanceAPIKeyExpiresAtTag,
+		Handler: func(field validator.FieldLevel) bool {
+			if !field.Field().CanInt() {
+				return false
+			}
+
+			expiresAt := field.Field().Int()
+
+			return expiresAt == 30 || expiresAt == 60 || expiresAt == 90 || expiresAt == 365
+		},
+		Error: errors.New("expires_at must be in [ 30 60 90 365 ]"),
 	},
 	{
 		Tag: MemberRoleTag,

--- a/server/api/routes/instance-api-key.go
+++ b/server/api/routes/instance-api-key.go
@@ -1,0 +1,96 @@
+package routes
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/server/api/services"
+)
+
+// The instance API key routes, relative to the admin API's base path. They are mounted by the
+// enterprise admin surface, which is what keeps them out of community builds and behind the
+// admin authorization check.
+const (
+	CreateInstanceAPIKeyURL = "/instance-api-keys"       //nolint:gosec // G101: a route path, not a credential
+	ListInstanceAPIKeysURL  = "/instance-api-keys"       //nolint:gosec // G101: a route path, not a credential
+	DeleteInstanceAPIKeyURL = "/instance-api-keys/:name" //nolint:gosec // G101: a route path, not a credential
+)
+
+// CreateInstanceAPIKey mints an instance API key and returns its plaintext, which is the only
+// time the plaintext is available.
+func (h *Handler) CreateInstanceAPIKey(c *gateway.Context) error {
+	req := new(requests.CreateInstanceAPIKey)
+
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	res, err := h.service.CreateInstanceAPIKey(c.Ctx(), req)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// ListInstanceAPIKeys serves every instance API key, without their plaintext.
+func (h *Handler) ListInstanceAPIKeys(c *gateway.Context) error {
+	req := new(requests.ListInstanceAPIKey)
+
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	req.Paginator.Normalize()
+
+	if req.Sorter.By == "" {
+		req.Sorter.By = "created_at"
+	}
+
+	if req.Sorter.Order == "" {
+		req.Sorter.Order = "desc"
+	}
+
+	if err := query.ValidateSorter(&req.Sorter, services.InstanceAPIKeySortFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	res, count, err := h.service.ListInstanceAPIKeys(c.Ctx(), req)
+	if err != nil {
+		return err
+	}
+
+	c.Response().Header().Set("X-Total-Count", strconv.Itoa(count))
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// DeleteInstanceAPIKey revokes an instance API key, taking effect immediately.
+func (h *Handler) DeleteInstanceAPIKey(c *gateway.Context) error {
+	req := new(requests.DeleteInstanceAPIKey)
+
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	if err := h.service.DeleteInstanceAPIKey(c.Ctx(), req); err != nil {
+		return err
+	}
+
+	return c.NoContent(http.StatusOK)
+}

--- a/server/api/routes/middleware/authn.go
+++ b/server/api/routes/middleware/authn.go
@@ -19,6 +19,7 @@ import (
 // a credential into an identity.
 type AuthnService interface {
 	AuthAPIKey(ctx context.Context, key string) (*models.APIKey, error)
+	AuthInstanceAPIKey(ctx context.Context, key string) (*models.InstanceAPIKey, error)
 	ResolveNamespaceRole(ctx context.Context, tenantID, userID string) (*models.Namespace, string, error)
 	GetUserAdmin(ctx context.Context, userID string) (bool, error)
 	PublicKey() *rsa.PublicKey
@@ -135,6 +136,23 @@ func (a *Authenticator) isAnonymous(c *echo.Context) bool {
 // when a credential was presented and could not be honoured.
 func (a *Authenticator) Resolve(c *echo.Context) (*gateway.Identity, error) {
 	if key := c.Request().Header.Get("X-API-Key"); key != "" {
+		if strings.HasPrefix(key, models.InstanceAPIKeyPrefix) {
+			if !strings.HasPrefix(c.Path(), adminAPIPrefix) {
+				return nil, nil
+			}
+
+			if _, err := a.service.AuthInstanceAPIKey(c.Request().Context(), key); err != nil {
+				log.WithError(err).Warn("failed to resolve the instance API key")
+
+				return nil, nil
+			}
+
+			return &gateway.Identity{
+				APIKey: key,
+				Admin:  true,
+			}, nil
+		}
+
 		apiKey, err := a.service.AuthAPIKey(c.Request().Context(), key)
 		if err != nil {
 			log.WithError(err).Warn("failed to resolve the API key")

--- a/server/api/routes/middleware/authn_instance_api_key_test.go
+++ b/server/api/routes/middleware/authn_instance_api_key_test.go
@@ -1,0 +1,152 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/server/api/services/mocks"
+	"github.com/shellhub-io/shellhub/server/api/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func apiKeyRequestTo(e *echo.Echo, path, key string) *echo.Context {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	req.Header.Set("X-API-Key", key)
+	c := e.NewContext(req, httptest.NewRecorder())
+	c.SetPath(path)
+
+	return c
+}
+
+func apiKeyRequest(e *echo.Echo, key string) *echo.Context {
+	return apiKeyRequestTo(e, "/admin/api/users", key)
+}
+
+func TestAuthenticatorResolveInstanceAPIKey(t *testing.T) {
+	const instanceKey = models.InstanceAPIKeyPrefix + "cdfd3cb0-c44e-4e54-b931-6d57713ad159"
+
+	cases := []struct {
+		description   string
+		key           string
+		requiredMocks func(service *mocks.MockService)
+		expected      *gateway.Identity
+	}{
+		{
+			description: "resolves a prefixed key to the instance administrator identity",
+			key:         instanceKey,
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("AuthInstanceAPIKey", mock.Anything, instanceKey).
+					Return(&models.InstanceAPIKey{ID: "digest", Name: "license-sync", CreatedBy: testUserID}, nil).
+					Once()
+			},
+			expected: &gateway.Identity{
+				APIKey: instanceKey,
+				Admin:  true,
+			},
+		},
+		{
+			description: "yields no identity when the creator is no longer an instance administrator",
+			key:         instanceKey,
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("AuthInstanceAPIKey", mock.Anything, instanceKey).
+					Return(nil, errors.New("unauthorized")).
+					Once()
+			},
+			expected: nil,
+		},
+		{
+			description: "yields no identity when the prefixed key is unknown",
+			key:         models.InstanceAPIKeyPrefix + "00000000-0000-4000-0000-000000000000",
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("AuthInstanceAPIKey", mock.Anything, models.InstanceAPIKeyPrefix+"00000000-0000-4000-0000-000000000000").
+					Return(nil, store.ErrNoDocuments).
+					Once()
+			},
+			expected: nil,
+		},
+		{
+			description: "yields no identity when the prefix carries no key at all",
+			key:         models.InstanceAPIKeyPrefix,
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("AuthInstanceAPIKey", mock.Anything, models.InstanceAPIKeyPrefix).
+					Return(nil, store.ErrNoDocuments).
+					Once()
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			service := new(mocks.MockService)
+			tc.requiredMocks(service)
+
+			identity, err := NewAuthenticator(service).Resolve(apiKeyRequest(echo.New(), tc.key))
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, identity)
+
+			service.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAuthenticatorResolveInstanceAPIKeyOffAdminSurface(t *testing.T) {
+	const instanceKey = models.InstanceAPIKeyPrefix + "cdfd3cb0-c44e-4e54-b931-6d57713ad159"
+
+	for _, path := range []string{
+		"/api/devices",
+		"/api/namespaces/:tenant",
+		"/api/users/security",
+	} {
+		t.Run(path, func(t *testing.T) {
+			service := new(mocks.MockService)
+
+			identity, err := NewAuthenticator(service).Resolve(
+				apiKeyRequestTo(echo.New(), path, instanceKey),
+			)
+			require.NoError(t, err)
+			assert.Nil(t, identity)
+
+			service.AssertNotCalled(t, "AuthInstanceAPIKey", mock.Anything, mock.Anything)
+			service.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAuthenticatorResolveNamespaceAPIKeyIsNeverAdmin(t *testing.T) {
+	const namespaceKey = "cdfd3cb0-c44e-4e54-b931-6d57713ad159"
+
+	for _, role := range []authorizer.Role{
+		authorizer.RoleOwner,
+		authorizer.RoleAdministrator,
+		authorizer.RoleOperator,
+		authorizer.RoleObserver,
+	} {
+		t.Run("role "+role.String(), func(t *testing.T) {
+			service := new(mocks.MockService)
+			service.On("AuthAPIKey", mock.Anything, namespaceKey).
+				Return(&models.APIKey{ID: "digest", Name: "ci", TenantID: testTenant, Role: role}, nil).
+				Once()
+
+			identity, err := NewAuthenticator(service).Resolve(apiKeyRequest(echo.New(), namespaceKey))
+			require.NoError(t, err)
+			require.NotNil(t, identity)
+
+			assert.False(t, identity.Admin, "a namespace API key must never carry the admin flag")
+			assert.Equal(t, testTenant, identity.TenantID)
+			assert.Equal(t, role, identity.Role)
+
+			service.AssertNotCalled(t, "AuthInstanceAPIKey", mock.Anything, mock.Anything)
+			service.AssertExpectations(t)
+		})
+	}
+}

--- a/server/api/services/auth.go
+++ b/server/api/services/auth.go
@@ -78,6 +78,15 @@ type AuthService interface {
 	// authenticating at once.
 	AuthAPIKey(ctx context.Context, key string) (apiKey *models.APIKey, err error)
 
+	// AuthInstanceAPIKey authenticates the given key as an instance administrator, returning its
+	// instance API key document. Unlike [AuthService.AuthAPIKey] it resolves to no namespace and no
+	// role: the caller is the instance administrator who created the key.
+	//
+	// It returns an error when the key does not exist, when it has expired, or when the user who
+	// created it is no longer an instance administrator, so a demotion revokes every key that user
+	// minted.
+	AuthInstanceAPIKey(ctx context.Context, key string) (apiKey *models.InstanceAPIKey, err error)
+
 	AuthPublicKey(ctx context.Context, req requests.PublicKeyAuth) (*models.PublicKeyAuthResponse, error)
 	PublicKey() *rsa.PublicKey
 }

--- a/server/api/services/errors.go
+++ b/server/api/services/errors.go
@@ -150,6 +150,8 @@ var (
 	ErrSameTags                        = errors.New("trying to update tags with the same content", ErrLayer, ErrCodeNoContentChange)
 	ErrAPIKeyNotFound                  = errors.New("APIKey not found", ErrLayer, ErrCodeNotFound)
 	ErrAPIKeyDuplicated                = errors.New("APIKey duplicated", ErrLayer, ErrCodeDuplicated)
+	ErrInstanceAPIKeyNotFound          = errors.New("InstanceAPIKey not found", ErrLayer, ErrCodeNotFound)
+	ErrInstanceAPIKeyDuplicated        = errors.New("InstanceAPIKey duplicated", ErrLayer, ErrCodeDuplicated)
 	ErrInstallKeyNotFound              = errors.New("InstallKey not found", ErrLayer, ErrCodeNotFound)
 	ErrInstallKeyDuplicated            = errors.New("InstallKey duplicated", ErrLayer, ErrCodeDuplicated)
 	ErrInstallKeyForbidden             = errors.New("the legacy install key cannot be modified", ErrLayer, ErrCodeForbidden)
@@ -241,6 +243,23 @@ func NewErrAPIKeyInvalid(name string) error {
 // NewErrAPIKeyDuplicated returns an error when the APIKey name is duplicated.
 func NewErrAPIKeyDuplicated(conflicts []string) error {
 	return NewErrDuplicated(ErrAPIKeyDuplicated, conflicts, nil)
+}
+
+// NewErrInstanceAPIKeyNotFound returns an error when the instance API key is not found.
+func NewErrInstanceAPIKeyNotFound(name string, next error) error {
+	return NewErrNotFound(ErrInstanceAPIKeyNotFound, name, next)
+}
+
+// NewErrInstanceAPIKeyInvalid reports that an instance API key did not authenticate. It carries no
+// detail about which check failed, so a caller cannot tell an unknown key from an expired one or
+// from one whose creator was demoted.
+func NewErrInstanceAPIKeyInvalid(name string) error {
+	return NewErrAuthInvalid(map[string]any{"instance-api-key": name}, nil)
+}
+
+// NewErrInstanceAPIKeyDuplicated returns an error when the instance API key name is taken.
+func NewErrInstanceAPIKeyDuplicated(conflicts []string) error {
+	return NewErrDuplicated(ErrInstanceAPIKeyDuplicated, conflicts, nil)
 }
 
 // NewErrInstallKeyNotFound returns an error when the InstallKey is not found.

--- a/server/api/services/instance-api-key.go
+++ b/server/api/services/instance-api-key.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/api/responses"
+	"github.com/shellhub-io/shellhub/pkg/clock"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/pkg/uuid"
+	"github.com/shellhub-io/shellhub/server/api/store"
+)
+
+// InstanceAPIKeySortFields is the set of field names accepted in the sort_by query parameter when
+// listing instance API keys. The row also holds the key's digest, which the response omits and a
+// sort must not order by.
+var InstanceAPIKeySortFields = query.NewFieldSet(
+	"name",
+	"created_at",
+	"updated_at",
+	"expires_at",
+)
+
+// InstanceAPIKeyService manages the keys that authenticate as an instance administrator rather
+// than as a member of a namespace. A key's plaintext is returned once, at creation, and only its
+// digest is kept.
+type InstanceAPIKeyService interface {
+	// CreateInstanceAPIKey mints an instance API key on behalf of the requesting administrator. The
+	// server generates the plaintext and returns it in the response, storing only its SHA256 digest,
+	// so a caller can read the key exactly once. It returns ErrUserNotFound when the requesting
+	// username does not resolve, ErrAuthForbidden when that user is not an instance administrator,
+	// ErrBadRequest for an expiry outside the permitted set, and ErrInstanceAPIKeyDuplicated when
+	// the name is taken.
+	CreateInstanceAPIKey(ctx context.Context, req *requests.CreateInstanceAPIKey) (res *responses.CreateInstanceAPIKey, err error)
+
+	// ListInstanceAPIKeys retrieves every instance API key together with the total count before
+	// pagination.
+	ListInstanceAPIKeys(ctx context.Context, req *requests.ListInstanceAPIKey) (apiKeys []models.InstanceAPIKey, count int, err error)
+
+	// DeleteInstanceAPIKey revokes the named instance API key, taking effect immediately. It
+	// returns ErrInstanceAPIKeyNotFound when no key carries that name.
+	DeleteInstanceAPIKey(ctx context.Context, req *requests.DeleteInstanceAPIKey) (err error)
+}
+
+func (s *service) CreateInstanceAPIKey(ctx context.Context, req *requests.CreateInstanceAPIKey) (*responses.CreateInstanceAPIKey, error) {
+	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, req.Username)
+	if err != nil {
+		return nil, NewErrUserNotFound(req.Username, err)
+	}
+
+	if !user.Admin {
+		return nil, NewErrAuthForbidden()
+	}
+
+	var expiresAt time.Time
+	switch req.ExpiresAt {
+	case 30, 60, 90:
+		expiresAt = clock.Now().AddDate(0, 0, req.ExpiresAt)
+	case 365:
+		expiresAt = clock.Now().AddDate(1, 0, 0)
+	default:
+		return nil, NewErrBadRequest(errors.New("expires_at must be one of 30, 60, 90 or 365 days"))
+	}
+
+	plain := models.InstanceAPIKeyPrefix + uuid.Generate()
+
+	apiKey := &models.InstanceAPIKey{
+		ID:        instanceAPIKeyDigest(plain),
+		Name:      req.Name,
+		CreatedBy: user.ID,
+		ExpiresAt: expiresAt,
+	}
+
+	if _, err := s.store.InstanceAPIKeyCreate(ctx, apiKey); err != nil {
+		if errors.Is(err, store.ErrDuplicate) {
+			return nil, NewErrInstanceAPIKeyDuplicated([]string{"name"})
+		}
+
+		return nil, err
+	}
+
+	return responses.CreateInstanceAPIKeyFromModel(apiKey, plain), nil
+}
+
+func (s *service) ListInstanceAPIKeys(ctx context.Context, req *requests.ListInstanceAPIKey) ([]models.InstanceAPIKey, int, error) {
+	if req.Sorter.By == "" {
+		req.Sorter.By = "created_at"
+	}
+
+	req.Sorter.Tiebreak = "key_digest"
+
+	return s.store.InstanceAPIKeyList(
+		ctx,
+		s.store.Options().Sort(&req.Sorter),
+		s.store.Options().Paginate(&req.Paginator),
+	)
+}
+
+func (s *service) DeleteInstanceAPIKey(ctx context.Context, req *requests.DeleteInstanceAPIKey) error {
+	if err := s.store.InstanceAPIKeyDelete(ctx, req.Name); err != nil {
+		if errors.Is(err, store.ErrNoDocuments) {
+			return NewErrInstanceAPIKeyNotFound(req.Name, err)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) AuthInstanceAPIKey(ctx context.Context, key string) (*models.InstanceAPIKey, error) {
+	apiKey, err := s.store.InstanceAPIKeyResolve(ctx, store.InstanceAPIKeyIDResolver, instanceAPIKeyDigest(key))
+	if err != nil {
+		return nil, NewErrInstanceAPIKeyNotFound("", err)
+	}
+
+	if !apiKey.IsValid() {
+		return nil, NewErrInstanceAPIKeyInvalid(apiKey.Name)
+	}
+
+	admin, err := s.GetUserAdmin(ctx, apiKey.CreatedBy)
+	if err != nil || !admin {
+		return nil, NewErrInstanceAPIKeyInvalid(apiKey.Name)
+	}
+
+	return apiKey, nil
+}
+
+func instanceAPIKeyDigest(plain string) string {
+	sum := sha256.Sum256([]byte(plain))
+
+	return hex.EncodeToString(sum[:])
+}

--- a/server/api/services/instance-api-key_test.go
+++ b/server/api/services/instance-api-key_test.go
@@ -1,0 +1,369 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/api/responses"
+	storecache "github.com/shellhub-io/shellhub/pkg/cache"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/pkg/uuid"
+	uuidmock "github.com/shellhub-io/shellhub/pkg/uuid/mocks"
+	"github.com/shellhub-io/shellhub/server/api/store"
+	storemock "github.com/shellhub-io/shellhub/server/api/store/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func instanceKeyDigest(plain string) string {
+	sum := sha256.Sum256([]byte(plain))
+
+	return hex.EncodeToString(sum[:])
+}
+
+func TestCreateInstanceAPIKey(t *testing.T) {
+	type Expected struct {
+		res *responses.CreateInstanceAPIKey
+		err error
+	}
+
+	storeMock := storemock.NewMockStore(t)
+
+	cases := []struct {
+		description   string
+		req           *requests.CreateInstanceAPIKey
+		requiredMocks func(context.Context)
+		expected      Expected
+	}{
+		{
+			description: "fails when the requesting user does not exist",
+			req: &requests.CreateInstanceAPIKey{
+				Username:  "ghost",
+				Name:      "billing-export",
+				ExpiresAt: 30,
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "ghost").
+					Return(nil, errors.New("error")).
+					Once()
+			},
+			expected: Expected{
+				res: nil,
+				err: NewErrUserNotFound("ghost", errors.New("error")),
+			},
+		},
+		{
+			description: "fails when the requesting user is not an instance administrator",
+			req: &requests.CreateInstanceAPIKey{
+				Username:  "regular",
+				Name:      "billing-export",
+				ExpiresAt: 30,
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "regular").
+					Return(&models.User{ID: "user-1", Admin: false}, nil).
+					Once()
+			},
+			expected: Expected{
+				res: nil,
+				err: NewErrAuthForbidden(),
+			},
+		},
+		{
+			description: "fails when the expiration is outside the permitted set",
+			req: &requests.CreateInstanceAPIKey{
+				Username:  "admin",
+				Name:      "billing-export",
+				ExpiresAt: -1,
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "admin").
+					Return(&models.User{ID: "user-1", Admin: true}, nil).
+					Once()
+			},
+			expected: Expected{
+				res: nil,
+				err: NewErrBadRequest(errors.New("expires_at must be one of 30, 60, 90 or 365 days")),
+			},
+		},
+		{
+			description: "fails when the name is already taken",
+			req: &requests.CreateInstanceAPIKey{
+				Username:  "admin",
+				Name:      "billing-export",
+				ExpiresAt: 30,
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "admin").
+					Return(&models.User{ID: "user-1", Admin: true}, nil).
+					Once()
+
+				uuidMock := new(uuidmock.MockUUID)
+				uuid.DefaultBackend = uuidMock
+				uuidMock.On("Generate").Return("cdfd3cb0-c44e-4e54-b931-6d57713ad159").Once()
+
+				clockMock.On("Now").Return(now)
+				storeMock.
+					On("InstanceAPIKeyCreate", ctx, &models.InstanceAPIKey{
+						ID:        instanceKeyDigest(models.InstanceAPIKeyPrefix + "cdfd3cb0-c44e-4e54-b931-6d57713ad159"),
+						Name:      "billing-export",
+						CreatedBy: "user-1",
+						ExpiresAt: now.AddDate(0, 0, 30),
+					}).
+					Return("", store.ErrDuplicate).
+					Once()
+			},
+			expected: Expected{
+				res: nil,
+				err: NewErrInstanceAPIKeyDuplicated([]string{"name"}),
+			},
+		},
+		{
+			description: "succeeds and returns the prefixed plaintext key once",
+			req: &requests.CreateInstanceAPIKey{
+				Username:  "admin",
+				Name:      "license-sync",
+				ExpiresAt: 365,
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "admin").
+					Return(&models.User{ID: "user-1", Admin: true}, nil).
+					Once()
+
+				uuidMock := new(uuidmock.MockUUID)
+				uuid.DefaultBackend = uuidMock
+				uuidMock.On("Generate").Return("cdfd3cb0-c44e-4e54-b931-6d57713ad159").Once()
+
+				clockMock.On("Now").Return(now)
+				storeMock.
+					On("InstanceAPIKeyCreate", ctx, &models.InstanceAPIKey{
+						ID:        instanceKeyDigest(models.InstanceAPIKeyPrefix + "cdfd3cb0-c44e-4e54-b931-6d57713ad159"),
+						Name:      "license-sync",
+						CreatedBy: "user-1",
+						ExpiresAt: now.AddDate(1, 0, 0),
+					}).
+					Return(instanceKeyDigest(models.InstanceAPIKeyPrefix+"cdfd3cb0-c44e-4e54-b931-6d57713ad159"), nil).
+					Once()
+			},
+			expected: Expected{
+				res: &responses.CreateInstanceAPIKey{
+					ID:        models.InstanceAPIKeyPrefix + "cdfd3cb0-c44e-4e54-b931-6d57713ad159",
+					Name:      "license-sync",
+					CreatedBy: "user-1",
+					ExpiresAt: now.AddDate(1, 0, 0),
+				},
+				err: nil,
+			},
+		},
+	}
+
+	s := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache())
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.Background()
+			tc.requiredMocks(ctx)
+
+			res, err := s.CreateInstanceAPIKey(ctx, tc.req)
+			require.Equal(t, tc.expected, Expected{res, err})
+		})
+	}
+
+	uuid.DefaultBackend = realUUIDBackend
+	storeMock.AssertExpectations(t)
+}
+
+func TestAuthInstanceAPIKey(t *testing.T) {
+	type Expected struct {
+		res *models.InstanceAPIKey
+		err error
+	}
+
+	storeMock := storemock.NewMockStore(t)
+
+	plain := models.InstanceAPIKeyPrefix + "cdfd3cb0-c44e-4e54-b931-6d57713ad159"
+	digest := instanceKeyDigest(plain)
+
+	cases := []struct {
+		description   string
+		key           string
+		requiredMocks func(context.Context)
+		expected      Expected
+	}{
+		{
+			description: "fails when the key does not exist",
+			key:         plain,
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("InstanceAPIKeyResolve", ctx, store.InstanceAPIKeyIDResolver, digest).
+					Return(nil, store.ErrNoDocuments).
+					Once()
+			},
+			expected: Expected{
+				res: nil,
+				err: NewErrInstanceAPIKeyNotFound("", store.ErrNoDocuments),
+			},
+		},
+		{
+			description: "fails when the key has expired",
+			key:         plain,
+			requiredMocks: func(ctx context.Context) {
+				clockMock.On("Now").Return(now)
+				storeMock.
+					On("InstanceAPIKeyResolve", ctx, store.InstanceAPIKeyIDResolver, digest).
+					Return(&models.InstanceAPIKey{
+						ID:        digest,
+						Name:      "expired",
+						CreatedBy: "user-1",
+						ExpiresAt: now.Add(-time.Hour),
+					}, nil).
+					Once()
+			},
+			expected: Expected{
+				res: nil,
+				err: NewErrInstanceAPIKeyInvalid("expired"),
+			},
+		},
+		{
+			description: "fails when the creator is no longer an instance administrator",
+			key:         plain,
+			requiredMocks: func(ctx context.Context) {
+				clockMock.On("Now").Return(now)
+				storeMock.
+					On("InstanceAPIKeyResolve", ctx, store.InstanceAPIKeyIDResolver, digest).
+					Return(&models.InstanceAPIKey{
+						ID:        digest,
+						Name:      "demoted",
+						CreatedBy: "user-1",
+						ExpiresAt: now.Add(time.Hour),
+					}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "user-1").
+					Return(&models.User{ID: "user-1", Admin: false}, nil).
+					Once()
+			},
+			expected: Expected{
+				res: nil,
+				err: NewErrInstanceAPIKeyInvalid("demoted"),
+			},
+		},
+		{
+			description: "succeeds when the key is valid and its creator is still an administrator",
+			key:         plain,
+			requiredMocks: func(ctx context.Context) {
+				clockMock.On("Now").Return(now)
+				storeMock.
+					On("InstanceAPIKeyResolve", ctx, store.InstanceAPIKeyIDResolver, digest).
+					Return(&models.InstanceAPIKey{
+						ID:        digest,
+						Name:      "license-sync",
+						CreatedBy: "user-1",
+						ExpiresAt: now.Add(time.Hour),
+					}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "user-1").
+					Return(&models.User{ID: "user-1", Admin: true}, nil).
+					Once()
+			},
+			expected: Expected{
+				res: &models.InstanceAPIKey{
+					ID:        digest,
+					Name:      "license-sync",
+					CreatedBy: "user-1",
+					ExpiresAt: now.Add(time.Hour),
+				},
+				err: nil,
+			},
+		},
+	}
+
+	s := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache())
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.Background()
+			tc.requiredMocks(ctx)
+
+			res, err := s.AuthInstanceAPIKey(ctx, tc.key)
+			require.Equal(t, tc.expected, Expected{res, err})
+		})
+	}
+
+	storeMock.AssertExpectations(t)
+}
+
+func TestListInstanceAPIKeys(t *testing.T) {
+	storeMock := storemock.NewMockStore(t)
+	queryOptionsMock := storemock.NewMockQueryOptions(t)
+	storeMock.On("Options").Return(queryOptionsMock).Maybe()
+
+	s := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache())
+
+	ctx := context.Background()
+	expected := []models.InstanceAPIKey{{ID: "digest", Name: "license-sync", CreatedBy: "user-1"}}
+
+	queryOptionsMock.
+		On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "key_digest"}).
+		Return(nil).
+		Once()
+	queryOptionsMock.
+		On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
+		Return(nil).
+		Once()
+	storeMock.
+		On("InstanceAPIKeyList", ctx, mock.AnythingOfType("[]store.QueryOption")).
+		Return(expected, 1, nil).
+		Once()
+
+	apiKeys, count, err := s.ListInstanceAPIKeys(ctx, &requests.ListInstanceAPIKey{
+		Paginator: query.Paginator{Page: 1, PerPage: 10},
+		Sorter:    query.Sorter{By: "created_at", Order: query.OrderAsc},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.Equal(t, expected, apiKeys)
+
+	storeMock.AssertExpectations(t)
+}
+
+func TestDeleteInstanceAPIKey(t *testing.T) {
+	storeMock := storemock.NewMockStore(t)
+	s := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache())
+
+	ctx := context.Background()
+
+	t.Run("fails when the key does not exist", func(t *testing.T) {
+		storeMock.
+			On("InstanceAPIKeyDelete", ctx, "ghost").
+			Return(store.ErrNoDocuments).
+			Once()
+
+		err := s.DeleteInstanceAPIKey(ctx, &requests.DeleteInstanceAPIKey{Name: "ghost"})
+		require.Equal(t, NewErrInstanceAPIKeyNotFound("ghost", store.ErrNoDocuments), err)
+	})
+
+	t.Run("succeeds when the key exists", func(t *testing.T) {
+		storeMock.
+			On("InstanceAPIKeyDelete", ctx, "retired").
+			Return(nil).
+			Once()
+
+		require.NoError(t, s.DeleteInstanceAPIKey(ctx, &requests.DeleteInstanceAPIKey{Name: "retired"}))
+	})
+
+	storeMock.AssertExpectations(t)
+}

--- a/server/api/services/mocks/mock_service.go
+++ b/server/api/services/mocks/mock_service.go
@@ -449,6 +449,74 @@ func (_c *MockService_AuthDevice_Call) RunAndReturn(run func(ctx context.Context
 	return _c
 }
 
+// AuthInstanceAPIKey provides a mock function for the type MockService
+func (_mock *MockService) AuthInstanceAPIKey(ctx context.Context, key string) (*models.InstanceAPIKey, error) {
+	ret := _mock.Called(ctx, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AuthInstanceAPIKey")
+	}
+
+	var r0 *models.InstanceAPIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*models.InstanceAPIKey, error)); ok {
+		return returnFunc(ctx, key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *models.InstanceAPIKey); ok {
+		r0 = returnFunc(ctx, key)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.InstanceAPIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, key)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_AuthInstanceAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AuthInstanceAPIKey'
+type MockService_AuthInstanceAPIKey_Call struct {
+	*mock.Call
+}
+
+// AuthInstanceAPIKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - key string
+func (_e *MockService_Expecter) AuthInstanceAPIKey(ctx any, key any) *MockService_AuthInstanceAPIKey_Call {
+	return &MockService_AuthInstanceAPIKey_Call{Call: _e.mock.On("AuthInstanceAPIKey", ctx, key)}
+}
+
+func (_c *MockService_AuthInstanceAPIKey_Call) Run(run func(ctx context.Context, key string)) *MockService_AuthInstanceAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_AuthInstanceAPIKey_Call) Return(apiKey *models.InstanceAPIKey, err error) *MockService_AuthInstanceAPIKey_Call {
+	_c.Call.Return(apiKey, err)
+	return _c
+}
+
+func (_c *MockService_AuthInstanceAPIKey_Call) RunAndReturn(run func(ctx context.Context, key string) (*models.InstanceAPIKey, error)) *MockService_AuthInstanceAPIKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AuthIsCacheToken provides a mock function for the type MockService
 func (_mock *MockService) AuthIsCacheToken(ctx context.Context, tenant string, id string) (bool, error) {
 	ret := _mock.Called(ctx, tenant, id)
@@ -1368,6 +1436,74 @@ func (_c *MockService_CreateInstallKey_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
+// CreateInstanceAPIKey provides a mock function for the type MockService
+func (_mock *MockService) CreateInstanceAPIKey(ctx context.Context, req *requests.CreateInstanceAPIKey) (*responses.CreateInstanceAPIKey, error) {
+	ret := _mock.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateInstanceAPIKey")
+	}
+
+	var r0 *responses.CreateInstanceAPIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.CreateInstanceAPIKey) (*responses.CreateInstanceAPIKey, error)); ok {
+		return returnFunc(ctx, req)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.CreateInstanceAPIKey) *responses.CreateInstanceAPIKey); ok {
+		r0 = returnFunc(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*responses.CreateInstanceAPIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.CreateInstanceAPIKey) error); ok {
+		r1 = returnFunc(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_CreateInstanceAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateInstanceAPIKey'
+type MockService_CreateInstanceAPIKey_Call struct {
+	*mock.Call
+}
+
+// CreateInstanceAPIKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *requests.CreateInstanceAPIKey
+func (_e *MockService_Expecter) CreateInstanceAPIKey(ctx any, req any) *MockService_CreateInstanceAPIKey_Call {
+	return &MockService_CreateInstanceAPIKey_Call{Call: _e.mock.On("CreateInstanceAPIKey", ctx, req)}
+}
+
+func (_c *MockService_CreateInstanceAPIKey_Call) Run(run func(ctx context.Context, req *requests.CreateInstanceAPIKey)) *MockService_CreateInstanceAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *requests.CreateInstanceAPIKey
+		if args[1] != nil {
+			arg1 = args[1].(*requests.CreateInstanceAPIKey)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_CreateInstanceAPIKey_Call) Return(res *responses.CreateInstanceAPIKey, err error) *MockService_CreateInstanceAPIKey_Call {
+	_c.Call.Return(res, err)
+	return _c
+}
+
+func (_c *MockService_CreateInstanceAPIKey_Call) RunAndReturn(run func(ctx context.Context, req *requests.CreateInstanceAPIKey) (*responses.CreateInstanceAPIKey, error)) *MockService_CreateInstanceAPIKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateNamespace provides a mock function for the type MockService
 func (_mock *MockService) CreateNamespace(ctx context.Context, namespace *requests.NamespaceCreate) (*models.Namespace, error) {
 	ret := _mock.Called(ctx, namespace)
@@ -2265,6 +2401,63 @@ func (_c *MockService_DeleteDeviceCustomField_Call) Return(err error) *MockServi
 }
 
 func (_c *MockService_DeleteDeviceCustomField_Call) RunAndReturn(run func(ctx context.Context, req *requests.DeviceDeleteCustomField) error) *MockService_DeleteDeviceCustomField_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteInstanceAPIKey provides a mock function for the type MockService
+func (_mock *MockService) DeleteInstanceAPIKey(ctx context.Context, req *requests.DeleteInstanceAPIKey) error {
+	ret := _mock.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteInstanceAPIKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.DeleteInstanceAPIKey) error); ok {
+		r0 = returnFunc(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockService_DeleteInstanceAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteInstanceAPIKey'
+type MockService_DeleteInstanceAPIKey_Call struct {
+	*mock.Call
+}
+
+// DeleteInstanceAPIKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *requests.DeleteInstanceAPIKey
+func (_e *MockService_Expecter) DeleteInstanceAPIKey(ctx any, req any) *MockService_DeleteInstanceAPIKey_Call {
+	return &MockService_DeleteInstanceAPIKey_Call{Call: _e.mock.On("DeleteInstanceAPIKey", ctx, req)}
+}
+
+func (_c *MockService_DeleteInstanceAPIKey_Call) Run(run func(ctx context.Context, req *requests.DeleteInstanceAPIKey)) *MockService_DeleteInstanceAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *requests.DeleteInstanceAPIKey
+		if args[1] != nil {
+			arg1 = args[1].(*requests.DeleteInstanceAPIKey)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_DeleteInstanceAPIKey_Call) Return(err error) *MockService_DeleteInstanceAPIKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockService_DeleteInstanceAPIKey_Call) RunAndReturn(run func(ctx context.Context, req *requests.DeleteInstanceAPIKey) error) *MockService_DeleteInstanceAPIKey_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4447,6 +4640,80 @@ func (_c *MockService_ListInstallKeys_Call) Return(installKeys []models.InstallK
 }
 
 func (_c *MockService_ListInstallKeys_Call) RunAndReturn(run func(ctx context.Context, req *requests.ListInstallKey) ([]models.InstallKey, int, error)) *MockService_ListInstallKeys_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListInstanceAPIKeys provides a mock function for the type MockService
+func (_mock *MockService) ListInstanceAPIKeys(ctx context.Context, req *requests.ListInstanceAPIKey) ([]models.InstanceAPIKey, int, error) {
+	ret := _mock.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListInstanceAPIKeys")
+	}
+
+	var r0 []models.InstanceAPIKey
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.ListInstanceAPIKey) ([]models.InstanceAPIKey, int, error)); ok {
+		return returnFunc(ctx, req)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.ListInstanceAPIKey) []models.InstanceAPIKey); ok {
+		r0 = returnFunc(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.InstanceAPIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.ListInstanceAPIKey) int); ok {
+		r1 = returnFunc(ctx, req)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *requests.ListInstanceAPIKey) error); ok {
+		r2 = returnFunc(ctx, req)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockService_ListInstanceAPIKeys_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListInstanceAPIKeys'
+type MockService_ListInstanceAPIKeys_Call struct {
+	*mock.Call
+}
+
+// ListInstanceAPIKeys is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *requests.ListInstanceAPIKey
+func (_e *MockService_Expecter) ListInstanceAPIKeys(ctx any, req any) *MockService_ListInstanceAPIKeys_Call {
+	return &MockService_ListInstanceAPIKeys_Call{Call: _e.mock.On("ListInstanceAPIKeys", ctx, req)}
+}
+
+func (_c *MockService_ListInstanceAPIKeys_Call) Run(run func(ctx context.Context, req *requests.ListInstanceAPIKey)) *MockService_ListInstanceAPIKeys_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *requests.ListInstanceAPIKey
+		if args[1] != nil {
+			arg1 = args[1].(*requests.ListInstanceAPIKey)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_ListInstanceAPIKeys_Call) Return(apiKeys []models.InstanceAPIKey, count int, err error) *MockService_ListInstanceAPIKeys_Call {
+	_c.Call.Return(apiKeys, count, err)
+	return _c
+}
+
+func (_c *MockService_ListInstanceAPIKeys_Call) RunAndReturn(run func(ctx context.Context, req *requests.ListInstanceAPIKey) ([]models.InstanceAPIKey, int, error)) *MockService_ListInstanceAPIKeys_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/api/services/service.go
+++ b/server/api/services/service.go
@@ -53,6 +53,7 @@ type Service interface {
 	SetupService
 	SystemService
 	APIKeyService
+	InstanceAPIKeyService
 	InstallKeyService
 	FirewallService
 	LicenseService

--- a/server/api/store/instance_api_key.go
+++ b/server/api/store/instance_api_key.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+// InstanceAPIKeyResolver names the field an instance API key is looked up by.
+type InstanceAPIKeyResolver uint
+
+// The fields an instance API key can be resolved by. The zero value is not one, so an unset
+// resolver cannot silently mean the first.
+const (
+	InstanceAPIKeyIDResolver InstanceAPIKeyResolver = iota + 1
+	InstanceAPIKeyNameResolver
+)
+
+// InstanceAPIKeyStore persists the API keys that authenticate as an instance administrator.
+//
+// No method takes a [scope.Scope]: an instance API key belongs to the instance rather than to a
+// namespace, so there is nothing to bound a query to. That also keeps instance keys unreachable
+// from [APIKeyStore], which is what stops a namespace key from ever resolving to an administrator.
+type InstanceAPIKeyStore interface {
+	// InstanceAPIKeyCreate creates an instance API key with the provided data. It returns the
+	// inserted ID, and ErrDuplicate when the name or the digest is already taken.
+	InstanceAPIKeyCreate(ctx context.Context, apiKey *models.InstanceAPIKey) (insertedID string, err error)
+
+	// InstanceAPIKeyResolve fetches an instance API key using a specific resolver. It returns
+	// ErrNoDocuments when no key matches, and ErrResolverNotFound for an unknown resolver.
+	InstanceAPIKeyResolve(ctx context.Context, resolver InstanceAPIKeyResolver, value string, opts ...QueryOption) (*models.InstanceAPIKey, error)
+
+	// InstanceAPIKeyList retrieves every instance API key, together with the total count before
+	// pagination.
+	InstanceAPIKeyList(ctx context.Context, opts ...QueryOption) (apiKeys []models.InstanceAPIKey, count int, err error)
+
+	// InstanceAPIKeyDelete deletes the instance API key with the given name. It returns
+	// ErrNoDocuments when no key matches.
+	InstanceAPIKeyDelete(ctx context.Context, name string) error
+}

--- a/server/api/store/mocks/mock_store.go
+++ b/server/api/store/mocks/mock_store.go
@@ -3153,6 +3153,301 @@ func (_c *MockStore_InstallKeyUpdate_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// InstanceAPIKeyCreate provides a mock function for the type MockStore
+func (_mock *MockStore) InstanceAPIKeyCreate(ctx context.Context, apiKey *models.InstanceAPIKey) (string, error) {
+	ret := _mock.Called(ctx, apiKey)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstanceAPIKeyCreate")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *models.InstanceAPIKey) (string, error)); ok {
+		return returnFunc(ctx, apiKey)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *models.InstanceAPIKey) string); ok {
+		r0 = returnFunc(ctx, apiKey)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *models.InstanceAPIKey) error); ok {
+		r1 = returnFunc(ctx, apiKey)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_InstanceAPIKeyCreate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InstanceAPIKeyCreate'
+type MockStore_InstanceAPIKeyCreate_Call struct {
+	*mock.Call
+}
+
+// InstanceAPIKeyCreate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - apiKey *models.InstanceAPIKey
+func (_e *MockStore_Expecter) InstanceAPIKeyCreate(ctx any, apiKey any) *MockStore_InstanceAPIKeyCreate_Call {
+	return &MockStore_InstanceAPIKeyCreate_Call{Call: _e.mock.On("InstanceAPIKeyCreate", ctx, apiKey)}
+}
+
+func (_c *MockStore_InstanceAPIKeyCreate_Call) Run(run func(ctx context.Context, apiKey *models.InstanceAPIKey)) *MockStore_InstanceAPIKeyCreate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *models.InstanceAPIKey
+		if args[1] != nil {
+			arg1 = args[1].(*models.InstanceAPIKey)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyCreate_Call) Return(insertedID string, err error) *MockStore_InstanceAPIKeyCreate_Call {
+	_c.Call.Return(insertedID, err)
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyCreate_Call) RunAndReturn(run func(ctx context.Context, apiKey *models.InstanceAPIKey) (string, error)) *MockStore_InstanceAPIKeyCreate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InstanceAPIKeyDelete provides a mock function for the type MockStore
+func (_mock *MockStore) InstanceAPIKeyDelete(ctx context.Context, name string) error {
+	ret := _mock.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstanceAPIKeyDelete")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_InstanceAPIKeyDelete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InstanceAPIKeyDelete'
+type MockStore_InstanceAPIKeyDelete_Call struct {
+	*mock.Call
+}
+
+// InstanceAPIKeyDelete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *MockStore_Expecter) InstanceAPIKeyDelete(ctx any, name any) *MockStore_InstanceAPIKeyDelete_Call {
+	return &MockStore_InstanceAPIKeyDelete_Call{Call: _e.mock.On("InstanceAPIKeyDelete", ctx, name)}
+}
+
+func (_c *MockStore_InstanceAPIKeyDelete_Call) Run(run func(ctx context.Context, name string)) *MockStore_InstanceAPIKeyDelete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyDelete_Call) Return(err error) *MockStore_InstanceAPIKeyDelete_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyDelete_Call) RunAndReturn(run func(ctx context.Context, name string) error) *MockStore_InstanceAPIKeyDelete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InstanceAPIKeyList provides a mock function for the type MockStore
+func (_mock *MockStore) InstanceAPIKeyList(ctx context.Context, opts ...store.QueryOption) ([]models.InstanceAPIKey, int, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, opts)
+	} else {
+		tmpRet = _mock.Called(ctx)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstanceAPIKeyList")
+	}
+
+	var r0 []models.InstanceAPIKey
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...store.QueryOption) ([]models.InstanceAPIKey, int, error)); ok {
+		return returnFunc(ctx, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, ...store.QueryOption) []models.InstanceAPIKey); ok {
+		r0 = returnFunc(ctx, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.InstanceAPIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, ...store.QueryOption) int); ok {
+		r1 = returnFunc(ctx, opts...)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, ...store.QueryOption) error); ok {
+		r2 = returnFunc(ctx, opts...)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockStore_InstanceAPIKeyList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InstanceAPIKeyList'
+type MockStore_InstanceAPIKeyList_Call struct {
+	*mock.Call
+}
+
+// InstanceAPIKeyList is a helper method to define mock.On call
+//   - ctx context.Context
+//   - opts ...store.QueryOption
+func (_e *MockStore_Expecter) InstanceAPIKeyList(ctx any, opts ...any) *MockStore_InstanceAPIKeyList_Call {
+	return &MockStore_InstanceAPIKeyList_Call{Call: _e.mock.On("InstanceAPIKeyList",
+		append([]any{ctx}, opts...)...)}
+}
+
+func (_c *MockStore_InstanceAPIKeyList_Call) Run(run func(ctx context.Context, opts ...store.QueryOption)) *MockStore_InstanceAPIKeyList_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []store.QueryOption
+		var variadicArgs []store.QueryOption
+		if len(args) > 1 {
+			variadicArgs = args[1].([]store.QueryOption)
+		}
+		arg1 = variadicArgs
+		run(
+			arg0,
+			arg1...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyList_Call) Return(apiKeys []models.InstanceAPIKey, count int, err error) *MockStore_InstanceAPIKeyList_Call {
+	_c.Call.Return(apiKeys, count, err)
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyList_Call) RunAndReturn(run func(ctx context.Context, opts ...store.QueryOption) ([]models.InstanceAPIKey, int, error)) *MockStore_InstanceAPIKeyList_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// InstanceAPIKeyResolve provides a mock function for the type MockStore
+func (_mock *MockStore) InstanceAPIKeyResolve(ctx context.Context, resolver store.InstanceAPIKeyResolver, value string, opts ...store.QueryOption) (*models.InstanceAPIKey, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, resolver, value, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, resolver, value)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstanceAPIKeyResolve")
+	}
+
+	var r0 *models.InstanceAPIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, store.InstanceAPIKeyResolver, string, ...store.QueryOption) (*models.InstanceAPIKey, error)); ok {
+		return returnFunc(ctx, resolver, value, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, store.InstanceAPIKeyResolver, string, ...store.QueryOption) *models.InstanceAPIKey); ok {
+		r0 = returnFunc(ctx, resolver, value, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.InstanceAPIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, store.InstanceAPIKeyResolver, string, ...store.QueryOption) error); ok {
+		r1 = returnFunc(ctx, resolver, value, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_InstanceAPIKeyResolve_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InstanceAPIKeyResolve'
+type MockStore_InstanceAPIKeyResolve_Call struct {
+	*mock.Call
+}
+
+// InstanceAPIKeyResolve is a helper method to define mock.On call
+//   - ctx context.Context
+//   - resolver store.InstanceAPIKeyResolver
+//   - value string
+//   - opts ...store.QueryOption
+func (_e *MockStore_Expecter) InstanceAPIKeyResolve(ctx any, resolver any, value any, opts ...any) *MockStore_InstanceAPIKeyResolve_Call {
+	return &MockStore_InstanceAPIKeyResolve_Call{Call: _e.mock.On("InstanceAPIKeyResolve",
+		append([]any{ctx, resolver, value}, opts...)...)}
+}
+
+func (_c *MockStore_InstanceAPIKeyResolve_Call) Run(run func(ctx context.Context, resolver store.InstanceAPIKeyResolver, value string, opts ...store.QueryOption)) *MockStore_InstanceAPIKeyResolve_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 store.InstanceAPIKeyResolver
+		if args[1] != nil {
+			arg1 = args[1].(store.InstanceAPIKeyResolver)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 []store.QueryOption
+		var variadicArgs []store.QueryOption
+		if len(args) > 3 {
+			variadicArgs = args[3].([]store.QueryOption)
+		}
+		arg3 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyResolve_Call) Return(instanceAPIKey *models.InstanceAPIKey, err error) *MockStore_InstanceAPIKeyResolve_Call {
+	_c.Call.Return(instanceAPIKey, err)
+	return _c
+}
+
+func (_c *MockStore_InstanceAPIKeyResolve_Call) RunAndReturn(run func(ctx context.Context, resolver store.InstanceAPIKeyResolver, value string, opts ...store.QueryOption) (*models.InstanceAPIKey, error)) *MockStore_InstanceAPIKeyResolve_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MembershipInvitationCreate provides a mock function for the type MockStore
 func (_mock *MockStore) MembershipInvitationCreate(ctx context.Context, invitation *models.MembershipInvitation) error {
 	ret := _mock.Called(ctx, invitation)

--- a/server/api/store/pg/entity/entity.go
+++ b/server/api/store/pg/entity/entity.go
@@ -11,6 +11,7 @@ func Entities() []any {
 		(*AccessPolicy)(nil),
 		(*APIKey)(nil),
 		(*Device)(nil),
+		(*InstanceAPIKey)(nil),
 		(*Membership)(nil),
 		(*Namespace)(nil),
 		(*PrivateKey)(nil),

--- a/server/api/store/pg/entity/instance-api-key.go
+++ b/server/api/store/pg/entity/instance-api-key.go
@@ -1,0 +1,53 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/uptrace/bun"
+)
+
+// InstanceAPIKey is a row of instance_api_keys, holding a credential that authenticates as an
+// instance administrator.
+type InstanceAPIKey struct {
+	bun.BaseModel `bun:"table:instance_api_keys"`
+
+	KeyDigest string    `bun:"key_digest,pk"`
+	Name      string    `bun:"name"`
+	UserID    string    `bun:"user_id"`
+	CreatedAt time.Time `bun:"created_at"`
+	UpdatedAt time.Time `bun:"updated_at"`
+	ExpiresAt time.Time `bun:"expires_at"`
+}
+
+// InstanceAPIKeyFromModel projects an instance API key into its row form.
+func InstanceAPIKeyFromModel(model *models.InstanceAPIKey) *InstanceAPIKey {
+	if model == nil {
+		return nil
+	}
+
+	return &InstanceAPIKey{
+		KeyDigest: model.ID,
+		Name:      model.Name,
+		UserID:    model.CreatedBy,
+		CreatedAt: model.CreatedAt,
+		UpdatedAt: model.UpdatedAt,
+		ExpiresAt: model.ExpiresAt,
+	}
+}
+
+// InstanceAPIKeyToModel rebuilds an instance API key from its row.
+func InstanceAPIKeyToModel(entity *InstanceAPIKey) *models.InstanceAPIKey {
+	if entity == nil {
+		return nil
+	}
+
+	return &models.InstanceAPIKey{
+		ID:        entity.KeyDigest,
+		Name:      entity.Name,
+		CreatedBy: entity.UserID,
+		CreatedAt: entity.CreatedAt.UTC(),
+		UpdatedAt: entity.UpdatedAt.UTC(),
+		ExpiresAt: entity.ExpiresAt.UTC(),
+	}
+}

--- a/server/api/store/pg/instance-api-key.go
+++ b/server/api/store/pg/instance-api-key.go
@@ -1,0 +1,100 @@
+package pg
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/clock"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/store"
+	"github.com/shellhub-io/shellhub/server/api/store/pg/entity"
+	"github.com/uptrace/bun"
+)
+
+// InstanceAPIKeyCreate implements [store.InstanceAPIKeyStore].
+func (pg *Pg) InstanceAPIKeyCreate(ctx context.Context, apiKey *models.InstanceAPIKey) (string, error) {
+	db := pg.GetConnection(ctx)
+
+	apiKey.CreatedAt = clock.Now()
+	apiKey.UpdatedAt = clock.Now()
+
+	if _, err := db.NewInsert().Model(entity.InstanceAPIKeyFromModel(apiKey)).Exec(ctx); err != nil {
+		return "", fromSQLError(err)
+	}
+
+	return apiKey.ID, nil
+}
+
+// InstanceAPIKeyResolve implements [store.InstanceAPIKeyStore].
+func (pg *Pg) InstanceAPIKeyResolve(ctx context.Context, resolver store.InstanceAPIKeyResolver, value string, opts ...store.QueryOption) (*models.InstanceAPIKey, error) {
+	db := pg.GetConnection(ctx)
+
+	column, err := InstanceAPIKeyResolverToString(resolver)
+	if err != nil {
+		return nil, err
+	}
+
+	apiKey := new(entity.InstanceAPIKey)
+
+	query := db.NewSelect().Model(apiKey).Where("? = ?", bun.Ident(column), value)
+	if query, err = applyOptions(ctx, query, opts...); err != nil {
+		return nil, err
+	}
+
+	if err := query.Scan(ctx); err != nil {
+		return nil, fromSQLError(err)
+	}
+
+	return entity.InstanceAPIKeyToModel(apiKey), nil
+}
+
+// InstanceAPIKeyList implements [store.InstanceAPIKeyStore].
+func (pg *Pg) InstanceAPIKeyList(ctx context.Context, opts ...store.QueryOption) ([]models.InstanceAPIKey, int, error) {
+	db := pg.GetConnection(ctx)
+
+	entities := make([]entity.InstanceAPIKey, 0)
+
+	query, err := applyOptions(ctx, db.NewSelect().Model(&entities), opts...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	count, err := query.ScanAndCount(ctx)
+	if err != nil {
+		return nil, 0, fromSQLError(err)
+	}
+
+	apiKeys := make([]models.InstanceAPIKey, len(entities))
+	for i, e := range entities {
+		apiKeys[i] = *entity.InstanceAPIKeyToModel(&e)
+	}
+
+	return apiKeys, count, nil
+}
+
+// InstanceAPIKeyDelete implements [store.InstanceAPIKeyStore].
+func (pg *Pg) InstanceAPIKeyDelete(ctx context.Context, name string) error {
+	db := pg.GetConnection(ctx)
+
+	r, err := db.NewDelete().Model((*entity.InstanceAPIKey)(nil)).Where("name = ?", name).Exec(ctx)
+	if err != nil {
+		return fromSQLError(err)
+	}
+
+	if rowsAffected, err := r.RowsAffected(); err != nil || rowsAffected == 0 {
+		return store.ErrNoDocuments
+	}
+
+	return nil
+}
+
+// InstanceAPIKeyResolverToString maps a resolver onto the column it looks up.
+func InstanceAPIKeyResolverToString(resolver store.InstanceAPIKeyResolver) (string, error) {
+	switch resolver {
+	case store.InstanceAPIKeyIDResolver:
+		return "key_digest", nil
+	case store.InstanceAPIKeyNameResolver:
+		return "name", nil
+	default:
+		return "", store.ErrResolverNotFound
+	}
+}

--- a/server/api/store/pg/migrations/025_instance_api_keys.tx.down.sql
+++ b/server/api/store/pg/migrations/025_instance_api_keys.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS instance_api_keys;

--- a/server/api/store/pg/migrations/025_instance_api_keys.tx.up.sql
+++ b/server/api/store/pg/migrations/025_instance_api_keys.tx.up.sql
@@ -1,0 +1,21 @@
+-- Instance API keys: credentials that authenticate as an instance administrator rather than as a
+-- member of a namespace. They live in their own table because api_keys.namespace_id is part of that
+-- table's primary key and so cannot be null, and because keeping the two apart is what makes a
+-- namespace key structurally incapable of resolving to an administrator.
+--
+-- expires_at is NOT NULL: unlike a namespace key, an instance key cannot be created without an
+-- expiration date.
+CREATE TABLE instance_api_keys (
+    key_digest character(64) NOT NULL,
+    name character varying NOT NULL,
+    user_id uuid NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    PRIMARY KEY (key_digest),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+--bun:split
+
+CREATE UNIQUE INDEX instance_api_keys_name_unique ON instance_api_keys USING btree (name);

--- a/server/api/store/pg/store_test.go
+++ b/server/api/store/pg/store_test.go
@@ -104,6 +104,15 @@ func TestPgStore(t *testing.T) {
 		suite.TestAPIKeyDeleteAllByCreator(t)
 	})
 
+	runSubSuite(t, "InstanceAPIKeyStore", func(t *testing.T, suite *storetest.Suite) {
+		t.Helper()
+
+		suite.TestInstanceAPIKeyCreate(t)
+		suite.TestInstanceAPIKeyResolve(t)
+		suite.TestInstanceAPIKeyList(t)
+		suite.TestInstanceAPIKeyDelete(t)
+	})
+
 	runSubSuite(t, "InstallKeyStore", func(t *testing.T, suite *storetest.Suite) {
 		t.Helper()
 

--- a/server/api/store/store.go
+++ b/server/api/store/store.go
@@ -17,6 +17,7 @@ type Store interface {
 	PrivateKeyStore
 	StatsStore
 	APIKeyStore
+	InstanceAPIKeyStore
 	InstallKeyStore
 	TransactionStore
 	SystemStore

--- a/server/api/store/storetest/helpers.go
+++ b/server/api/store/storetest/helpers.go
@@ -637,3 +637,63 @@ func (s *Suite) CreatePrivateKey(t *testing.T, opts ...PrivateKeyOption) string 
 
 	return key.Fingerprint
 }
+
+// InstanceAPIKeyOption allows customization of test instance API keys
+type InstanceAPIKeyOption func(*models.InstanceAPIKey)
+
+// WithInstanceAPIKeyName sets the name
+func WithInstanceAPIKeyName(name string) InstanceAPIKeyOption {
+	return func(key *models.InstanceAPIKey) {
+		key.Name = name
+	}
+}
+
+// WithInstanceAPIKeyCreatedBy sets the creating user
+func WithInstanceAPIKeyCreatedBy(userID string) InstanceAPIKeyOption {
+	return func(key *models.InstanceAPIKey) {
+		key.CreatedBy = userID
+	}
+}
+
+// WithInstanceAPIKeyExpiresAt sets the expiration date
+func WithInstanceAPIKeyExpiresAt(expiresAt time.Time) InstanceAPIKeyOption {
+	return func(key *models.InstanceAPIKey) {
+		key.ExpiresAt = expiresAt
+	}
+}
+
+// CreateInstanceAPIKey creates an instance API key with default or customized values.
+// Returns the generated key ID (SHA256 hash of the prefixed plain key).
+// If the creating user is not provided via options, one is created.
+func (s *Suite) CreateInstanceAPIKey(t *testing.T, opts ...InstanceAPIKeyOption) string {
+	t.Helper()
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	plainKey := models.InstanceAPIKeyPrefix + uuid.Generate()
+	keySum := sha256.Sum256([]byte(plainKey))
+	hashedKey := hex.EncodeToString(keySum[:])
+
+	key := &models.InstanceAPIKey{
+		ID:        hashedKey,
+		Name:      "instance_apikey_" + uniqueHex(t, 16),
+		CreatedBy: "",
+		CreatedAt: clock.Now(),
+		UpdatedAt: clock.Now(),
+		ExpiresAt: clock.Now().AddDate(0, 0, 30),
+	}
+
+	for _, opt := range opts {
+		opt(key)
+	}
+
+	if key.CreatedBy == "" {
+		key.CreatedBy = s.CreateUser(t)
+	}
+
+	keyID, err := st.InstanceAPIKeyCreate(ctx, key)
+	require.NoError(t, err)
+	require.NotEmpty(t, keyID)
+
+	return key.ID
+}

--- a/server/api/store/storetest/instance_api_key_tests.go
+++ b/server/api/store/storetest/instance_api_key_tests.go
@@ -1,0 +1,148 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/clock"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstanceAPIKeyCreate exercises InstanceAPIKeyCreate against the store under test.
+func (s *Suite) TestInstanceAPIKeyCreate(t *testing.T) {
+	t.Run("succeeds when data is valid", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		digest := s.CreateInstanceAPIKey(t)
+		assert.NotEmpty(t, digest)
+	})
+
+	t.Run("fails when the name is already taken", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		ctx := context.Background()
+		st := s.provider.Store()
+
+		s.CreateInstanceAPIKey(t, WithInstanceAPIKeyName("billing-export"))
+
+		duplicated := &models.InstanceAPIKey{
+			ID:        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			Name:      "billing-export",
+			CreatedBy: s.CreateUser(t),
+			ExpiresAt: clock.Now().AddDate(0, 0, 30),
+		}
+
+		_, err := st.InstanceAPIKeyCreate(ctx, duplicated)
+		require.ErrorIs(t, err, store.ErrDuplicate)
+	})
+}
+
+// TestInstanceAPIKeyResolve exercises InstanceAPIKeyResolve against the store under test.
+func (s *Suite) TestInstanceAPIKeyResolve(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	t.Run("fails when the key is not found", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		apiKey, err := st.InstanceAPIKeyResolve(ctx, store.InstanceAPIKeyIDResolver, "nonexistent")
+		require.ErrorIs(t, err, store.ErrNoDocuments)
+		assert.Nil(t, apiKey)
+	})
+
+	t.Run("fails when the resolver is unknown", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		apiKey, err := st.InstanceAPIKeyResolve(ctx, store.InstanceAPIKeyResolver(0), "whatever")
+		require.ErrorIs(t, err, store.ErrResolverNotFound)
+		assert.Nil(t, apiKey)
+	})
+
+	t.Run("succeeds when resolving by digest", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		userID := s.CreateUser(t)
+		expiresAt := clock.Now().AddDate(0, 0, 90).UTC().Truncate(time.Second)
+		digest := s.CreateInstanceAPIKey(t,
+			WithInstanceAPIKeyName("license-sync"),
+			WithInstanceAPIKeyCreatedBy(userID),
+			WithInstanceAPIKeyExpiresAt(expiresAt),
+		)
+
+		apiKey, err := st.InstanceAPIKeyResolve(ctx, store.InstanceAPIKeyIDResolver, digest)
+		require.NoError(t, err)
+		require.NotNil(t, apiKey)
+		assert.Equal(t, digest, apiKey.ID)
+		assert.Equal(t, "license-sync", apiKey.Name)
+		assert.Equal(t, userID, apiKey.CreatedBy)
+		assert.WithinDuration(t, expiresAt, apiKey.ExpiresAt, time.Second)
+	})
+
+	t.Run("succeeds when resolving by name", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		digest := s.CreateInstanceAPIKey(t, WithInstanceAPIKeyName("user-export"))
+
+		apiKey, err := st.InstanceAPIKeyResolve(ctx, store.InstanceAPIKeyNameResolver, "user-export")
+		require.NoError(t, err)
+		require.NotNil(t, apiKey)
+		assert.Equal(t, digest, apiKey.ID)
+	})
+}
+
+// TestInstanceAPIKeyList exercises InstanceAPIKeyList against the store under test.
+func (s *Suite) TestInstanceAPIKeyList(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	t.Run("succeeds when there are no keys", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		apiKeys, count, err := st.InstanceAPIKeyList(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+		assert.Empty(t, apiKeys)
+	})
+
+	t.Run("succeeds when keys exist", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		s.CreateInstanceAPIKey(t, WithInstanceAPIKeyName("first"))
+		s.CreateInstanceAPIKey(t, WithInstanceAPIKeyName("second"))
+
+		apiKeys, count, err := st.InstanceAPIKeyList(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		require.Len(t, apiKeys, 2)
+
+		names := []string{apiKeys[0].Name, apiKeys[1].Name}
+		assert.ElementsMatch(t, []string{"first", "second"}, names)
+	})
+}
+
+// TestInstanceAPIKeyDelete exercises InstanceAPIKeyDelete against the store under test.
+func (s *Suite) TestInstanceAPIKeyDelete(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	t.Run("fails when the key is not found", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		require.ErrorIs(t, st.InstanceAPIKeyDelete(ctx, "nonexistent"), store.ErrNoDocuments)
+	})
+
+	t.Run("succeeds when the key exists", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		s.CreateInstanceAPIKey(t, WithInstanceAPIKeyName("retired"))
+
+		require.NoError(t, st.InstanceAPIKeyDelete(ctx, "retired"))
+
+		_, err := st.InstanceAPIKeyResolve(ctx, store.InstanceAPIKeyNameResolver, "retired")
+		require.ErrorIs(t, err, store.ErrNoDocuments)
+	})
+}

--- a/server/api/store/storetest/suite.go
+++ b/server/api/store/storetest/suite.go
@@ -88,6 +88,13 @@ func (s *Suite) Run(t *testing.T) {
 		s.TestAPIKeyDelete(t)
 	})
 
+	t.Run("InstanceAPIKeyStore", func(t *testing.T) {
+		s.TestInstanceAPIKeyCreate(t)
+		s.TestInstanceAPIKeyResolve(t)
+		s.TestInstanceAPIKeyList(t)
+		s.TestInstanceAPIKeyDelete(t)
+	})
+
 	t.Run("InstallKeyStore", func(t *testing.T) {
 		s.TestInstallKeyEventCreate(t)
 		s.TestInstallKeyEventList(t)

--- a/ui/apps/console/src/App.tsx
+++ b/ui/apps/console/src/App.tsx
@@ -69,6 +69,9 @@ const AdminDevices = lazy(() => import("./pages/admin/devices"));
 const AdminDeviceDetails = lazy(
   () => import("./pages/admin/devices/AdminDeviceDetails"),
 );
+const AdminInstanceApiKeys = lazy(
+  () => import("./pages/admin/instance-api-keys/InstanceApiKeys"),
+);
 const AdminFirewallRules = lazy(() => import("./pages/admin/firewall-rules"));
 const AdminFirewallRuleDetails = lazy(
   () => import("./pages/admin/firewall-rules/AdminFirewallRuleDetails"),
@@ -206,6 +209,10 @@ export default function App() {
                     <Route
                       path="/admin/sessions/:uid"
                       element={<AdminSessionDetails />}
+                    />
+                    <Route
+                      path="/admin/instance-api-keys"
+                      element={<AdminInstanceApiKeys />}
                     />
                     <Route
                       path="/admin/settings/authentication"

--- a/ui/apps/console/src/components/layout/AdminSidebar.tsx
+++ b/ui/apps/console/src/components/layout/AdminSidebar.tsx
@@ -10,6 +10,7 @@ import {
   MegaphoneIcon,
   Cog6ToothIcon,
   KeyIcon,
+  LockClosedIcon,
   DocumentCheckIcon,
   ChevronDownIcon,
 } from "@heroicons/react/24/outline";
@@ -90,6 +91,11 @@ const settingsGroup: NavGroup = {
       to: "/admin/settings/authentication",
       label: "Authentication",
       icon: <KeyIcon className={navIcon} />,
+    },
+    {
+      to: "/admin/instance-api-keys",
+      label: "Instance API Keys",
+      icon: <LockClosedIcon className={navIcon} />,
     },
     {
       to: "/admin/license",

--- a/ui/apps/console/src/hooks/useInstanceApiKeyMutations.ts
+++ b/ui/apps/console/src/hooks/useInstanceApiKeyMutations.ts
@@ -1,0 +1,32 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  createInstanceApiKeyMutation,
+  deleteInstanceApiKeyMutation,
+} from "@/client";
+import { useInvalidateByIds } from "./useInvalidateQueries";
+
+/**
+ * Creates an instance API key, refreshing the list. The response carries the only copy of the
+ * secret the caller will ever see, so it has to be shown before the mutation's data is discarded.
+ */
+export function useCreateInstanceApiKey() {
+  const invalidate = useInvalidateByIds("listInstanceApiKeys");
+
+  return useMutation({
+    ...createInstanceApiKeyMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+/**
+ * Revokes an instance API key, refreshing the list. Anything still authenticating with it starts
+ * failing at once.
+ */
+export function useDeleteInstanceApiKey() {
+  const invalidate = useInvalidateByIds("listInstanceApiKeys");
+
+  return useMutation({
+    ...deleteInstanceApiKeyMutation(),
+    onSuccess: invalidate,
+  });
+}

--- a/ui/apps/console/src/hooks/useInstanceApiKeys.ts
+++ b/ui/apps/console/src/hooks/useInstanceApiKeys.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  listInstanceApiKeys,
+  listInstanceApiKeysQueryKey,
+  type ListInstanceApiKeysData,
+  type InstanceApiKey,
+} from "@/client";
+import { paginatedQueryFn, type PaginatedResult } from "@/api/pagination";
+
+interface UseInstanceApiKeysParams {
+  page?: number;
+  perPage?: number;
+  orderBy?: "asc" | "desc";
+}
+
+/**
+ * A page of the instance's admin API keys, newest first.
+ */
+export function useInstanceApiKeys({
+  page = 1,
+  perPage = 10,
+  orderBy = "desc",
+}: UseInstanceApiKeysParams = {}) {
+  const options = {
+    query: { page, per_page: perPage, order_by: orderBy },
+  } satisfies { query: ListInstanceApiKeysData["query"] };
+
+  const result = useQuery<PaginatedResult<InstanceApiKey>>({
+    queryKey: listInstanceApiKeysQueryKey(options),
+    queryFn: paginatedQueryFn(listInstanceApiKeys, options),
+  });
+
+  return {
+    apiKeys: result.data?.data ?? [],
+    totalCount: result.data?.totalCount ?? 0,
+    isLoading: result.isLoading,
+    error: result.error,
+  };
+}

--- a/ui/apps/console/src/pages/admin/instance-api-keys/GenerateInstanceKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/instance-api-keys/GenerateInstanceKeyDrawer.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { KeyIcon, CheckIcon } from "@heroicons/react/24/outline";
+import { Card, Button } from "@shellhub/design-system/primitives";
+import { isSdkError } from "@/api/errors";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useCreateInstanceApiKey } from "@/hooks/useInstanceApiKeyMutations";
+import CopyButton from "@/components/common/CopyButton";
+import Drawer from "@/components/common/Drawer";
+import {
+  FormInputField,
+  FormRadioGroupField,
+} from "@/components/common/fields/rhf";
+import FormRootError from "@/components/common/fields/FormRootError";
+import RadioPill from "@/components/common/fields/RadioPill";
+import { useDrawerForm } from "@/hooks/useDrawerForm";
+import { LABEL } from "@/utils/styles";
+import {
+  generateInstanceKeySchema,
+  GENERATE_INSTANCE_KEY_DEFAULTS,
+  buildGenerateInstanceKeyBody,
+  INSTANCE_KEY_EXPIRY_OPTIONS,
+  type GenerateInstanceKeyFormValues,
+} from "./schemas";
+
+/**
+ * Creates an instance API key and shows it. This is the only time the secret is readable, so the
+ * drawer has to present it before it can be closed.
+ */
+function GenerateInstanceKeyDrawer({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const createKey = useCreateInstanceApiKey();
+  const form = useDrawerForm(
+    open,
+    generateInstanceKeySchema,
+    GENERATE_INSTANCE_KEY_DEFAULTS,
+  );
+  const {
+    control,
+    handleSubmit,
+    setError,
+    clearErrors,
+    formState: { isValid, isSubmitting, errors },
+  } = form;
+
+  const [generatedKey, setGeneratedKey] = useState("");
+
+  useResetOnOpen(open, () => setGeneratedKey(""));
+
+  const onValid = async (values: GenerateInstanceKeyFormValues) => {
+    if (!values.expiresAt) return;
+
+    clearErrors("root");
+    try {
+      const result = await createKey.mutateAsync({
+        body: buildGenerateInstanceKeyBody({
+          name: values.name,
+          expiresAt: values.expiresAt,
+        }),
+      });
+      setGeneratedKey(result.id);
+    } catch (err) {
+      if (isSdkError(err) && err.status === 409) {
+        setError("name", { message: "That name is already taken." });
+      } else {
+        setError("root", {
+          message: "Failed to generate the instance API key.",
+        });
+      }
+    }
+  };
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title="Generate Instance API Key"
+      footer={
+        generatedKey ? (
+          <Button variant="primary" onClick={onClose}>
+            Done
+          </Button>
+        ) : (
+          <>
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => void handleSubmit(onValid)()}
+              disabled={!isValid || isSubmitting}
+              loading={isSubmitting}
+              icon={<KeyIcon className="w-4 h-4" strokeWidth={2} />}
+            >
+              Generate
+            </Button>
+          </>
+        )
+      }
+    >
+      {generatedKey ? (
+        <div className="space-y-5">
+          <div className="flex items-start gap-3 bg-accent-green/[0.06] border border-accent-green/20 rounded-xl px-4 py-3.5">
+            <CheckIcon className="w-5 h-5 text-accent-green shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-medium text-text-primary">
+                Instance API Key Generated
+              </p>
+              <p className="text-2xs text-text-muted mt-0.5">
+                Copy this key now. You won't be able to see it again.
+              </p>
+            </div>
+          </div>
+          <div>
+            <span id="generated-instance-api-key-label" className={LABEL}>
+              Your Instance API Key
+            </span>
+            <Card
+              aria-labelledby="generated-instance-api-key-label"
+              className="rounded-lg px-3.5 py-2.5 flex items-center gap-2"
+            >
+              <code className="flex-1 text-xs font-mono text-accent-cyan break-all select-all">
+                {generatedKey}
+              </code>
+              <CopyButton text={generatedKey} size="md" />
+            </Card>
+          </div>
+        </div>
+      ) : (
+        <form
+          onSubmit={(e) => void handleSubmit(onValid)(e)}
+          className="space-y-5"
+        >
+          <FormInputField
+            name="name"
+            control={control}
+            id="generate-instance-key-name"
+            label="Name"
+            placeholder="e.g. billing-export"
+            maxLength={20}
+          />
+          <FormRadioGroupField
+            name="expiresAt"
+            control={control}
+            label="Expiration"
+            containerClassName="flex flex-wrap gap-1.5"
+          >
+            {INSTANCE_KEY_EXPIRY_OPTIONS.map((opt) => (
+              <RadioPill
+                key={opt.value}
+                value={String(opt.value)}
+                label={opt.label}
+              />
+            ))}
+          </FormRadioGroupField>
+          <FormRootError message={errors.root?.message} />
+        </form>
+      )}
+    </Drawer>
+  );
+}
+
+export default GenerateInstanceKeyDrawer;

--- a/ui/apps/console/src/pages/admin/instance-api-keys/GenerateInstanceKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/instance-api-keys/GenerateInstanceKeyDrawer.tsx
@@ -52,8 +52,6 @@ function GenerateInstanceKeyDrawer({
   useResetOnOpen(open, () => setGeneratedKey(""));
 
   const onValid = async (values: GenerateInstanceKeyFormValues) => {
-    if (!values.expiresAt) return;
-
     clearErrors("root");
     try {
       const result = await createKey.mutateAsync({

--- a/ui/apps/console/src/pages/admin/instance-api-keys/InstanceApiKeys.tsx
+++ b/ui/apps/console/src/pages/admin/instance-api-keys/InstanceApiKeys.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+import { KeyIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
+import { useInstanceApiKeys } from "@/hooks/useInstanceApiKeys";
+import { useDeleteInstanceApiKey } from "@/hooks/useInstanceApiKeyMutations";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
+import { type InstanceApiKey } from "@/client";
+import PageHeader from "@/components/common/PageHeader";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+import DataTable, { type Column } from "@/components/common/DataTable";
+import { formatDateShort } from "@/utils/date";
+import { pageCount } from "@/utils/pagination";
+import GenerateInstanceKeyDrawer from "./GenerateInstanceKeyDrawer";
+
+type InstanceApiKeyListParams = {
+  page: number;
+};
+
+const INSTANCE_API_KEY_LIST_DEFAULTS: InstanceApiKeyListParams = { page: 1 };
+
+function hasExpired(expiresAt: string) {
+  return new Date(expiresAt).getTime() <= Date.now();
+}
+
+/**
+ * The instance API keys page of the admin panel. These keys authenticate as an instance
+ * administrator rather than as a member of a namespace, so they are managed here rather than
+ * alongside a namespace's own keys.
+ */
+function InstanceApiKeys() {
+  const { params, setPage } = usePaginatedListState<InstanceApiKeyListParams>({
+    defaults: INSTANCE_API_KEY_LIST_DEFAULTS,
+  });
+  const page = params.page;
+  const { apiKeys, totalCount, isLoading } = useInstanceApiKeys({ page });
+
+  const deleteKey = useDeleteInstanceApiKey();
+  const [generateOpen, setGenerateOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<InstanceApiKey | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const closeDelete = () => {
+    setDeleteError(null);
+    setDeleteTarget(null);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteError(null);
+    try {
+      await deleteKey.mutateAsync({ path: { name: deleteTarget.name } });
+      if (apiKeys.length === 1 && page > 1) setPage(page - 1);
+      closeDelete();
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error
+          ? err.message
+          : "Failed to revoke the instance API key.",
+      );
+    }
+  };
+
+  const columns: Column<InstanceApiKey>[] = [
+    {
+      key: "name",
+      header: "Name",
+      render: (key) => (
+        <span className="text-sm font-medium text-text-primary">
+          {key.name}
+        </span>
+      ),
+    },
+    {
+      key: "created_at",
+      header: "Created",
+      render: (key) => (
+        <span className="text-xs text-text-secondary">
+          {formatDateShort(key.created_at)}
+        </span>
+      ),
+    },
+    {
+      key: "expires_at",
+      header: "Expires",
+      render: (key) => (
+        <span
+          className={cn(
+            "text-xs",
+            hasExpired(key.expires_at)
+              ? "text-accent-red"
+              : "text-text-secondary",
+          )}
+        >
+          {formatDateShort(key.expires_at)}
+        </span>
+      ),
+    },
+    {
+      key: "actions",
+      header: "Actions",
+      headerClassName: "text-right",
+      render: (key) => (
+        <div className="flex items-center justify-end gap-1">
+          <IconButton
+            variant="danger"
+            title="Revoke"
+            aria-label="Revoke instance API key"
+            onClick={() => setDeleteTarget(key)}
+          >
+            <TrashIcon className="w-4 h-4" />
+          </IconButton>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="animate-fade-in">
+      <PageHeader
+        icon={<KeyIcon className="w-6 h-6" />}
+        overline="Settings"
+        title="Instance API Keys"
+        description="Credentials that authenticate automation as an instance administrator"
+      >
+        <Button
+          onClick={() => setGenerateOpen(true)}
+          icon={<KeyIcon className="w-4 h-4" strokeWidth={2} />}
+        >
+          Generate Key
+        </Button>
+      </PageHeader>
+
+      <div className="flex items-center justify-between mb-5">
+        <p className="text-sm text-text-muted">
+          {totalCount} key{totalCount !== 1 ? "s" : ""}
+        </p>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={apiKeys}
+        rowKey={(key) => key.name}
+        isLoading={isLoading}
+        loadingMessage="Loading instance API keys..."
+        page={page}
+        totalPages={pageCount(totalCount)}
+        onPageChange={setPage}
+        rowClassName={(key) =>
+          hasExpired(key.expires_at)
+            ? "bg-accent-red/[0.03] border-l-2 border-l-accent-red/50"
+            : "border-l-2 border-l-transparent"
+        }
+        emptyState={
+          <div className="text-center">
+            <KeyIcon className="w-10 h-10 text-text-muted/30 mx-auto mb-3" />
+            <p className="text-sm text-text-muted">No instance API keys yet</p>
+            <p className="text-2xs text-text-muted/60 mt-1">
+              Generate a key to automate the admin API
+            </p>
+          </div>
+        }
+      />
+
+      <GenerateInstanceKeyDrawer
+        open={generateOpen}
+        onClose={() => setGenerateOpen(false)}
+      />
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onClose={closeDelete}
+        onConfirm={confirmDelete}
+        title="Revoke Instance API Key"
+        description={
+          <>
+            Are you sure you want to revoke{" "}
+            <span className="font-medium text-text-primary">
+              {deleteTarget?.name}
+            </span>
+            ? Any automation using this key will stop working immediately.
+          </>
+        }
+        confirmLabel="Revoke"
+      >
+        {deleteError && (
+          <p className="text-xs text-accent-red">{deleteError}</p>
+        )}
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+export default InstanceApiKeys;

--- a/ui/apps/console/src/pages/admin/instance-api-keys/__tests__/InstanceApiKeys.test.tsx
+++ b/ui/apps/console/src/pages/admin/instance-api-keys/__tests__/InstanceApiKeys.test.tsx
@@ -83,7 +83,7 @@ describe("InstanceApiKeys", () => {
     ).toBeInTheDocument();
   });
 
-  it("refuses to submit until an expiry is chosen", async () => {
+  it("opens with the shortest expiry already selected", async () => {
     const user = userEvent.setup();
 
     renderPage();
@@ -91,14 +91,15 @@ describe("InstanceApiKeys", () => {
     await user.click(
       await screen.findByRole("button", { name: /generate key/i }),
     );
+
+    const expiry = screen.getByRole("radiogroup", { name: /expiration/i });
+    expect(within(expiry).getByRole("radio", { name: /30 days/i })).toBeChecked();
+
     await user.type(await screen.findByLabelText(/name/i), "license-sync");
 
-    const submit = screen.getByRole("button", { name: /^generate$/i });
-    expect(submit).toBeDisabled();
-
-    await user.click(screen.getByRole("radio", { name: /30 days/i }));
-
-    await waitFor(() => expect(submit).toBeEnabled());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^generate$/i })).toBeEnabled(),
+    );
   });
 
   it("offers no never-expires option", async () => {

--- a/ui/apps/console/src/pages/admin/instance-api-keys/__tests__/InstanceApiKeys.test.tsx
+++ b/ui/apps/console/src/pages/admin/instance-api-keys/__tests__/InstanceApiKeys.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import InstanceApiKeys from "../InstanceApiKeys";
+import type { InstanceApiKey } from "@/client";
+import { createTestWrapper } from "@/tests/wrapper";
+import { mockSdkResponse, paginatedResponse } from "@/tests/sdk";
+import { ClipboardProvider } from "@/components/common/ClipboardProvider";
+
+const sdk = vi.hoisted(() =>
+  mockSdkGen({
+    listInstanceApiKeys: vi.fn(),
+    createInstanceApiKey: vi.fn(),
+    deleteInstanceApiKey: vi.fn(),
+  }),
+);
+
+vi.mock("@/components/common/ConfirmDialog", async () => ({
+  default: (await import("@/tests/mocks")).MockConfirmDialog,
+}));
+
+function mockInstanceApiKey(
+  overrides: Partial<InstanceApiKey> = {},
+): InstanceApiKey {
+  return {
+    name: "billing-export",
+    created_by: "3dd0d1f8-8246-4519-b11a-a3dd33717f65",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    expires_at: "2036-05-31T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sdk.listInstanceApiKeys.mockResolvedValue(
+    paginatedResponse([mockInstanceApiKey()]),
+  );
+  sdk.deleteInstanceApiKey.mockResolvedValue(mockSdkResponse(undefined));
+});
+
+function renderPage() {
+  return render(
+    <ClipboardProvider>
+      <InstanceApiKeys />
+    </ClipboardProvider>,
+    {
+      wrapper: createTestWrapper({
+        initialEntries: ["/admin/instance-api-keys"],
+      }),
+    },
+  );
+}
+
+describe("InstanceApiKeys", () => {
+  it("lists the instance keys the API returns", async () => {
+    renderPage();
+
+    expect(await screen.findByText("billing-export")).toBeInTheDocument();
+  });
+
+  it("shows the plaintext key once after creating one", async () => {
+    const user = userEvent.setup();
+    sdk.createInstanceApiKey.mockResolvedValue(
+      mockSdkResponse({
+        ...mockInstanceApiKey({ name: "license-sync" }),
+        id: "sh_admin_cdfd3cb0-c44e-4e54-b931-6d57713ad159",
+      }),
+    );
+
+    renderPage();
+
+    await user.click(
+      await screen.findByRole("button", { name: /generate key/i }),
+    );
+    await user.type(await screen.findByLabelText(/name/i), "license-sync");
+    await user.click(screen.getByRole("radio", { name: /30 days/i }));
+    await user.click(screen.getByRole("button", { name: /^generate$/i }));
+
+    expect(
+      await screen.findByText("sh_admin_cdfd3cb0-c44e-4e54-b931-6d57713ad159"),
+    ).toBeInTheDocument();
+  });
+
+  it("refuses to submit until an expiry is chosen", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(
+      await screen.findByRole("button", { name: /generate key/i }),
+    );
+    await user.type(await screen.findByLabelText(/name/i), "license-sync");
+
+    const submit = screen.getByRole("button", { name: /^generate$/i });
+    expect(submit).toBeDisabled();
+
+    await user.click(screen.getByRole("radio", { name: /30 days/i }));
+
+    await waitFor(() => expect(submit).toBeEnabled());
+  });
+
+  it("offers no never-expires option", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(
+      await screen.findByRole("button", { name: /generate key/i }),
+    );
+
+    const expiry = screen.getByRole("radiogroup", { name: /expiration/i });
+    expect(within(expiry).queryByRole("radio", { name: /never/i })).toBeNull();
+  });
+
+  it("revokes a key", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(
+      await screen.findByRole("button", { name: /revoke instance api key/i }),
+    );
+    await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+
+    await waitFor(() => {
+      expect(sdk.deleteInstanceApiKey).toHaveBeenCalledWith(
+        expect.objectContaining({ path: { name: "billing-export" } }),
+      );
+    });
+  });
+});

--- a/ui/apps/console/src/pages/admin/instance-api-keys/schemas.ts
+++ b/ui/apps/console/src/pages/admin/instance-api-keys/schemas.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+/**
+ * The expiry choices for an instance API key. There is no "never": an instance-wide credential
+ * that never expires is the one most likely to be forgotten and later found somewhere it should
+ * not be.
+ */
+export const INSTANCE_KEY_EXPIRY_OPTIONS = [
+  { label: "30 days", value: 30 },
+  { label: "60 days", value: 60 },
+  { label: "90 days", value: 90 },
+  { label: "1 year", value: 365 },
+] as const;
+
+/**
+ * Validates the generate-instance-key form.
+ */
+export const generateInstanceKeySchema = z.object({
+  name: z
+    .string()
+    .regex(
+      /^[a-zA-Z0-9_-]{3,20}$/,
+      "Name must be 3-20 characters: letters, numbers, - and _ only.",
+    ),
+  expiresAt: z.enum(["30", "60", "90", "365"]).optional(),
+}).refine((values) => values.expiresAt !== undefined, {
+  message: "Choose how long this key should live.",
+  path: ["expiresAt"],
+});
+
+/**
+ * The generate-instance-key form's values, derived from the schema.
+ */
+export type GenerateInstanceKeyFormValues = z.infer<
+  typeof generateInstanceKeySchema
+>;
+
+/**
+ * What the form starts as. The expiry is deliberately unset, so choosing how long an
+ * instance-wide credential lives is a decision rather than a default the form made.
+ */
+export const GENERATE_INSTANCE_KEY_DEFAULTS: GenerateInstanceKeyFormValues = {
+  name: "",
+  expiresAt: undefined,
+};
+
+/**
+ * A chosen expiry, once the form has been validated.
+ */
+export type InstanceKeyExpiry = NonNullable<
+  GenerateInstanceKeyFormValues["expiresAt"]
+>;
+
+/**
+ * Builds the create request body, converting the radio group's string back into the number the
+ * API expects.
+ */
+export function buildGenerateInstanceKeyBody(values: {
+  name: string;
+  expiresAt: InstanceKeyExpiry;
+}) {
+  return {
+    name: values.name.trim(),
+    expires_at: Number(values.expiresAt) as 30 | 60 | 90 | 365,
+  };
+}

--- a/ui/apps/console/src/pages/admin/instance-api-keys/schemas.ts
+++ b/ui/apps/console/src/pages/admin/instance-api-keys/schemas.ts
@@ -22,10 +22,7 @@ export const generateInstanceKeySchema = z.object({
       /^[a-zA-Z0-9_-]{3,20}$/,
       "Name must be 3-20 characters: letters, numbers, - and _ only.",
     ),
-  expiresAt: z.enum(["30", "60", "90", "365"]).optional(),
-}).refine((values) => values.expiresAt !== undefined, {
-  message: "Choose how long this key should live.",
-  path: ["expiresAt"],
+  expiresAt: z.enum(["30", "60", "90", "365"]),
 });
 
 /**
@@ -36,20 +33,18 @@ export type GenerateInstanceKeyFormValues = z.infer<
 >;
 
 /**
- * What the form starts as. The expiry is deliberately unset, so choosing how long an
- * instance-wide credential lives is a decision rather than a default the form made.
+ * What the form starts as. The expiry opens on the shortest option, matching the namespace key
+ * drawer, so the group is never in the empty state that reads as "selecting this is optional".
  */
 export const GENERATE_INSTANCE_KEY_DEFAULTS: GenerateInstanceKeyFormValues = {
   name: "",
-  expiresAt: undefined,
+  expiresAt: "30",
 };
 
 /**
  * A chosen expiry, once the form has been validated.
  */
-export type InstanceKeyExpiry = NonNullable<
-  GenerateInstanceKeyFormValues["expiresAt"]
->;
+export type InstanceKeyExpiry = GenerateInstanceKeyFormValues["expiresAt"];
 
 /**
  * Builds the create request body, converting the radio group's string back into the number the


### PR DESCRIPTION
> **Related:** shellhub-io/cloud#2532 mounts these routes on the admin surface. Both PRs are one feature and should land together: this one alone adds unreachable handlers, and the cloud one alone will not compile.

## What

Adds a new credential type: an **instance API key**, which authenticates as an instance administrator rather than as a member of a namespace. The plaintext is prefixed `sh_admin_`, sent in the `X-API-KEY` header, and accepted only under `/admin/api`. Keys are minted, listed and revoked from a new admin console page under **Settings → Instance API Keys**.

## Why

Automating the admin surface previously meant driving it with a human administrator's JWT, which expires in an hour and dies with the session. There was no credential that could act instance-wide without a person logging in, so anything scripted against `/admin/api` (usage exports, scheduled reports, provisioning) had no supportable way to authenticate.

Namespace API keys cannot fill this role: they carry a `namespace_id` and a role, and the admin surface has neither. Extending them would have meant a nullable namespace on a credential type where "no namespace" and "some namespace" mean fundamentally different levels of access, which is exactly the ambiguity that leads to a bypass.

## Changes

**Model and storage.** New `models.InstanceAPIKey` and a dedicated `instance_api_keys` table (migration `023`). The keys live in their own table rather than in `api_keys` because `api_keys.namespace_id` is part of that table's primary key and cannot be null. Keeping the two apart is not only modelling tidiness: it is what makes a namespace key structurally incapable of resolving to an administrator, since neither store can reach the other's rows. `expires_at` is `NOT NULL`, a unique index enforces name uniqueness across the instance, and a foreign key on `users` cascades keys away when their creator is deleted.

**Only the digest is stored.** The primary key is a SHA256 digest of the prefixed plaintext, so the plaintext exists exactly once, in the creation response, and a database dump leaks nothing usable. `responses.CreateInstanceAPIKeyFromModel` takes that plaintext as an explicit argument because the model carries only the digest: passing it separately is what stops the digest being returned to the caller by omission.

**Authentication.** `AuthInstanceAPIKey` hashes the incoming key, resolves it by digest, and rejects it unless it is unexpired *and* its creator is still an instance administrator. A demotion therefore revokes every key that user minted, with no explicit revocation step.

**The path guard.** `Resolve` in `routes/middleware/authn.go` branches on the `sh_admin_` prefix **before consulting any store**, so the credential states which kind of key it is instead of the server inferring it from a failed namespace lookup, and refuses the key outright on any path outside `/admin/api`. Without that check the key produced a request shape (`no X-ID` plus `X-Admin: true`) that `RequiresTenant` reads as an admin-panel call, skipping the tenant guard and allowing the key to act on every namespace through endpoints documented as returning only the caller's own. An unusable credential yields no identity rather than an error, and the swallowed error is logged so a store outage stays distinguishable from a bad key.

**Sort allowlist.** `InstanceAPIKeySortFields` restricts `sort_by` to `name`, `created_at`, `updated_at` and `expires_at`, validated in the handler via `query.ValidateSorter`. Without it the client could order by any column on the table, including `key_digest`: not a disclosure of the digests, but an ordering oracle over values the response deliberately omits. This mirrors `APIKeySortFields` and its use in `routes/api-key.go:60`.

**Expiry is mandatory** and must be one of 30, 60, 90 or 365 days, unlike a namespace key which may live forever. 365 maps to a calendar year rather than 365 days.

**Console.** New page, drawer and two hooks. The expiry radio group opens on 30 days, the shortest of the four options and the same default the namespace key drawer uses; a radio group left empty reads as optional, which is the wrong signal for a field the server requires. The plaintext is surfaced once on creation with a copy affordance.

**OpenAPI.** New `instance-api-key` security scheme, two new path files, two new schemas, and a clarification on the existing `api-key` scheme stating it is never accepted on the admin surface. The admin path files now declare `instance-api-key` where they previously declared `api-key`, which was already wrong: those routes never accepted a namespace key.

**gosec.** The three route constants carry `//nolint:gosec` with reasons. G101 matches on the identifier name regardless of the value being a route path.

## Security notes

**Two CodeQL alerts on this diff are false positives and have been dismissed.** CodeQL flags `sha256.Sum256` as a weak hash on a password, in `services/instance-api-key.go` and `storetest/helpers.go`. The hashed value is not a password: it is `models.InstanceAPIKeyPrefix + uuid.Generate()`, a random token with 122 bits of entropy. An expensive KDF raises the per-guess cost against low-entropy human-chosen secrets; there is nothing to guess here, and brute force is already infeasible by a margin no work factor meaningfully changes. A slow hash would also be a per-request cost on every authenticated call to the admin surface. Namespace API keys have always been hashed the same way (`services/api-key.go:81-82`); the alert fires only because these lines are new. Flagging explicitly so a reviewer can disagree.

## Testing

**Automated**

```
./bin/docker-compose exec server sh -c "cd server && go test ./api/..."
./bin/docker-compose exec ui sh -c "cd apps/console && npm run build && npm run lint && npm run test"
```

Note `server/` is its own Go module: running from the repo root reports `[setup failed]` for `api/routes` rather than running it, which is how the sort validation gap initially went unnoticed locally.

Console: 219 files, 3111 tests, `tsc -b` and eslint clean. New coverage lives in `services/instance-api-key_test.go` (minting, the admin check, the expiry set, duplicate names, expired keys, demoted creators), `storetest/instance_api_key_tests.go` (the store contract against a real Postgres via testcontainers), `middleware/authn_instance_api_key_test.go` (the path guard, asserting a prefixed key on `/api/devices`, `/api/namespaces/:tenant` and `/api/users/security` yields no identity and never reaches the store), and `InstanceApiKeys.test.tsx`. The existing `TestListHandlersValidateEveryQueryFieldTheyAccept` covers the sort allowlist by construction.

One pre-existing unrelated failure: `TestInstallScriptRendersAValidShellScript`, because `install.sh` is tracked in git but not mounted into the container.

**Exercising the feature**

Requires `SHELLHUB_EDITION=enterprise` or `cloud`, and both this branch and shellhub-io/cloud#XXX checked out.

1. Log in as an instance administrator and open **Settings → Instance API Keys** in the admin sidebar. If the item is absent, the user is not an instance admin.
2. Mint a key. Confirm the expiry opens on 30 days, and that the plaintext is shown once, prefixed `sh_admin_`. Save it as `$K`.
3. Confirm it authenticates the admin surface:
   ```
   curl -s -H "X-API-Key: $K" http://localhost/admin/api/namespaces | jq '.[0]'
   curl -s -H "X-API-Key: $K" http://localhost/admin/api/devices | jq '.[0]'
   ```
4. **Confirm it cannot escape to the namespace surface.** All three must return `401`:
   ```
   for p in /api/devices /api/namespaces/00000000-0000-4000-0000-000000000000 /api/users/security; do
     curl -s -o /dev/null -w "$p -> %{http_code}\n" -H "X-API-Key: $K" "http://localhost$p"
   done
   ```
5. **Confirm it cannot mint successors.** Must return `403` with an empty body, from `BlockAPIKey`:
   ```
   curl -s -o /dev/null -w "%{http_code}\n" -X POST -H "X-API-Key: $K" -H 'Content-Type: application/json' \
     -d '{"name":"escalate","expires_at":30}' http://localhost/admin/api/instance-api-keys
   ```
   The same applies to listing and deleting: those three routes are JWT-only by design.
6. **Confirm the sort allowlist.** As a logged-in admin, `GET /admin/api/instance-api-keys?sort_by=key_digest` must return `400`, while `sort_by=name` must return `200`.
7. Revoke the key in the console and confirm it immediately returns `401` on the admin surface.
8. Optionally, demote the creating user and confirm their keys stop working without being revoked.

## Follow-ups

- Documentation for the feature on the Astro docs site, deliberately scoped to a separate PR. The endpoints are under `/admin`, so `customer-filter.js` excludes them from the published API reference by design.
