### PR TITLE
fix(ui): make quick search arrow navigation and clicks work

### DIFF
--- a/ui/apps/docs/src/components/CommandPalette.astro
+++ b/ui/apps/docs/src/components/CommandPalette.astro
@@ -1,0 +1,110 @@
+---
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { sidebar, flattenItems } from "../data/sidebar";
+
+const allItems = sidebar.flatMap(section =>
+  flattenItems(section.items).map(item => ({
+    label: item.label,
+    href: item.href,
+    section: section.label,
+  }))
+);
+
+const rawPath = Astro.url.pathname.replace(/\/$/, "");
+const currentPath = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+---
+
+<div class="cmd-palette" id="cmd-palette">
+  <div class="cmd-overlay" id="cmd-overlay"></div>
+  <div class="cmd-dialog">
+    <div class="cmd-input-row">
+      <MagnifyingGlassIcon className="cmd-search-icon" aria-hidden="true" />
+      <input type="text" class="cmd-input" id="cmd-input" placeholder="Search documentation..." autocomplete="off" spellcheck="false" />
+      <kbd class="cmd-esc">esc</kbd>
+    </div>
+    <div class="cmd-results" id="cmd-results"></div>
+  </div>
+</div>
+
+<script define:vars={{ allItems, currentPath }}>
+  const palette = document.getElementById("cmd-palette");
+  const overlay = document.getElementById("cmd-overlay");
+  const input = document.getElementById("cmd-input");
+  const results = document.getElementById("cmd-results");
+
+  let selectedIdx = 0;
+  let filtered = allItems;
+
+  function open() {
+    palette.classList.add("cmd-open");
+    input.value = "";
+    selectedIdx = 0;
+    render(allItems);
+    requestAnimationFrame(() => input.focus());
+  }
+
+  function close() { palette.classList.remove("cmd-open"); }
+
+  function select(idx) {
+    results.querySelector(".cmd-item--sel")?.classList.remove("cmd-item--sel");
+    selectedIdx = idx;
+    const el = results.querySelector(`[data-i="${idx}"]`);
+    el?.classList.add("cmd-item--sel");
+    el?.scrollIntoView({ block: "nearest" });
+  }
+
+  function render(items) {
+    filtered = items;
+    let section = "";
+    let html = "";
+    items.forEach((item, i) => {
+      if (item.section !== section) {
+        section = item.section;
+        html += `<div class="cmd-section">${section}</div>`;
+      }
+      const sel = i === selectedIdx ? " cmd-item--sel" : "";
+      const cur = item.href.replace(/\/$/, "") === currentPath ? " cmd-item--cur" : "";
+      html += `<a href="${item.href}" class="cmd-item${sel}${cur}" data-i="${i}">
+        <span>${item.label}</span>
+        ${cur ? '<span class="cmd-badge">current</span>' : ""}
+      </a>`;
+    });
+    results.innerHTML = html || '<div class="cmd-empty">No results</div>';
+    results.querySelector(".cmd-item--sel")?.scrollIntoView({ block: "nearest" });
+  }
+
+  function filter(q) {
+    q = q.toLowerCase().trim();
+    if (!q) return render(allItems);
+    selectedIdx = 0;
+    render(allItems.filter(it =>
+      it.label.toLowerCase().includes(q) ||
+      it.section.toLowerCase().includes(q) ||
+      it.href.toLowerCase().includes(q)
+    ));
+  }
+
+  document.getElementById("cmd-trigger")?.addEventListener("click", open);
+  document.getElementById("hero-search")?.addEventListener("click", open);
+  overlay?.addEventListener("click", close);
+
+  document.addEventListener("keydown", (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      palette.classList.contains("cmd-open") ? close() : open();
+    }
+    if (!palette.classList.contains("cmd-open")) return;
+    if (e.key === "Escape") { close(); return; }
+    if (e.key === "ArrowDown") { e.preventDefault(); select(Math.min(selectedIdx + 1, filtered.length - 1)); }
+    if (e.key === "ArrowUp") { e.preventDefault(); select(Math.max(selectedIdx - 1, 0)); }
+    if (e.key === "Enter" && filtered[selectedIdx]) { e.preventDefault(); window.location.href = filtered[selectedIdx].href; }
+  });
+
+  input?.addEventListener("input", (e) => filter(e.target.value));
+  results?.addEventListener("mouseover", (e) => {
+    const item = e.target.closest(".cmd-item");
+    if (!item) return;
+    const idx = parseInt(item.dataset.i);
+    if (idx !== selectedIdx) select(idx);
+  });
+</script>

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -8,6 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { sidebar, flattenItems } from "../data/sidebar";
 import { websiteUrl } from "../data/links";
+import CommandPalette from "../components/CommandPalette.astro";
 
 interface Props {
   title: string;
@@ -30,11 +31,6 @@ const currentIndex = allPages.findIndex(p => p.href.replace(/\/$/, "") === curre
 const prevPage = currentIndex > 0 ? allPages[currentIndex - 1] : null;
 const nextPage = currentIndex < allPages.length - 1 ? allPages[currentIndex + 1] : null;
 
-// `icon` is a React component and is never read by the client script (it only uses
-// label/items). A component has no JSON-serializable fields, so define:vars would
-// serialize it to a dead `{}` per section; strip it to keep that noise out of the
-// inlined payload.
-const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
 ---
 
 <html lang="en">
@@ -213,103 +209,9 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
       </aside>
     </div>
 
-    <!-- Command Palette -->
-    <div class="cmd-palette" id="cmd-palette">
-      <div class="cmd-overlay" id="cmd-overlay"></div>
-      <div class="cmd-dialog">
-        <div class="cmd-input-row">
-          <MagnifyingGlassIcon className="cmd-search-icon" aria-hidden="true" />
-          <input type="text" class="cmd-input" id="cmd-input" placeholder="Search documentation..." autocomplete="off" spellcheck="false" />
-          <kbd class="cmd-esc">esc</kbd>
-        </div>
-        <div class="cmd-results" id="cmd-results"></div>
-      </div>
-    </div>
+    <CommandPalette />
 
-    <script define:vars={{ sidebar: sidebarForScript, currentPath }}>
-      // Command palette
-      function flattenSidebarItems(items, sectionLabel) {
-        return items.flatMap(item =>
-          item.href
-            ? [{ label: item.label, href: item.href, section: sectionLabel }]
-            : flattenSidebarItems(item.items, sectionLabel)
-        );
-      }
-      const allItems = sidebar.flatMap(section =>
-        flattenSidebarItems(section.items, section.label)
-      );
-
-      const palette = document.getElementById("cmd-palette");
-      const overlay = document.getElementById("cmd-overlay");
-      const input = document.getElementById("cmd-input");
-      const results = document.getElementById("cmd-results");
-      const trigger = document.getElementById("cmd-trigger");
-
-      let selectedIdx = 0;
-      let filtered = allItems;
-
-      function open() {
-        palette.classList.add("cmd-open");
-        input.value = "";
-        selectedIdx = 0;
-        render(allItems);
-        requestAnimationFrame(() => input.focus());
-      }
-
-      function close() { palette.classList.remove("cmd-open"); }
-
-      function render(items) {
-        filtered = items;
-        let section = "";
-        let html = "";
-        items.forEach((item, i) => {
-          if (item.section !== section) {
-            section = item.section;
-            html += `<div class="cmd-section">${section}</div>`;
-          }
-          const sel = i === selectedIdx ? " cmd-item--sel" : "";
-          const cur = item.href.replace(/\/$/, "") === currentPath ? " cmd-item--cur" : "";
-          html += `<a href="${item.href}" class="cmd-item${sel}${cur}" data-i="${i}">
-            <span>${item.label}</span>
-            ${cur ? '<span class="cmd-badge">current</span>' : ""}
-          </a>`;
-        });
-        results.innerHTML = html || '<div class="cmd-empty">No results</div>';
-        results.querySelector(".cmd-item--sel")?.scrollIntoView({ block: "nearest" });
-      }
-
-      function filter(q) {
-        q = q.toLowerCase().trim();
-        if (!q) return render(allItems);
-        selectedIdx = 0;
-        render(allItems.filter(it =>
-          it.label.toLowerCase().includes(q) ||
-          it.section.toLowerCase().includes(q) ||
-          it.href.toLowerCase().includes(q)
-        ));
-      }
-
-      trigger?.addEventListener("click", open);
-      overlay?.addEventListener("click", close);
-
-      document.addEventListener("keydown", (e) => {
-        if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-          e.preventDefault();
-          palette.classList.contains("cmd-open") ? close() : open();
-        }
-        if (!palette.classList.contains("cmd-open")) return;
-        if (e.key === "Escape") { close(); return; }
-        if (e.key === "ArrowDown") { e.preventDefault(); selectedIdx = Math.min(selectedIdx + 1, filtered.length - 1); render(filtered); }
-        if (e.key === "ArrowUp") { e.preventDefault(); selectedIdx = Math.max(selectedIdx - 1, 0); render(filtered); }
-        if (e.key === "Enter" && filtered[selectedIdx]) { e.preventDefault(); window.location.href = filtered[selectedIdx].href; }
-      });
-
-      input?.addEventListener("input", (e) => filter(e.target.value));
-      results?.addEventListener("mouseover", (e) => {
-        const item = e.target.closest(".cmd-item");
-        if (item) { selectedIdx = parseInt(item.dataset.i); render(filtered); }
-      });
-
+    <script>
       // Sidebar scroll persistence (desktop only — skip when the drawer is hidden off-canvas)
       const sidebarEl = document.getElementById("docs-sidebar");
       if (sidebarEl) {

--- a/ui/apps/docs/src/pages/index.astro
+++ b/ui/apps/docs/src/pages/index.astro
@@ -8,6 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { sidebar, flattenItems } from "../data/sidebar";
 import { websiteUrl, docsUrl } from "../data/links";
+import CommandPalette from "../components/CommandPalette.astro";
 
 const sections = sidebar.map(section => ({
   label: section.label,
@@ -15,11 +16,6 @@ const sections = sidebar.map(section => ({
   icon: section.icon,
   items: flattenItems(section.items).filter(item => item.featured),
 }));
-
-// Flatten all items for command palette
-const allItems = sidebar.flatMap(section =>
-  flattenItems(section.items).map(item => ({ ...item, section: section.label }))
-);
 ---
 
 <html lang="en">
@@ -125,112 +121,6 @@ const allItems = sidebar.flatMap(section =>
 
     <Footer app="docs" websiteUrl={websiteUrl} docsUrl={docsUrl} />
 
-    <!-- Command Palette -->
-    <div class="cmd-palette" id="cmd-palette">
-      <div class="cmd-overlay" id="cmd-overlay"></div>
-      <div class="cmd-dialog">
-        <div class="cmd-input-row">
-          <MagnifyingGlassIcon className="cmd-search-icon" aria-hidden="true" />
-          <input type="text" class="cmd-input" id="cmd-input" placeholder="Search documentation..." autocomplete="off" spellcheck="false" />
-          <kbd class="cmd-esc">esc</kbd>
-        </div>
-        <div class="cmd-results" id="cmd-results"></div>
-      </div>
-    </div>
-
-    <script define:vars={{ allItems }}>
-      const currentPath = window.location.pathname.replace(/\/$/, "");
-
-      const palette = document.getElementById("cmd-palette");
-      const overlay = document.getElementById("cmd-overlay");
-      const input = document.getElementById("cmd-input");
-      const results = document.getElementById("cmd-results");
-      const trigger = document.getElementById("cmd-trigger");
-      const heroSearch = document.getElementById("hero-search");
-
-      let selectedIdx = 0;
-      let filtered = allItems;
-
-      function open() {
-        palette.classList.add("cmd-open");
-        input.value = "";
-        selectedIdx = 0;
-        render(allItems);
-        requestAnimationFrame(() => input.focus());
-      }
-
-      function close() {
-        palette.classList.remove("cmd-open");
-      }
-
-      function render(items) {
-        filtered = items;
-        let section = "";
-        let html = "";
-
-        items.forEach((item, i) => {
-          if (item.section !== section) {
-            section = item.section;
-            html += `<div class="cmd-section">${section}</div>`;
-          }
-          const sel = i === selectedIdx ? " cmd-item--sel" : "";
-          html += `<a href="${item.href}" class="cmd-item${sel}" data-i="${i}">
-            <span>${item.label}</span>
-          </a>`;
-        });
-
-        results.innerHTML = html || '<div class="cmd-empty">No results</div>';
-        const selEl = results.querySelector(".cmd-item--sel");
-        selEl?.scrollIntoView({ block: "nearest" });
-      }
-
-      function filter(q) {
-        q = q.toLowerCase().trim();
-        if (!q) return render(allItems);
-        selectedIdx = 0;
-        render(allItems.filter(it =>
-          it.label.toLowerCase().includes(q) ||
-          it.section.toLowerCase().includes(q) ||
-          it.href.toLowerCase().includes(q)
-        ));
-      }
-
-      trigger?.addEventListener("click", open);
-      heroSearch?.addEventListener("click", open);
-      overlay?.addEventListener("click", close);
-
-      document.addEventListener("keydown", (e) => {
-        if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-          e.preventDefault();
-          palette.classList.contains("cmd-open") ? close() : open();
-        }
-        if (!palette.classList.contains("cmd-open")) return;
-        if (e.key === "Escape") { close(); return; }
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          selectedIdx = Math.min(selectedIdx + 1, filtered.length - 1);
-          render(filtered);
-        }
-        if (e.key === "ArrowUp") {
-          e.preventDefault();
-          selectedIdx = Math.max(selectedIdx - 1, 0);
-          render(filtered);
-        }
-        if (e.key === "Enter" && filtered[selectedIdx]) {
-          e.preventDefault();
-          window.location.href = filtered[selectedIdx].href;
-        }
-      });
-
-      input?.addEventListener("input", (e) => filter(e.target.value));
-
-      results?.addEventListener("mouseover", (e) => {
-        const item = e.target.closest(".cmd-item");
-        if (item) {
-          selectedIdx = parseInt(item.dataset.i);
-          render(filtered);
-        }
-      });
-    </script>
+    <CommandPalette />
   </body>
 </html>


### PR DESCRIPTION
## What
Arrow-key navigation and clicking results in the docs quick search palette were both broken. The palette code was also duplicated between `DocsLayout.astro` and `index.astro`, so only one copy had fixes applied at a time.

## Why
The `mouseover` and arrow-key handlers called `render()`, which replaced `results.innerHTML` on every selection change. This destroyed the `<a>` element under the cursor between `mousedown` and `mouseup`, so the browser never paired them into a `click` event. It also caused a re-render loop: replacing an element under the cursor fires a new `mouseover` on its replacement, which calls `render()` again.

## Changes
- **`CommandPalette.astro`** (new): extracted the shared palette markup and script into a single component. Computes `allItems` and `currentPath` internally from the sidebar data — no props needed. Binds both `cmd-trigger` and `hero-search` as open triggers (the latter only exists on the index page; `?.addEventListener` no-ops elsewhere).
- **`DocsLayout.astro`**: replaced ~100 lines of inline palette code with `<CommandPalette />`. The remaining sidebar/TOC script dropped its `define:vars` since the palette was its only consumer.
- **`index.astro`**: replaced ~110 lines of duplicated palette code with `<CommandPalette />`.
- **Fix**: added a `select(idx)` function that swaps the `cmd-item--sel` class on existing DOM nodes instead of rebuilding the list. Arrow keys and mouseover use `select()`; `render()` is reserved for actual list changes (open, filter). The mouseover handler guards against redundant calls when the index hasn't changed.