### PR TITLE
ci: stop the Go lint step verifying its config over the network

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -115,6 +115,7 @@ jobs:
           version: v2.11.3
           args: --timeout 2m ${{ matrix.lint_args }} ./...
           skip-cache: true
+          verify: false
 
       - name: Set SHELLHUB_DATABASE for integration tests
         if: matrix.project == 'tests' && matrix.database != '' && steps.filter.outputs.go == 'true' && github.event.pull_request.draft == false


### PR DESCRIPTION
`golangci-lint-action` defaults to `verify: true`, which runs `golangci-lint config verify` before
linting. That command fetches its JSON schema from `golangci-lint.run` and has no offline mode —
there is no `--schema` flag, and a `$schema` key in the config is rejected as an unknown property.

So every push made four requests to a third-party host, one per matrix leg, on the path that gates
merges. On [run 33672076496](https://github.com/shellhub-io/shellhub/actions/runs/33672076496) one
timed out and QA went red on master:

```
##[error]Failed to run: Error: Command failed: golangci-lint config verify
  [../.golangci.yaml] validate: compile schema: failing loading
  "https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The linter never ran. No `.go` file was analysed.

## What this gives up

Tested against the real `.golangci.yaml` with v2.11.3:

| Broken config | `golangci-lint run` | `config verify` |
|---|---|---|
| Unknown linter name | exit 3, `can't load config` | catches |
| YAML syntax / type error | exit 3, `can't read viper config` | catches |
| Unknown top-level key (`linterz:`) | **exit 1, silently ignored** | exit 3, `additional properties not allowed` |

Only the third row is lost. `run` aborts on the other two by itself, so those stay covered.

The gap is real: viper ignores keys it does not recognise, so a misspelled block reads as
configuration and configures nothing. It is accepted because the config changes rarely, a typo in
it is not urgent, and the alternative was letting an external host decide whether master is green.

If the gap starts to matter, the fix is a scheduled job running `config verify` on its own — off
the merge path, where an outage costs nothing.