### PR TITLE
test(install): adopt bats-core for install.sh and its agent wrapper

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -72,3 +72,38 @@ jobs:
           fi
           docker run --rm -v "$PWD:/src" -w /src "$image" \
             sh -c 'apk add --no-cache bats jq >/dev/null && bats tests/ui/gen-config.bats'
+
+  install-sh:
+    name: install.sh
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install bats
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+
+      # No paths filter: install.sh is served from server/api/services/system.go
+      # and drives the agent, so a change on either side can break it without
+      # the script itself appearing in the diff.
+      - name: Lint install.sh
+        run: shellcheck -s sh -S warning install.sh
+
+      - name: Run install.sh tests
+        run: bats install.bats shellhub-agent-wrapper.bats
+
+      # The runner's /bin/sh is dash. Users curl|sh this script onto whatever
+      # they have, so run the same suite where /bin/sh is busybox ash. Read the
+      # version out of the agent's Dockerfile so an alpine bump is covered by
+      # the same guard.
+      - name: Run install.sh tests on busybox
+        run: |
+          version=$(sed -n 's/^ARG ALPINE_VERSION=\(.*\)$/\1/p' agent/Dockerfile)
+          if [ -z "$version" ]; then
+            echo "could not read ALPINE_VERSION from agent/Dockerfile" >&2
+            exit 1
+          fi
+          docker run --rm -v "$PWD:/src" -w /src "alpine:$version" \
+            sh -c 'apk add --no-cache bats >/dev/null && bats install.bats shellhub-agent-wrapper.bats'

--- a/install.bats
+++ b/install.bats
@@ -1,0 +1,924 @@
+#!/usr/bin/env bats
+# Tests for install.sh itself: its functions and its install-method detection.
+# The wrapper it generates is a separate artifact, covered by
+# shellhub-agent-wrapper.bats.
+
+load install.helpers
+
+setup() {
+    setup_install_env
+
+    stub_bin id 'echo 0'
+    skip_enrollment_wait
+
+    export SERVER_ADDRESS="https://cloud.example.test"
+    export AGENT_VERSION="v0.0.0-test"
+    export AGENT_IMAGE="shellhubio/agent:v0.0.0-test"
+    export INSTALL_DIR="$BATS_TEST_TMPDIR/usr-local-bin"
+    export TMP_DIR="$BATS_TEST_TMPDIR/tmp"
+    export AGENT_KEY="$BATS_TEST_TMPDIR/shellhub.key"
+    export PRIVATE_KEY="/host$AGENT_KEY"
+    export PROC_VERSION="$BATS_TEST_TMPDIR/proc-version"
+    export OS_RELEASE="$BATS_TEST_TMPDIR/os-release"
+
+    mkdir -p "$INSTALL_DIR" "$TMP_DIR"
+    echo "Linux version 6.8.0-generic" > "$PROC_VERSION"
+    echo 'NAME="Ubuntu"' > "$OS_RELEASE"
+
+    RUNTIME=docker
+}
+
+skip_enrollment_wait() {
+    touch "$BATS_TEST_TMPDIR/shellhub.key"
+    stub_bin sleep 'exit 0'
+}
+
+with_tenant() {
+    export TENANT_ID="00000000-0000-4000-a000-000000000000"
+}
+
+as_non_root() {
+    stub_bin id 'echo 1000'
+    stub_sudo
+}
+
+stub_sudo() {
+    stub_bin sudo 'echo "sudo $*" >> "$CALLS"; export RAN_UNDER_SUDO=1; exec "$@"'
+}
+
+use_podman() {
+    RUNTIME=podman
+    stub_bin systemctl 'exit 0'
+}
+
+container_install() {
+    [ -x "$STUB_DIR/$RUNTIME" ] || stub_bin "$RUNTIME"
+    call_install "${RUNTIME}_install" "$@"
+}
+
+fake_agent_binary() {
+    export AGENT_BINARY="$BATS_TEST_TMPDIR/fake-agent"
+    printf '#!/bin/sh\necho "agent $*" >> "$CALLS"\nexit %s\n' "${1:-0}" > "$AGENT_BINARY"
+    chmod +x "$AGENT_BINARY"
+}
+
+enter_wsl() {
+    echo "Linux version 5.15.0-microsoft-standard-WSL2 Microsoft" > "$PROC_VERSION"
+    stub_bin find 'echo "$STUB_DIR/wsl.exe"'
+    stub_bin wsl.exe "echo \"WSL version: ${1:-2.0.0.0}\""
+}
+
+@test "check_podman_boot_restart aborts when systemctl is missing" {
+    call_install check_podman_boot_restart
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "systemctl not found"
+    assert_output_contains "SKIP_BOOT_RESTART_CHECK=1"
+}
+
+@test "check_podman_boot_restart aborts when podman-restart.service is disabled" {
+    stub_bin systemctl 'echo "systemctl $*" >> "$CALLS"; exit 1'
+
+    call_install check_podman_boot_restart
+
+    [ "$status" -eq 1 ]
+    assert_called "systemctl is-enabled podman-restart.service"
+    assert_output_contains "podman-restart.service is not enabled"
+    assert_output_contains "sudo systemctl enable podman-restart.service"
+}
+
+@test "check_podman_boot_restart passes silently when podman-restart.service is enabled" {
+    stub_bin systemctl 'echo "systemctl $*" >> "$CALLS"; exit 0'
+
+    call_install check_podman_boot_restart
+
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    assert_called "systemctl is-enabled podman-restart.service"
+}
+
+@test "SKIP_BOOT_RESTART_CHECK installs anyway when systemctl is missing" {
+    export SKIP_BOOT_RESTART_CHECK=1
+
+    call_install check_podman_boot_restart
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "skipping podman-restart.service check"
+    assert_output_contains "will NOT auto-start on boot"
+}
+
+@test "SKIP_BOOT_RESTART_CHECK installs anyway when podman-restart.service is disabled" {
+    export SKIP_BOOT_RESTART_CHECK=1
+    stub_bin systemctl 'echo "systemctl $*" >> "$CALLS"; exit 1'
+
+    call_install check_podman_boot_restart
+
+    [ "$status" -eq 0 ]
+    refute_called "systemctl is-enabled"
+    assert_output_contains "skipping podman-restart.service check"
+}
+
+@test "enrollment_summary reports a pairing code ahead of every other credential" {
+    with_tenant
+    export CODE=ABC123 INSTALL_KEY=key-1
+
+    call_install enrollment_summary
+
+    [ "$output" = "pairing code (pre-authorized)" ]
+}
+
+@test "enrollment_summary reports an install key ahead of a tenant" {
+    with_tenant
+    export INSTALL_KEY=key-1
+
+    call_install enrollment_summary
+
+    [ "$output" = "install key" ]
+}
+
+@test "enrollment_summary reports a tenant as landing pending" {
+    with_tenant
+
+    call_install enrollment_summary
+
+    [ "$output" = "tenant $TENANT_ID (device lands pending)" ]
+}
+
+@test "enrollment_summary points at the login flow when no credential is given" {
+    call_install enrollment_summary
+
+    [ "$output" = "none — enroll with 'shellhub-agent login'" ]
+}
+
+@test "enroll_agent_interactively runs the login flow when no credential names a namespace" {
+    stub_bin shellhub-agent
+
+    call_install enroll_agent_interactively shellhub-agent "$AGENT_KEY"
+
+    [ "$status" -eq 0 ]
+    assert_called "shellhub-agent login"
+}
+
+@test "enroll_agent_interactively waits for the agent key before starting the login flow" {
+    rm -f "$AGENT_KEY"
+    stub_bin sleep 'echo "sleep $*" >> "$CALLS"'
+    stub_bin shellhub-agent
+
+    call_install enroll_agent_interactively shellhub-agent "$AGENT_KEY"
+
+    [ "$status" -eq 0 ]
+    [ "$(grep -c '^sleep 1$' "$CALLS")" -eq 30 ]
+    assert_called "shellhub-agent login"
+}
+
+@test "enroll_agent_interactively does not wait when the agent key is already on disk" {
+    stub_bin sleep 'echo "sleep $*" >> "$CALLS"'
+    stub_bin shellhub-agent
+
+    call_install enroll_agent_interactively shellhub-agent "$AGENT_KEY"
+
+    [ "$status" -eq 0 ]
+    refute_called "sleep"
+}
+
+@test "enroll_agent_interactively survives a login the user abandons" {
+    stub_bin shellhub-agent 'echo "shellhub-agent $*" >> "$CALLS"; exit 130'
+
+    call_install enroll_agent_interactively shellhub-agent "$AGENT_KEY"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "enroll_agent_interactively skips the login flow for a pairing code" {
+    export CODE=ABC123
+    stub_bin shellhub-agent
+
+    call_install enroll_agent_interactively shellhub-agent "$AGENT_KEY"
+
+    [ "$status" -eq 0 ]
+    refute_called "shellhub-agent"
+    assert_output_contains "pre-authorized"
+}
+
+@test "enroll_agent_interactively skips the login flow for an install key" {
+    export INSTALL_KEY=key-1
+    stub_bin shellhub-agent
+
+    call_install enroll_agent_interactively shellhub-agent "$AGENT_KEY"
+
+    [ "$status" -eq 0 ]
+    refute_called "shellhub-agent"
+    assert_output_contains "install key's namespace"
+}
+
+@test "enroll_agent_interactively skips the login flow for a tenant" {
+    with_tenant
+    stub_bin shellhub-agent
+
+    call_install enroll_agent_interactively shellhub-agent "$AGENT_KEY"
+
+    [ "$status" -eq 0 ]
+    refute_called "shellhub-agent"
+    assert_output_contains "appear as pending in the console"
+}
+
+@test "docker_install runs the container with unless-stopped so it survives a reboot" {
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "docker run -d --name=shellhub --restart=unless-stopped"
+}
+
+@test "podman_install runs the container with unless-stopped so podman-restart.service picks it up" {
+    use_podman
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "podman run -d --name=shellhub --replace --restart=unless-stopped"
+}
+
+@test "docker_install grants the agent the host access it needs" {
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "--privileged --net=host --pid=host"
+    assert_called "-v /:/host"
+    assert_called "-v /var/run/docker.sock:/var/run/docker.sock"
+    assert_called "-v /etc/resolv.conf:/etc/resolv.conf"
+}
+
+@test "podman_install grants the agent the host access it needs" {
+    use_podman
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "--privileged --pid=host --security-opt label=disable --network host"
+    assert_called "-v /:/host"
+}
+
+@test "podman_install presents the podman socket to the agent as the docker socket" {
+    use_podman
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "-v /var/run/podman/podman.sock:/var/run/docker.sock"
+}
+
+@test "docker_install labels the agent container so the wrapper can find it" {
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "--label shellhub.role=agent"
+    assert_output_contains "Starting ShellHub container in Agent mode"
+}
+
+@test "podman_install labels the agent container so the wrapper can find it" {
+    use_podman
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "--label shellhub.role=agent"
+}
+
+@test "docker_install treats an explicit agent mode as the default mode" {
+    container_install agent
+
+    [ "$status" -eq 0 ]
+    assert_called "--label shellhub.role=agent"
+    assert_output_contains "Starting ShellHub container in Agent mode"
+}
+
+@test "podman_install treats an explicit agent mode as the default mode" {
+    use_podman
+
+    container_install agent
+
+    [ "$status" -eq 0 ]
+    assert_called "--label shellhub.role=agent"
+}
+
+@test "docker_install omits the agent label in connector mode" {
+    with_tenant
+
+    container_install connector
+
+    [ "$status" -eq 0 ]
+    refute_called "--label shellhub.role=agent"
+    assert_called "--name=shellhub-connector"
+    assert_called "-e SHELLHUB_PRIVATE_KEYS=/host/etc/shellhub/connector/keys"
+}
+
+@test "podman_install omits the agent label in connector mode" {
+    use_podman
+    with_tenant
+
+    container_install connector
+
+    [ "$status" -eq 0 ]
+    refute_called "--label shellhub.role=agent"
+    assert_called "--name=shellhub-connector"
+    assert_called "-e SHELLHUB_PRIVATE_KEYS=/host/etc/shellhub/connector/keys"
+}
+
+@test "docker_install refuses connector mode without a tenant" {
+    container_install connector
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "TENANT_ID is required"
+    refute_called "docker run"
+}
+
+@test "podman_install refuses connector mode without a tenant" {
+    use_podman
+
+    container_install connector
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "TENANT_ID is required"
+    refute_called "podman run"
+}
+
+@test "docker_install rejects an unknown mode" {
+    container_install bogus
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Invalid mode: bogus"
+    refute_called "docker run"
+}
+
+@test "podman_install rejects an unknown mode" {
+    use_podman
+
+    container_install bogus
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Invalid mode: bogus"
+    refute_called "podman run"
+}
+
+@test "docker_install maps credentials and preferences onto the agent environment" {
+    with_tenant
+    export CODE=ABC123 INSTALL_KEY=key-1 KEEPALIVE_INTERVAL=45
+    export PREFERRED_HOSTNAME=box PREFERRED_IDENTITY=eth0
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "-e SHELLHUB_PAIRING_CODE=ABC123"
+    assert_called "-e SHELLHUB_INSTALL_KEY=key-1"
+    assert_called "-e SHELLHUB_KEEPALIVE_INTERVAL=45"
+    assert_called "-e SHELLHUB_PREFERRED_HOSTNAME=box"
+    assert_called "-e SHELLHUB_PREFERRED_IDENTITY=eth0"
+    assert_called "-e SHELLHUB_TENANT_ID=$TENANT_ID"
+    assert_called "-e SHELLHUB_SERVER_ADDRESS=$SERVER_ADDRESS"
+}
+
+@test "podman_install maps credentials and preferences onto the agent environment" {
+    use_podman
+    with_tenant
+    export CODE=ABC123 INSTALL_KEY=key-1 KEEPALIVE_INTERVAL=45
+    export PREFERRED_HOSTNAME=box PREFERRED_IDENTITY=eth0
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "-e SHELLHUB_PAIRING_CODE=ABC123"
+    assert_called "-e SHELLHUB_INSTALL_KEY=key-1"
+    assert_called "-e SHELLHUB_KEEPALIVE_INTERVAL=45"
+    assert_called "-e SHELLHUB_PREFERRED_HOSTNAME=box"
+    assert_called "-e SHELLHUB_PREFERRED_IDENTITY=eth0"
+    assert_called "-e SHELLHUB_TENANT_ID=$TENANT_ID"
+    assert_called "-e SHELLHUB_SERVER_ADDRESS=$SERVER_ADDRESS"
+}
+
+@test "docker_install omits environment variables for options left unset" {
+    container_install
+
+    [ "$status" -eq 0 ]
+    refute_called "SHELLHUB_TENANT_ID"
+    refute_called "SHELLHUB_PAIRING_CODE"
+    refute_called "SHELLHUB_INSTALL_KEY"
+    refute_called "SHELLHUB_KEEPALIVE_INTERVAL"
+    refute_called "SHELLHUB_PREFERRED_"
+    assert_called "-e SHELLHUB_PRIVATE_KEY=$PRIVATE_KEY"
+}
+
+@test "podman_install omits environment variables for options left unset" {
+    use_podman
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    refute_called "SHELLHUB_TENANT_ID"
+    refute_called "SHELLHUB_PAIRING_CODE"
+    refute_called "SHELLHUB_INSTALL_KEY"
+    refute_called "SHELLHUB_KEEPALIVE_INTERVAL"
+    refute_called "SHELLHUB_PREFERRED_"
+    assert_called "-e SHELLHUB_PRIVATE_KEY=$PRIVATE_KEY"
+}
+
+@test "docker_install pulls the agent image by default" {
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "docker pull -q $AGENT_IMAGE"
+    assert_output_contains "Downloading ShellHub container image"
+}
+
+@test "podman_install pulls the agent image by default" {
+    use_podman
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "podman pull -q $AGENT_IMAGE"
+    assert_output_contains "Downloading ShellHub container image"
+}
+
+@test "docker_install skips the pull when the image was overridden" {
+    export AGENT_IMAGE_OVERRIDDEN=1
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    refute_called "docker pull"
+    assert_output_contains "skipping pull"
+}
+
+@test "podman_install skips the pull when the image was overridden" {
+    use_podman
+    export AGENT_IMAGE_OVERRIDDEN=1
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    refute_called "podman pull"
+    assert_output_contains "skipping pull"
+}
+
+@test "docker_install aborts when the image pull fails" {
+    stub_bin docker 'echo "docker $*" >> "$CALLS"; [ "$1" = pull ] && exit 1; exit 0'
+
+    container_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Failed to download shellhub container image"
+    refute_called "docker run"
+}
+
+@test "podman_install aborts when the image pull fails" {
+    use_podman
+    stub_bin podman 'echo "podman $*" >> "$CALLS"; [ "$1" = pull ] && exit 1; exit 0'
+
+    container_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Failed to download shellhub container image"
+    refute_called "podman run"
+}
+
+@test "docker_install honours CONTAINER_NAME" {
+    export CONTAINER_NAME=my-agent
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "--name=my-agent"
+    assert_called "docker rm -f my-agent"
+}
+
+@test "podman_install honours CONTAINER_NAME" {
+    use_podman
+    export CONTAINER_NAME=my-agent
+
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "--name=my-agent"
+}
+
+@test "docker_install removes an existing container so the new one carries the role label" {
+    container_install
+
+    [ "$status" -eq 0 ]
+    assert_called "docker rm -f shellhub"
+}
+
+@test "podman_install checks the boot restart unit before touching podman" {
+    RUNTIME=podman
+
+    container_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "systemctl not found"
+    refute_called "podman"
+}
+
+@test "install_agent_wrapper writes an executable wrapper bound to podman" {
+    call_install install_agent_wrapper podman
+
+    [ "$status" -eq 0 ]
+    [ -x "$INSTALL_DIR/shellhub-agent" ]
+    assert_output_contains "Installed shellhub-agent wrapper at $INSTALL_DIR/shellhub-agent"
+    assert_file_contains "$INSTALL_DIR/shellhub-agent" "podman ps --filter label=shellhub.role=agent"
+    assert_file_contains "$INSTALL_DIR/shellhub-agent" "podman exec"
+    refute_file_contains "$INSTALL_DIR/shellhub-agent" "docker exec"
+}
+
+@test "install_agent_wrapper writes an executable wrapper bound to docker" {
+    call_install install_agent_wrapper docker
+
+    [ "$status" -eq 0 ]
+    [ -x "$INSTALL_DIR/shellhub-agent" ]
+    assert_file_contains "$INSTALL_DIR/shellhub-agent" "docker ps --filter label=shellhub.role=agent"
+    assert_file_contains "$INSTALL_DIR/shellhub-agent" "docker exec"
+    refute_file_contains "$INSTALL_DIR/shellhub-agent" "podman exec"
+}
+
+@test "install_agent_wrapper escalates to write into a root-owned directory" {
+    as_non_root
+
+    call_install install_agent_wrapper docker
+
+    [ "$status" -eq 0 ]
+    assert_called "sudo tee $INSTALL_DIR/shellhub-agent"
+    assert_called "sudo chmod +x $INSTALL_DIR/shellhub-agent"
+}
+
+@test "install_agent_wrapper aborts when the install directory does not exist" {
+    export INSTALL_DIR="$BATS_TEST_TMPDIR/absent"
+
+    call_install install_agent_wrapper docker
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Failed to install shellhub-agent wrapper"
+}
+
+@test "snap_install requires a tenant" {
+    stub_bin snap
+
+    call_install snap_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "TENANT_ID is required"
+    refute_called "snap install"
+}
+
+@test "snap_install refuses an install key it cannot honour" {
+    with_tenant
+    export INSTALL_KEY=key-1
+    stub_bin snap
+
+    call_install snap_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "INSTALL_KEY is not supported by the snap install method"
+    refute_called "snap install"
+}
+
+@test "snap_install aborts when snap is not available" {
+    with_tenant
+
+    call_install snap_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Snap is not installed or not supported on this system"
+}
+
+@test "snap_install configures the service from the environment" {
+    with_tenant
+    export PREFERRED_HOSTNAME=box KEEPALIVE_INTERVAL=45
+    stub_bin snap
+    stub_sudo
+
+    call_install snap_install
+
+    [ "$status" -eq 0 ]
+    assert_called "snap install --classic --channel=latest/stable shellhub"
+    assert_called "snap set shellhub server-address=$SERVER_ADDRESS"
+    assert_called "snap set shellhub tenant-id=$TENANT_ID"
+    assert_called "snap set shellhub preferred-hostname=box"
+    assert_called "snap set shellhub keepalive-interval=45"
+    assert_called "snap start shellhub"
+}
+
+@test "standalone_install passes the credentials on to the agent service" {
+    with_tenant
+    export INSTALL_KEY=key-1 KEEPALIVE_INTERVAL=45
+    fake_agent_binary
+
+    call_install standalone_install
+
+    [ "$status" -eq 0 ]
+    assert_called "agent install --server-address=$SERVER_ADDRESS --tenant-id=$TENANT_ID --install-key=key-1 --keepalive-interval=45"
+    [ -x "$INSTALL_DIR/shellhub-agent" ]
+}
+
+@test "standalone_install escalates when it is not already root" {
+    with_tenant
+    as_non_root
+    fake_agent_binary
+
+    call_install standalone_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "This install method requires root privileges"
+    assert_called "sudo $INSTALL_DIR/shellhub-agent install"
+}
+
+@test "standalone_install removes the binary when the service install fails" {
+    with_tenant
+    fake_agent_binary 1
+
+    call_install standalone_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Failed to install ShellHub agent service"
+    [ ! -e "$INSTALL_DIR/shellhub-agent" ]
+}
+
+@test "docker_uninstall removes the container and the wrapper" {
+    stub_bin docker
+    call_install install_agent_wrapper docker
+
+    call_install docker_uninstall
+
+    [ "$status" -eq 0 ]
+    assert_called "docker rm -f shellhub"
+    [ ! -e "$INSTALL_DIR/shellhub-agent" ]
+}
+
+@test "docker_uninstall escalates when it is not already root" {
+    stub_bin docker
+    call_install install_agent_wrapper docker
+    as_non_root
+
+    call_install docker_uninstall
+
+    [ "$status" -eq 0 ]
+    assert_called "sudo docker rm -f shellhub"
+    assert_called "sudo rm -f $INSTALL_DIR/shellhub-agent"
+}
+
+@test "podman_uninstall removes the container and the wrapper" {
+    stub_bin podman
+    call_install install_agent_wrapper podman
+
+    call_install podman_uninstall
+
+    [ "$status" -eq 0 ]
+    assert_called "podman rm -f shellhub"
+    [ ! -e "$INSTALL_DIR/shellhub-agent" ]
+}
+
+@test "podman_uninstall escalates when it is not already root" {
+    stub_bin podman
+    call_install install_agent_wrapper podman
+    as_non_root
+
+    call_install podman_uninstall
+
+    [ "$status" -eq 0 ]
+    assert_called "sudo podman rm -f shellhub"
+    assert_called "sudo rm -f $INSTALL_DIR/shellhub-agent"
+}
+
+@test "docker_uninstall reports a container that was already gone" {
+    stub_bin docker 'echo "docker $*" >> "$CALLS"; exit 1'
+
+    call_install docker_uninstall
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "not found (may already be removed)"
+}
+
+@test "standalone_uninstall reports a missing binary" {
+    call_install standalone_uninstall
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "ShellHub agent binary not found"
+}
+
+@test "standalone_uninstall stops the service and removes the binary" {
+    with_tenant
+    fake_agent_binary
+    call_install standalone_install
+
+    call_install standalone_uninstall
+
+    [ "$status" -eq 0 ]
+    assert_called "agent uninstall"
+    [ ! -e "$INSTALL_DIR/shellhub-agent" ]
+}
+
+@test "wsl_install aborts when systemd is not enabled" {
+    stub_bin systemctl 'exit 1'
+
+    call_install wsl_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "requires systemd to be enabled"
+}
+
+@test "wsl_install aborts when WSL networking is not mirrored" {
+    stub_bin systemctl 'exit 0'
+    stub_bin wslinfo 'echo nat'
+
+    call_install wsl_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "networking mode must be set to mirrored"
+}
+
+@test "wsl_install falls through to the standalone install once both preconditions hold" {
+    with_tenant
+    stub_bin systemctl 'exit 0'
+    stub_bin wslinfo 'echo mirrored'
+    fake_agent_binary
+
+    call_install wsl_install
+
+    [ "$status" -eq 0 ]
+    assert_called "agent install --server-address=$SERVER_ADDRESS"
+}
+
+@test "the installer aborts on FreeBSD" {
+    stub_bin uname 'echo FreeBSD'
+
+    run_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Automatic installation is not supported on FreeBSD"
+}
+
+@test "detection prefers docker when it is accessible" {
+    stub_bin docker
+    stub_bin podman
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Installing ShellHub using docker method"
+    assert_called "docker run -d"
+    refute_called "podman run"
+}
+
+@test "detection falls back to podman when docker is absent" {
+    stub_bin podman
+    stub_bin systemctl 'exit 0'
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Installing ShellHub using podman method"
+    assert_called "podman run -d"
+}
+
+@test "detection retries docker with sudo when it is only reachable as root" {
+    unset AGENT_IMAGE
+    stub_bin docker 'echo "docker $*" >> "$CALLS"; [ "$1" = info ] && [ -z "$RAN_UNDER_SUDO" ] && exit 1; exit 0'
+    stub_sudo
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_called "sudo docker info"
+    assert_called "sudo docker pull -q docker.io/shellhubio/agent:$AGENT_VERSION"
+    assert_called "sudo docker run -d"
+}
+
+@test "detection retries podman with sudo when it is only reachable as root" {
+    unset AGENT_IMAGE
+    stub_bin podman 'echo "podman $*" >> "$CALLS"; [ "$1" = info ] && [ -z "$RAN_UNDER_SUDO" ] && exit 1; exit 0'
+    stub_bin systemctl 'exit 0'
+    stub_sudo
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_called "sudo podman info"
+    assert_called "sudo podman pull -q docker.io/shellhubio/agent:$AGENT_VERSION"
+    assert_called "sudo podman run -d"
+}
+
+@test "detection falls back to snap when no container runtime is available" {
+    with_tenant
+    stub_bin snap
+    stub_sudo
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Installing ShellHub using snap method"
+    assert_called "snap install --classic --channel=latest/stable shellhub"
+}
+
+@test "detection falls back to the standalone install when nothing else is available" {
+    fake_agent_binary
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Installing ShellHub using standalone method"
+    assert_called "agent install --server-address=$SERVER_ADDRESS"
+}
+
+@test "an explicit INSTALL_METHOD skips detection entirely" {
+    export INSTALL_METHOD=standalone
+    stub_bin docker
+    fake_agent_binary
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Installing ShellHub using standalone method"
+    refute_called "docker info"
+}
+
+@test "an unsupported INSTALL_METHOD is rejected" {
+    export INSTALL_METHOD=bogus
+
+    run_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Install method not supported"
+}
+
+@test "detection reports WSL 2 on Ubuntu" {
+    enter_wsl
+    stub_bin systemctl 'exit 0'
+    stub_bin wslinfo 'echo mirrored'
+    fake_agent_binary
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Detected WSL environment"
+    assert_output_contains "Installing ShellHub using WSL method"
+    assert_called "agent install --server-address=$SERVER_ADDRESS"
+}
+
+@test "detection aborts when WSL is older than version 2" {
+    enter_wsl 1.2.5.0
+
+    run_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "WSL version 2 is required"
+}
+
+@test "detection aborts on WSL with a distro other than Ubuntu" {
+    enter_wsl
+    echo 'NAME="Debian GNU/Linux"' > "$OS_RELEASE"
+
+    run_install
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Only Ubuntu is supported in WSL"
+}
+
+@test "WSL detection overrides an explicit INSTALL_METHOD, so a chosen method does not survive WSL" {
+    export INSTALL_METHOD=standalone
+    enter_wsl
+    stub_bin systemctl 'exit 0'
+    stub_bin wslinfo 'echo mirrored'
+    fake_agent_binary
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Installing ShellHub using WSL method"
+}
+
+@test "the installer reports the enrollment credential before installing anything" {
+    with_tenant
+    stub_bin docker
+
+    run_install
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Enrollment: tenant $TENANT_ID (device lands pending)"
+}
+
+@test "uninstall dispatches to the detected method" {
+    stub_bin docker
+
+    run_install uninstall
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "Uninstalling ShellHub using docker method"
+    assert_called "docker rm -f shellhub"
+}
+
+@test "uninstall is refused for install methods that do not support it" {
+    export INSTALL_METHOD=snap
+
+    run_install uninstall
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "Uninstall is not yet supported for 'snap' install method"
+}

--- a/install.helpers.bash
+++ b/install.helpers.bash
@@ -1,0 +1,124 @@
+# Helpers for install.bats and shellhub-agent-wrapper.bats.
+#
+# Strategy: run install.sh (or the wrapper it emits) with a PATH holding only
+# a curated set of real utilities plus a directory of stubs that append their
+# own argv to $CALLS. Asserting on that log covers the decisions — which
+# container flags are passed, which env vars are mapped, when the script
+# aborts — without a container runtime, a systemd, or a network.
+#
+# A binary left out of both lists is genuinely absent, which is how the
+# "systemctl is missing" and "xdg-open is missing" branches are reached.
+
+INSTALL_SH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/install.sh"
+
+# Utilities install.sh needs to do its work. Deliberately excludes everything
+# whose presence a branch keys off: docker, podman, snap, systemctl, sudo,
+# wslinfo, find, xdg-open, curl, wget.
+INSTALL_TEST_REAL_BINS="sh sed grep awk tr wc cat head tail cut mktemp chmod mkdir rm cp mv ln gzip sleep uname tee env dirname basename"
+
+# Build the curated PATH once per file, then a per-test stub dir on top.
+setup_install_env() {
+    REAL_BIN="$BATS_FILE_TMPDIR/real-bin"
+
+    if [ ! -d "$REAL_BIN" ]; then
+        mkdir -p "$REAL_BIN"
+        for bin in $INSTALL_TEST_REAL_BINS; do
+            if path=$(command -v "$bin"); then
+                ln -sf "$path" "$REAL_BIN/$bin"
+            fi
+        done
+    fi
+
+    STUB_DIR="$BATS_TEST_TMPDIR/stub-bin"
+    CALLS="$BATS_TEST_TMPDIR/calls"
+    mkdir -p "$STUB_DIR"
+    : > "$CALLS"
+
+    export REAL_BIN STUB_DIR CALLS
+}
+
+# Put an executable named $1 on the stubbed PATH. Its body is $2, or a
+# default that just records the invocation. Bodies are POSIX sh and can use
+# $CALLS, "$@" and exit codes.
+# Usage: stub_bin docker 'echo "docker $*" >> "$CALLS"; exit 0'
+stub_bin() {
+    local name="$1" body="${2-}"
+
+    if [ -z "$body" ]; then
+        body="echo \"$name \$*\" >> \"\$CALLS\""
+    fi
+
+    {
+        echo '#!/bin/sh'
+        echo "$body"
+    } > "$STUB_DIR/$name"
+    chmod +x "$STUB_DIR/$name"
+}
+
+# Source install.sh as a library in a fresh /bin/sh and call one of its
+# functions. Runs under the real POSIX shell rather than bats' bash, so the
+# functions are exercised the way a user's `curl | sh` runs them.
+# Usage: call_install check_podman_boot_restart
+call_install() {
+    run env PATH="$STUB_DIR:$REAL_BIN" INSTALL_SH_LIB=1 \
+        sh -c '. "$1"; shift; "$@"' sh "$INSTALL_SH" "$@"
+}
+
+# Run install.sh end to end, exercising the detection flow in main().
+run_install() {
+    run env PATH="$STUB_DIR:$REAL_BIN" "$INSTALL_SH" "$@"
+}
+
+assert_called() {
+    grep -qF -- "$1" "$CALLS" && return 0
+
+    echo "expected a recorded call containing: $1"
+    echo "--- recorded calls ---"
+    cat "$CALLS"
+    return 1
+}
+
+refute_called() {
+    grep -qF -- "$1" "$CALLS" || return 0
+
+    echo "unexpected recorded call containing: $1"
+    echo "--- recorded calls ---"
+    cat "$CALLS"
+    return 1
+}
+
+assert_file_contains() {
+    grep -qF -- "$2" "$1" && return 0
+
+    echo "expected $1 to contain: $2"
+    echo "--- $1 ---"
+    cat "$1"
+    return 1
+}
+
+refute_file_contains() {
+    grep -qF -- "$2" "$1" || return 0
+
+    echo "expected $1 not to contain: $2"
+    echo "--- $1 ---"
+    cat "$1"
+    return 1
+}
+
+assert_output_contains() {
+    [[ "$output" == *"$1"* ]] && return 0
+
+    echo "expected output to contain: $1"
+    echo "--- output ---"
+    echo "$output"
+    return 1
+}
+
+refute_output_contains() {
+    [[ "$output" != *"$1"* ]] && return 0
+
+    echo "expected output not to contain: $1"
+    echo "--- output ---"
+    echo "$output"
+    return 1
+}

--- a/install.sh
+++ b/install.sh
@@ -548,186 +548,190 @@ http_get() {
   fi
 }
 
-if [ "$(uname -s)" = "FreeBSD" ]; then
-  echo "👹 This system is running FreeBSD."
-  echo "❌ ERROR: Automatic installation is not supported on FreeBSD."
-  echo
-  echo "Please refer to the ShellHub port at https://github.com/shellhub-io/ports"
-  exit 1
-fi
-
-# TENANT_ID is optional wherever something else names the namespace: an install key does so on its
-# own, a pairing code claims one, and with neither the container methods boot into pairing and
-# enroll via 'shellhub-agent login'. Snap always requires it (checked in its function).
-
-SERVER_ADDRESS="${SERVER_ADDRESS:-https://cloud.shellhub.io}"
-TENANT_ID="${TENANT_ID}"
-INSTALL_METHOD="$INSTALL_METHOD"
-AGENT_VERSION="${AGENT_VERSION:-$(http_get $SERVER_ADDRESS/info | sed -E 's/.*"version":\s?"?([^,"]*)"?.*/\1/')}"
-[ -n "$AGENT_IMAGE" ] && AGENT_IMAGE_OVERRIDDEN="1"
-AGENT_IMAGE="${AGENT_IMAGE:-docker.io/shellhubio/agent:$AGENT_VERSION}"
-BINARY_ARCH="$BINARY_ARCH"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
-TMP_DIR="${TMP_DIR:-$(mktemp -d -t shellhub-installer-XXXXXX)}"
-
-# Auto detect arch if it has not already been set
-if [ -z "$BINARY_ARCH" ]; then
-  case $(uname -m) in
-  x86_64)
-    BINARY_ARCH=amd64
-    ;;
-  armv6l)
-    BINARY_ARCH=armv6
-    ;;
-  armv7l)
-    BINARY_ARCH=armv7
-    ;;
-  aarch64)
-    BINARY_ARCH=arm64
-    ;;
-  i386|i486|i586|i686)
-    BINARY_ARCH=386
-    ;;
-  esac
-fi
-
-echo "🛠️ ShellHub Agent Installer"
-echo
-if [ -z "$INSTALL_METHOD" ]; then
-  echo "This script will install the ShellHub agent on your system."
-  echo "It will auto-detect the best available installation method."
-  echo
-  echo "Installation methods (priority order):"
-  echo "  1. Docker     - If Docker is installed and accessible in rootful mode"
-  echo "  2. Podman     - If Podman is installed and accessible in rootful mode"
-  echo "  3. Snap       - If Snap package manager is available"
-  echo "  4. WSL        - If running in WSL2 with systemd and mirrored networking"
-  echo "  5. Standalone - Native binary with systemd"
-  echo
-fi
-
-echo "⚙️ Detected settings:"
-echo "- Server address: $SERVER_ADDRESS"
-echo "- Enrollment: $(enrollment_summary)"
-echo "- Agent version: $AGENT_VERSION"
-echo "- Architecture: $BINARY_ARCH"
-[ -n "$INSTALL_METHOD" ] && echo "- Install method: $INSTALL_METHOD"
-echo
-
-if [ -z "$INSTALL_METHOD" ] && type docker >/dev/null 2>&1; then
-  echo "🔍 Checking if Docker is available and accessible in rootful mode..."
-
-  export DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker.sock}"
-
-  for prefix in "" "sudo"; do
-    if $prefix docker info >/dev/null 2>&1; then
-      SUDO=$prefix
-      INSTALL_METHOD="docker"
-      break
-    fi
-  done
-
-  [ -z "$INSTALL_METHOD" ] && echo "ℹ️ Docker is not accessible in rootful mode."
-fi
-
-if [ -z "$INSTALL_METHOD" ] && type podman >/dev/null 2>&1; then
-  echo "🔍 Checking if Podman is available and accessible in rootful mode..."
-
-  export CONTAINER_HOST="${CONTAINER_HOST:-unix:///var/run/podman/podman.sock}"
-
-  for prefix in "" "sudo"; do
-    if $prefix podman info >/dev/null 2>&1; then
-      SUDO=$prefix
-      INSTALL_METHOD="podman"
-      break
-    fi
-  done
-
-  [ -z "$INSTALL_METHOD" ] && echo "ℹ️ Podman is not accessible in rootful mode."
-fi
-
-if [ -z "$INSTALL_METHOD" ]; then
-  echo
-  echo "⚠️  NOTE: No recommended installation method was detected."
-  echo "⚠️  For best performance, easier updates, and better isolation, it is strongly recommended to use Docker or Podman."
-  echo "ℹ️  The installer will proceed with an alternative method (Snap, Standalone, or WSL), but these may have limitations."
-  echo
-fi
-
-if [ -z "$INSTALL_METHOD" ] && type snap >/dev/null 2>&1; then
-  echo "🔍 Detected Snap package manager..."
-  INSTALL_METHOD="snap"
-fi
-
-# Check if running on WSL
-if grep -qi Microsoft /proc/version; then
-  echo "🔍 Detected WSL environment..."
-
-  WSL_EXE=$(find /mnt/*/Windows/System32/wsl.exe 2>/dev/null | head -n 1)
-  WSL_VERSION=$($WSL_EXE -v | tr -d '\0' | grep "WSL version" | awk -F'[ .:]+' '{print $3}')
-
-  if [ -z "$WSL_VERSION" ] || [ "$WSL_VERSION" -lt 2 ]; then
-    echo "❌ ERROR: WSL version 2 is required to run ShellHub."
+main() {
+  if [ "$(uname -s)" = "FreeBSD" ]; then
+    echo "👹 This system is running FreeBSD."
+    echo "❌ ERROR: Automatic installation is not supported on FreeBSD."
+    echo
+    echo "Please refer to the ShellHub port at https://github.com/shellhub-io/ports"
     exit 1
   fi
 
-  if  grep -qi 'NAME="Ubuntu"' /etc/os-release; then
-    INSTALL_METHOD="wsl"
-  else
-    echo "❌ Error: Only Ubuntu is supported in WSL."
-    exit 1
+  # TENANT_ID is optional wherever something else names the namespace: an install key does so on its
+  # own, a pairing code claims one, and with neither the container methods boot into pairing and
+  # enroll via 'shellhub-agent login'. Snap always requires it (checked in its function).
+
+  SERVER_ADDRESS="${SERVER_ADDRESS:-https://cloud.shellhub.io}"
+  TENANT_ID="${TENANT_ID}"
+  INSTALL_METHOD="$INSTALL_METHOD"
+  AGENT_VERSION="${AGENT_VERSION:-$(http_get $SERVER_ADDRESS/info | sed -E 's/.*"version":\s?"?([^,"]*)"?.*/\1/')}"
+  [ -n "$AGENT_IMAGE" ] && AGENT_IMAGE_OVERRIDDEN="1"
+  AGENT_IMAGE="${AGENT_IMAGE:-docker.io/shellhubio/agent:$AGENT_VERSION}"
+  BINARY_ARCH="$BINARY_ARCH"
+  INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+  TMP_DIR="${TMP_DIR:-$(mktemp -d -t shellhub-installer-XXXXXX)}"
+
+  # Auto detect arch if it has not already been set
+  if [ -z "$BINARY_ARCH" ]; then
+    case $(uname -m) in
+    x86_64)
+      BINARY_ARCH=amd64
+      ;;
+    armv6l)
+      BINARY_ARCH=armv6
+      ;;
+    armv7l)
+      BINARY_ARCH=armv7
+      ;;
+    aarch64)
+      BINARY_ARCH=arm64
+      ;;
+    i386|i486|i586|i686)
+      BINARY_ARCH=386
+      ;;
+    esac
   fi
-fi
 
-[ -z "$INSTALL_METHOD" ] && INSTALL_METHOD="standalone"
+  echo "🛠️ ShellHub Agent Installer"
+  echo
+  if [ -z "$INSTALL_METHOD" ]; then
+    echo "This script will install the ShellHub agent on your system."
+    echo "It will auto-detect the best available installation method."
+    echo
+    echo "Installation methods (priority order):"
+    echo "  1. Docker     - If Docker is installed and accessible in rootful mode"
+    echo "  2. Podman     - If Podman is installed and accessible in rootful mode"
+    echo "  3. Snap       - If Snap package manager is available"
+    echo "  4. WSL        - If running in WSL2 with systemd and mirrored networking"
+    echo "  5. Standalone - Native binary with systemd"
+    echo
+  fi
 
-case "$1" in
-uninstall)
-  case "$INSTALL_METHOD" in
-  standalone|wsl)
-    echo "🗑️ Uninstalling ShellHub using standalone method..."
-    standalone_uninstall
-    ;;
-  docker)
-    echo "🐳 Uninstalling ShellHub using docker method..."
-    docker_uninstall
-    ;;
-  podman)
-    echo "🐳 Uninstalling ShellHub using podman method..."
-    podman_uninstall
+  echo "⚙️ Detected settings:"
+  echo "- Server address: $SERVER_ADDRESS"
+  echo "- Enrollment: $(enrollment_summary)"
+  echo "- Agent version: $AGENT_VERSION"
+  echo "- Architecture: $BINARY_ARCH"
+  [ -n "$INSTALL_METHOD" ] && echo "- Install method: $INSTALL_METHOD"
+  echo
+
+  if [ -z "$INSTALL_METHOD" ] && type docker >/dev/null 2>&1; then
+    echo "🔍 Checking if Docker is available and accessible in rootful mode..."
+
+    export DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker.sock}"
+
+    for prefix in "" "sudo"; do
+      if $prefix docker info >/dev/null 2>&1; then
+        SUDO=$prefix
+        INSTALL_METHOD="docker"
+        break
+      fi
+    done
+
+    [ -z "$INSTALL_METHOD" ] && echo "ℹ️ Docker is not accessible in rootful mode."
+  fi
+
+  if [ -z "$INSTALL_METHOD" ] && type podman >/dev/null 2>&1; then
+    echo "🔍 Checking if Podman is available and accessible in rootful mode..."
+
+    export CONTAINER_HOST="${CONTAINER_HOST:-unix:///var/run/podman/podman.sock}"
+
+    for prefix in "" "sudo"; do
+      if $prefix podman info >/dev/null 2>&1; then
+        SUDO=$prefix
+        INSTALL_METHOD="podman"
+        break
+      fi
+    done
+
+    [ -z "$INSTALL_METHOD" ] && echo "ℹ️ Podman is not accessible in rootful mode."
+  fi
+
+  if [ -z "$INSTALL_METHOD" ]; then
+    echo
+    echo "⚠️  NOTE: No recommended installation method was detected."
+    echo "⚠️  For best performance, easier updates, and better isolation, it is strongly recommended to use Docker or Podman."
+    echo "ℹ️  The installer will proceed with an alternative method (Snap, Standalone, or WSL), but these may have limitations."
+    echo
+  fi
+
+  if [ -z "$INSTALL_METHOD" ] && type snap >/dev/null 2>&1; then
+    echo "🔍 Detected Snap package manager..."
+    INSTALL_METHOD="snap"
+  fi
+
+  # Check if running on WSL
+  if grep -qi Microsoft "${PROC_VERSION:-/proc/version}"; then
+    echo "🔍 Detected WSL environment..."
+
+    WSL_EXE=$(find /mnt/*/Windows/System32/wsl.exe 2>/dev/null | head -n 1)
+    WSL_VERSION=$($WSL_EXE -v | tr -d '\0' | grep "WSL version" | awk -F'[ .:]+' '{print $3}')
+
+    if [ -z "$WSL_VERSION" ] || [ "$WSL_VERSION" -lt 2 ]; then
+      echo "❌ ERROR: WSL version 2 is required to run ShellHub."
+      exit 1
+    fi
+
+    if grep -qi 'NAME="Ubuntu"' "${OS_RELEASE:-/etc/os-release}"; then
+      INSTALL_METHOD="wsl"
+    else
+      echo "❌ Error: Only Ubuntu is supported in WSL."
+      exit 1
+    fi
+  fi
+
+  [ -z "$INSTALL_METHOD" ] && INSTALL_METHOD="standalone"
+
+  case "$1" in
+  uninstall)
+    case "$INSTALL_METHOD" in
+    standalone|wsl)
+      echo "🗑️ Uninstalling ShellHub using standalone method..."
+      standalone_uninstall
+      ;;
+    docker)
+      echo "🐳 Uninstalling ShellHub using docker method..."
+      docker_uninstall
+      ;;
+    podman)
+      echo "🐳 Uninstalling ShellHub using podman method..."
+      podman_uninstall
+      ;;
+    *)
+      echo "❌ Uninstall is not yet supported for '$INSTALL_METHOD' install method."
+      exit 1
+      ;;
+    esac
     ;;
   *)
-    echo "❌ Uninstall is not yet supported for '$INSTALL_METHOD' install method."
-    exit 1
+    case "$INSTALL_METHOD" in
+    podman)
+      echo "🐳 Installing ShellHub using podman method..."
+      podman_install "$@"
+      ;;
+    docker)
+      echo "🐳 Installing ShellHub using docker method..."
+      docker_install "$@"
+      ;;
+    snap)
+      echo "📦 Installing ShellHub using snap method..."
+      snap_install
+      ;;
+    standalone)
+      echo "🐧 Installing ShellHub using standalone method..."
+      standalone_install
+      ;;
+    wsl)
+      echo "🪟 Installing ShellHub using WSL method..."
+      wsl_install
+      ;;
+    *)
+      echo "❌ Install method not supported."
+      exit 1
+      ;;
+    esac
     ;;
   esac
-  ;;
-*)
-  case "$INSTALL_METHOD" in
-  podman)
-    echo "🐳 Installing ShellHub using podman method..."
-    podman_install "$@"
-    ;;
-  docker)
-    echo "🐳 Installing ShellHub using docker method..."
-    docker_install "$@"
-    ;;
-  snap)
-    echo "📦 Installing ShellHub using snap method..."
-    snap_install
-    ;;
-  standalone)
-    echo "🐧 Installing ShellHub using standalone method..."
-    standalone_install
-    ;;
-  wsl)
-    echo "🪟 Installing ShellHub using WSL method..."
-    wsl_install
-    ;;
-  *)
-    echo "❌ Install method not supported."
-    exit 1
-    ;;
-  esac
-  ;;
-esac
+}
+
+[ "${INSTALL_SH_LIB:-}" = "1" ] || main "$@"

--- a/install.sh
+++ b/install.sh
@@ -200,7 +200,7 @@ podman_install() {
     shift 1
     ;;
   *)
-    echo "❌ Invalid mode: $2"
+    echo "❌ Invalid mode: $1"
     exit 1
     ;;
   esac
@@ -262,7 +262,7 @@ docker_install() {
     echo "📥 Downloading ShellHub container image..."
 
     {
-      docker pull -q "$AGENT_IMAGE"
+      $SUDO docker pull -q "$AGENT_IMAGE"
     } || {
       echo "❌ Failed to download shellhub container image."
       exit 1
@@ -288,7 +288,7 @@ docker_install() {
     shift 1
     ;;
   *)
-    echo "❌ Invalid mode: $2"
+    echo "❌ Invalid mode: $1"
     exit 1
     ;;
   esac

--- a/shellhub-agent-wrapper.bats
+++ b/shellhub-agent-wrapper.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+# Tests for the shellhub-agent wrapper that install.sh generates. The wrapper
+# is a separate artifact with its own runtime behaviour — it locates the agent
+# container and proxies commands into it — so install.sh appears here only in
+# setup_file, to produce the fixture. Coverage of the generation itself lives
+# in install.bats.
+
+load install.helpers
+
+setup_file() {
+    fixture_bin="$BATS_FILE_TMPDIR/fixture-bin"
+    mkdir -p "$fixture_bin"
+    printf '#!/bin/sh\necho 0\n' > "$fixture_bin/id"
+    chmod +x "$fixture_bin/id"
+
+    for runtime in docker podman; do
+        mkdir -p "$BATS_FILE_TMPDIR/$runtime"
+        env PATH="$fixture_bin:$PATH" INSTALL_SH_LIB=1 INSTALL_DIR="$BATS_FILE_TMPDIR/$runtime" \
+            sh -c '. "$1"; install_agent_wrapper "$2"' sh "$INSTALL_SH" "$runtime" > /dev/null
+    done
+}
+
+setup() {
+    setup_install_env
+
+    RUNTIME=docker
+    WRAPPER="$BATS_FILE_TMPDIR/docker/shellhub-agent"
+}
+
+use_podman() {
+    RUNTIME=podman
+    WRAPPER="$BATS_FILE_TMPDIR/podman/shellhub-agent"
+}
+
+# Stub the container runtime the wrapper drives.
+# Usage: stub_runtime <ps output> [exec output] [exec exit status]
+stub_runtime() {
+    export STUB_CONTAINERS="${1-}" STUB_EXEC_OUTPUT="${2-}" STUB_EXEC_STATUS="${3:-0}"
+
+    stub_bin "$RUNTIME" "echo \"$RUNTIME \$*\" >> \"\$CALLS\"
+case \"\$1\" in
+ps) [ -n \"\$STUB_CONTAINERS\" ] && printf '%s\n' \"\$STUB_CONTAINERS\" ;;
+exec)
+    [ -n \"\$STUB_EXEC_OUTPUT\" ] && printf '%s\n' \"\$STUB_EXEC_OUTPUT\"
+    exit \"\$STUB_EXEC_STATUS\"
+    ;;
+esac
+exit 0"
+}
+
+run_wrapper() {
+    run env PATH="$STUB_DIR:$REAL_BIN" "$WRAPPER" "$@"
+}
+
+@test "the wrapper looks the agent container up by its role label" {
+    stub_runtime shellhub
+
+    run_wrapper status
+
+    [ "$status" -eq 0 ]
+    assert_called "docker ps --filter label=shellhub.role=agent --format {{.Names}}"
+}
+
+@test "the wrapper proxies its arguments into the single agent container" {
+    stub_runtime shellhub
+
+    run_wrapper status --format json
+
+    [ "$status" -eq 0 ]
+    assert_called "docker exec shellhub agent status --format json"
+}
+
+@test "the wrapper reports when no agent container is running" {
+    stub_runtime ""
+
+    run_wrapper status
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "no running agent container found"
+    assert_output_contains "install.sh uninstall"
+    refute_called "docker exec"
+}
+
+@test "the wrapper refuses to guess between several agent containers" {
+    stub_runtime "$(printf 'shellhub\nshellhub-spare')"
+
+    run_wrapper status
+
+    [ "$status" -eq 1 ]
+    assert_output_contains "multiple agent containers found"
+    assert_output_contains "  shellhub"
+    assert_output_contains "  shellhub-spare"
+    refute_called "docker exec"
+}
+
+@test "the wrapper propagates the agent's exit status" {
+    stub_runtime shellhub "" 3
+
+    run_wrapper status
+
+    [ "$status" -eq 3 ]
+}
+
+@test "login opens the accept-device URL in the host browser" {
+    stub_runtime shellhub "https://cloud.example.test/accept-device?code=ABC123"
+    stub_bin xdg-open
+
+    run_wrapper login
+
+    [ "$status" -eq 0 ]
+    assert_called "xdg-open https://cloud.example.test/accept-device?code=ABC123"
+    assert_output_contains "(opened in your browser)"
+}
+
+@test "login says nothing about a browser it could not open" {
+    stub_runtime shellhub "https://cloud.example.test/accept-device?code=ABC123"
+    stub_bin xdg-open 'echo "xdg-open $*" >> "$CALLS"; exit 1'
+
+    run_wrapper login
+
+    [ "$status" -eq 0 ]
+    assert_called "xdg-open https://cloud.example.test/accept-device?code=ABC123"
+    refute_output_contains "opened in your browser"
+}
+
+@test "login strips the whitespace around the URL before handing it to the browser" {
+    stub_runtime shellhub "  https://cloud.example.test/accept-device?code=ABC123  "
+    stub_bin xdg-open
+
+    run_wrapper login
+
+    [ "$status" -eq 0 ]
+    assert_called "xdg-open https://cloud.example.test/accept-device?code=ABC123"
+}
+
+@test "login streams the agent output while watching for the URL" {
+    stub_runtime shellhub "$(printf 'waiting for acceptance\nhttps://cloud.example.test/accept-device?code=ABC123\ndone')"
+    stub_bin xdg-open
+
+    run_wrapper login
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "waiting for acceptance"
+    assert_output_contains "done"
+}
+
+@test "login propagates the agent's exit status through the browser path" {
+    stub_runtime shellhub "https://cloud.example.test/accept-device?code=ABC123" 3
+    stub_bin xdg-open
+
+    run_wrapper login
+
+    [ "$status" -eq 3 ]
+}
+
+@test "login proxies straight through when no browser is available" {
+    stub_runtime shellhub "https://cloud.example.test/accept-device?code=ABC123"
+
+    run_wrapper login
+
+    [ "$status" -eq 0 ]
+    assert_called "docker exec shellhub agent login"
+    refute_output_contains "opened in your browser"
+}
+
+@test "login propagates the agent's exit status when no browser is available" {
+    stub_runtime shellhub "" 3
+
+    run_wrapper login
+
+    [ "$status" -eq 3 ]
+}
+
+@test "the podman wrapper drives podman" {
+    use_podman
+    stub_runtime shellhub
+
+    run_wrapper status
+
+    [ "$status" -eq 0 ]
+    assert_called "podman ps --filter label=shellhub.role=agent"
+    assert_called "podman exec shellhub agent status"
+}


### PR DESCRIPTION
## What

`install.sh` gets a bats-core test suite — 95 tests across two files, run on every PR under both dash and busybox ash. Making the script testable surfaced two bugs, fixed here in their own commits.

## Why

Closes #6962. The restart-policy regression fixed in #6961 was only observable on a real Podman host, after a reboot: the script had no tests, so nothing on the way to master could have caught it. Its predecessor's hand-rolled `tests/install-boot-check_test.sh` was never actually committed.

## Changes

- **`main()` wrapper**: the top-level detection and dispatch ran on source, so no test could reach a single function without running the whole installer. Wrapped in `main()`, called unless `INSTALL_SH_LIB` is set. `git diff -w` shows the real change is 8 added / 4 removed lines; the remaining ~310 are indentation.
- **`PROC_VERSION` / `OS_RELEASE` seams**: the WSL probe reads `/proc/version` and `/etc/os-release` directly. Both are now indirected so a test can present a WSL or non-WSL host. Every other decision keys off a command looked up in `PATH`, which a test can already stub — these two files were the only ones that needed a seam.
- **`docker pull` privilege fix**: detection sets `SUDO` when Docker answers only as root, and `docker rm -f`, `docker run` and podman's own pull all honoured it. `docker pull` did not, so a root-only Docker host died at the pull before reaching any call that would have worked.
- **Invalid-mode message fix**: the branch printed `$2`, but the mode is `$1`. Since both install functions are called with the script's own arguments, `$2` was usually unset and the error read `Invalid mode: ` with nothing after it.
- **Two suites, not one**: `install.bats` sources or runs `install.sh`. `shellhub-agent-wrapper.bats` runs the `shellhub-agent` wrapper that `install.sh` *emits* — a separate artifact with its own runtime behaviour (container lookup by label, the login browser hand-off, exit-status propagation) that needs `install.sh` only to build its fixture in `setup_file`.
- **Harness**: both run the script under a `PATH` holding a curated set of real utilities plus stubs that record their argv. A binary left out of both lists is genuinely absent — that is how the "systemctl is missing" and "xdg-open is missing" branches are reached without a container runtime, a systemd, or a network. Functions are invoked through `sh -c '. install.sh; <fn>'`, so they run under the real POSIX shell rather than bats' bash.
- **CI**: new `install-sh` job in `script-tests.yml`, deliberately with no `dorny/paths-filter` unlike its siblings — `install.sh` is served from `server/api/services/system.go` and drives the agent, so a change on either side can break it without the script appearing in the diff. Runs `shellcheck -s sh -S warning`, the suite on the runner (dash), and the suite again under busybox ash, reading the alpine version from `agent/Dockerfile`.

## Testing

`bats install.bats shellhub-agent-wrapper.bats` from the repo root; the CI job's third step reproduces the busybox run locally.

Worth probing rather than taking on trust:

- The suite was mutation-checked, not just run green. Reverting `--restart=unless-stopped` to `on-failure` fails 2 tests; dropping the `shellhub.role=agent` label fails 4; neutering `check_podman_boot_restart` fails 16; removing `$SUDO` from `docker pull` fails 1.
- One test pins current behaviour rather than endorsing it: the WSL probe runs unguarded after the `INSTALL_METHOD` checks, so an explicitly chosen method does not survive a WSL host. Guarding it would also flip snap-over-WSL on Ubuntu, which belongs in its own change.
- `shift 1` in both `case` arms is dead code — the positional parameters are never read after the `case`, so deleting it changes nothing and no test can catch it. Left in place; worth a follow-up.
