### PR TITLE
docs(api): state a key's scope, and correct two errors

### DIFF
--- a/ui/apps/docs/src/pages/api.mdx
+++ b/ui/apps/docs/src/pages/api.mdx
@@ -21,8 +21,9 @@ An **API key** goes in a header:
 $ curl -H "X-API-Key: <your-api-key>" https://cloud.shellhub.io/api/devices
 ```
 
-It resolves to an identity carrying a namespace and a role. It does not expire on a timer, and it
-belongs to the namespace rather than to a browser session.
+It resolves to an identity carrying a namespace and a role. It belongs to the namespace rather
+than to a browser session, and its expiry is one you set at creation rather than a session lifetime
+the server imposes.
 
 A **bearer token** is the JWT from signing in:
 
@@ -40,7 +41,7 @@ leaves.
 
 ## Creating a key
 
-From the console, under **Namespace → API Keys**. A key has:
+From the console, under **Team → API Keys**. A key has:
 
 | Field | Meaning |
 |---|---|
@@ -50,6 +51,10 @@ From the console, under **Namespace → API Keys**. A key has:
 
 The name is the only external identifier — the internal id is a hash and is never returned. Name
 keys for what they do: `ci-deploy`, `inventory-sync`, not `key1`.
+
+A key is scoped to the one namespace it was created in. It reaches nothing in another namespace,
+and it is not accepted on the instance administration surface under `/admin/api`, which takes a
+credential of its own.
 
 <Callout variant="warning">
 A key's role must be **equal to or less than the role of whoever created it**. An operator cannot


### PR DESCRIPTION
Follow-up to shellhub-io/shellhub#7021.

## What

One paragraph on an API key's scope, plus two pre-existing fixes, on the existing REST
API page. One file, +8/-3.

## Why

A reader who meets a `401` from `/admin/api` had nothing on the page to explain it.

Instance API keys get no section of their own: nobody reading these docs can mint one.
Community ships no admin console, Cloud's belongs to ShellHub rather than the customer,
and Enterprise runs on ShellHub's infrastructure too. Worth revisiting when self-hosted
Enterprise ships. Note for then: the routes live under `/admin`, which
`customer-filter.js` drops from the published customer spec, so they are absent from the
API reference as well.

## Changes

- New paragraph under `## Creating a key`: the key is scoped to its namespace, and the
  administration surface takes a credential of its own.
- Two pre-existing errors fixed: the page claimed a key "does not expire on a timer"
  while documenting an optional expiry the server honours, and pointed at
  **Namespace → API Keys** when the tab is on **Team**.

No headings renamed, so every anchor and redirect is untouched.
