### PR TITLE
refactor(server): make every route state the authority it demands

### DIFF
--- a/pkg/api/authorizer/permissions.go
+++ b/pkg/api/authorizer/permissions.go
@@ -49,6 +49,7 @@ const (
 	BillingRemovePaymentMethod
 	BillingCancelSubscription
 	BillingCreateSubscription
+	BillingGetCustomer
 	BillingGetPaymentMethod
 	BillingGetSubscription
 
@@ -204,6 +205,7 @@ var ownerPermissions = []Permission{
 	BillingRemovePaymentMethod,
 	BillingCancelSubscription,
 	BillingCreateSubscription,
+	BillingGetCustomer,
 	BillingGetSubscription,
 
 	APIKeyCreate,

--- a/pkg/api/authorizer/role_test.go
+++ b/pkg/api/authorizer/role_test.go
@@ -97,6 +97,7 @@ func TestRolePermissions(t *testing.T) {
 				authorizer.BillingRemovePaymentMethod,
 				authorizer.BillingCancelSubscription,
 				authorizer.BillingCreateSubscription,
+				authorizer.BillingGetCustomer,
 				authorizer.BillingGetSubscription,
 				authorizer.APIKeyCreate,
 				authorizer.APIKeyUpdate,

--- a/server/api/pkg/gateway/guard.go
+++ b/server/api/pkg/gateway/guard.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/labstack/echo/v5"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
@@ -34,5 +35,28 @@ func BlockAPIKey(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		return next(c)
+	}
+}
+
+// RequiresAnyPermission refuses the request with 403 unless the role the request authenticated
+// with holds at least one of permissions. Naming none refuses every request, so the programming
+// error fails closed rather than admitting every caller.
+//
+// It answers 403 for the same reason [RequiresPermission] does: the caller is known and simply not
+// allowed.
+func RequiresAnyPermission(permissions ...authorizer.Permission) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			ctx, ok := From(c)
+			if !ok {
+				return c.NoContent(http.StatusForbidden)
+			}
+
+			if !slices.ContainsFunc(permissions, ctx.Role().HasPermission) {
+				return c.NoContent(http.StatusForbidden)
+			}
+
+			return next(c)
+		}
 	}
 }

--- a/server/api/pkg/gateway/mount_test.go
+++ b/server/api/pkg/gateway/mount_test.go
@@ -93,8 +93,8 @@ func TestRequiresDeclaresThePermitItEnforces(t *testing.T) {
 
 			declarations := gateway.Declarations(e)
 			require.Len(t, declarations, 1)
-			assert.True(t, declarations[0].RequiresPermission)
-			assert.Equal(t, authorizer.DeviceRemove, declarations[0].Permission)
+			assert.Equal(t, gateway.AuthorityPermission, declarations[0].Authority)
+			assert.Equal(t, []authorizer.Permission{authorizer.DeviceRemove}, declarations[0].Permissions)
 
 			assert.Equal(t, tc.expectedStatus, probe(t, e, map[string]string{
 				"X-Tenant-ID": probeTenant,
@@ -174,10 +174,119 @@ func TestGuardDeclaresNothing(t *testing.T) {
 
 	declarations := gateway.Declarations(e)
 	require.Len(t, declarations, 1)
-	assert.False(t, declarations[0].RequiresPermission)
+	assert.Equal(t, gateway.AuthorityUnstated, declarations[0].Authority)
 	assert.False(t, declarations[0].BlocksAPIKey)
 
 	assert.Equal(t, http.StatusTeapot, probe(t, e, map[string]string{"X-Tenant-ID": probeTenant, "X-ID": "user-id"}))
+}
+
+// TestRequiresAnyDeclaresThePermitsItEnforces covers the route whose rule is two permissions,
+// which [gateway.Requires] cannot express: the option records the set and admits a role holding
+// any one of it, so the declaration is still evidence of what the route does.
+//
+// The roles nest, so no two permissions are held disjointly by two of them, and a role holding
+// both cannot show which element admitted it. What isolates one is a single role holding exactly
+// one: an administrator plays a session and cannot delete a namespace, so the two orderings below
+// admit on different elements of the set.
+func TestRequiresAnyDeclaresThePermitsItEnforces(t *testing.T) {
+	cases := []struct {
+		description    string
+		permissions    []authorizer.Permission
+		role           string
+		expectedStatus int
+	}{
+		{
+			description:    "refuses a role holding neither",
+			permissions:    []authorizer.Permission{authorizer.NamespaceDelete, authorizer.BillingCreateCustomer},
+			role:           "administrator",
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description:    "admits a role holding only the first",
+			permissions:    []authorizer.Permission{authorizer.SessionPlay, authorizer.NamespaceDelete},
+			role:           "administrator",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			description:    "admits a role holding only the second",
+			permissions:    []authorizer.Permission{authorizer.NamespaceDelete, authorizer.SessionPlay},
+			role:           "administrator",
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			e := probeRouter(t, true)
+			gateway.GET(rootOf(e), "/probe", okRoute(), gateway.RequiresAny(tc.permissions...))
+
+			declarations := gateway.Declarations(e)
+			require.Len(t, declarations, 1)
+			assert.Equal(t, gateway.AuthorityPermission, declarations[0].Authority)
+			assert.Equal(t, tc.permissions, declarations[0].Permissions)
+
+			assert.Equal(t, tc.expectedStatus, probe(t, e, map[string]string{
+				"X-Tenant-ID": probeTenant,
+				"X-ID":        "user-id",
+				"X-Role":      tc.role,
+			}))
+		})
+	}
+}
+
+// TestRequiresAnyRefusesEveryoneWhenItNamesNothing fails closed on the programming error, so a
+// route registered with an empty set answers 403 rather than admitting every caller while the
+// route table waits to be run.
+func TestRequiresAnyRefusesEveryoneWhenItNamesNothing(t *testing.T) {
+	e := probeRouter(t, true)
+	gateway.GET(rootOf(e), "/probe", okRoute(), gateway.RequiresAny())
+
+	assert.Equal(t, http.StatusForbidden, probe(t, e, map[string]string{
+		"X-Tenant-ID": probeTenant,
+		"X-ID":        "user-id",
+		"X-Role":      "owner",
+	}))
+}
+
+// TestStatedAbsenceOfAuthorityInstallsNothing pins the half of the vocabulary that is a claim and
+// not a guard: a route saying the handler decides, or that it demands nothing, records the reason
+// it typed and leaves the request otherwise untouched.
+func TestStatedAbsenceOfAuthorityInstallsNothing(t *testing.T) {
+	cases := []struct {
+		description       string
+		option            gateway.RouteOption
+		expectedAuthority gateway.Authority
+	}{
+		{
+			description:       "the handler decides",
+			option:            gateway.PermissionInHandler("the probe reads the namespace from its path"),
+			expectedAuthority: gateway.AuthorityInHandler,
+		},
+		{
+			description:       "the route demands none",
+			option:            gateway.NoPermission("the probe acts on the caller's own record"),
+			expectedAuthority: gateway.AuthorityNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			e := probeRouter(t, true)
+			gateway.GET(rootOf(e), "/probe", okRoute(), tc.option)
+
+			declarations := gateway.Declarations(e)
+			require.Len(t, declarations, 1)
+			assert.Equal(t, tc.expectedAuthority, declarations[0].Authority)
+			assert.NotEmpty(t, declarations[0].AuthorityReason)
+			assert.Empty(t, declarations[0].Permissions)
+
+			assert.Equal(t, http.StatusOK, probe(t, e, map[string]string{
+				"X-Tenant-ID": probeTenant,
+				"X-ID":        "user-id",
+				"X-Role":      "observer",
+			}))
+		})
+	}
 }
 
 func probe(t *testing.T, e *echo.Echo, headers map[string]string) int {

--- a/server/api/pkg/gateway/route.go
+++ b/server/api/pkg/gateway/route.go
@@ -33,6 +33,26 @@ const (
 	ShapeLegacy Shape = "legacy"
 )
 
+// Authority names how a route decides what it demands of the caller's role. A route states one,
+// or claims [Anonymous] — which discharges the question, because a request carrying no actor has
+// no role for a permission to be checked against.
+type Authority string
+
+const (
+	// AuthorityUnstated is a route that claimed nothing. It is the zero value because forgetting
+	// is what the route table has to be able to see.
+	AuthorityUnstated Authority = ""
+	// AuthorityPermission is a route admitting a caller whose role holds one of the permissions it
+	// named, refused by the guard the claim installs.
+	AuthorityPermission Authority = "permission"
+	// AuthorityInHandler is a route whose admission decision needs request data a middleware
+	// cannot see, so the check stays in the handler and the reason says why.
+	AuthorityInHandler Authority = "in-handler"
+	// AuthorityNone is a route that demands no authority at all, and the reason says why that is
+	// safe.
+	AuthorityNone Authority = "none"
+)
+
 // OneHandler answers with a single value. It is a function of its inputs: it does not know that
 // HTTP exists, and cannot be called without the namespace it is bounded to and the actor
 // performing it.
@@ -245,9 +265,47 @@ func Anonymous(reason string) RouteOption {
 // of what the route does rather than a description of it.
 func Requires(permission authorizer.Permission) RouteOption {
 	return func(d *Declaration) echo.MiddlewareFunc {
-		d.Permission, d.RequiresPermission = permission, true
+		d.Authority, d.Permissions = AuthorityPermission, []authorizer.Permission{permission}
 
 		return RequiresPermission(permission)
+	}
+}
+
+// RequiresAny declares the permissions the route admits a caller for holding any one of, and
+// installs the guard that enforces the set. It is [Requires] for a route whose rule is more than
+// one permission, which would otherwise have to choose between an inexpressible claim and none.
+//
+// Naming nothing refuses every caller, because a route admitting a role that holds nothing is what
+// [NoPermission] says.
+func RequiresAny(permissions ...authorizer.Permission) RouteOption {
+	return func(d *Declaration) echo.MiddlewareFunc {
+		d.Authority, d.Permissions = AuthorityPermission, permissions
+
+		return RequiresAnyPermission(permissions...)
+	}
+}
+
+// PermissionInHandler declares that the route's permission is checked past the middleware chain,
+// because the check needs request data no middleware can see: a namespace named by a code in the
+// path rather than by the session, or a query parameter the permission widens the answer to rather
+// than admits. The check stays where it is; the route stops reading as though it had none.
+func PermissionInHandler(reason string) RouteOption {
+	return func(d *Declaration) echo.MiddlewareFunc {
+		d.Authority, d.AuthorityReason = AuthorityInHandler, reason
+
+		return nil
+	}
+}
+
+// NoPermission declares that the route demands no authority of its caller, and records why that is
+// safe: it acts on the caller's own record, it is prior to holding any role, or the credential it
+// answers to carries no role at all. The reason is a required argument, so a route cannot become
+// permissionless by copy-paste.
+func NoPermission(reason string) RouteOption {
+	return func(d *Declaration) echo.MiddlewareFunc {
+		d.Authority, d.AuthorityReason = AuthorityNone, reason
+
+		return nil
 	}
 }
 
@@ -301,10 +359,20 @@ type Declaration struct {
 	Method string
 	Path   string
 
-	// Permission is what the route demands of the caller's role. The zero value is a real
-	// permission, so RequiresPermission is what tells it apart from a route demanding none.
-	Permission         authorizer.Permission
-	RequiresPermission bool
+	// Authority is what the route demands of the caller's role, as one of a closed set. The zero
+	// value is a route that claimed nothing, which is what tells a forgotten claim from a route
+	// deliberately demanding none.
+	Authority Authority
+
+	// AuthorityReason is why the route installs no permission guard — because the check is past
+	// the middleware chain, or because there is nothing to check. It is set by the two claims that
+	// install no guard, and empty for the one that does.
+	AuthorityReason string
+
+	// Permissions is the set the caller's role must intersect for the route to admit the call. One
+	// element is [Requires]; several is [RequiresAny]. It is empty unless Authority is
+	// [AuthorityPermission].
+	Permissions []authorizer.Permission
 
 	// BlocksAPIKey reports whether the route refuses a request authenticated by an API key. The
 	// refusal is about the credential and not the authority: a key carrying a role that holds the

--- a/server/api/routes/anonymous.go
+++ b/server/api/routes/anonymous.go
@@ -15,9 +15,11 @@ func registerAnonymousRoutes(authn *routesmiddleware.Authenticator) {
 	}
 
 	allow(http.MethodPost, AuthLocalUserURL)
+	allow(http.MethodPost, AuthLocalUserURLV2)
 	allow(http.MethodPost, RegisterUserURL)
 
 	allow(http.MethodPost, AuthDeviceURL)
+	allow(http.MethodPost, AuthDeviceURLV2)
 
 	allow(http.MethodPost, CreateDevicePairingURL)
 	allow(http.MethodGet, GetDevicePairingStatusURL)

--- a/server/api/routes/anonymous_test.go
+++ b/server/api/routes/anonymous_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/envs/envstest"
+	"github.com/shellhub-io/shellhub/pkg/models"
 	routesmiddleware "github.com/shellhub-io/shellhub/server/api/routes/middleware"
 	"github.com/shellhub-io/shellhub/server/api/services"
 	serviceMocks "github.com/shellhub-io/shellhub/server/api/services/mocks"
@@ -174,5 +175,75 @@ func TestAnonymousRouteReachableWithoutCredential(t *testing.T) {
 	require.NotNil(t, seen)
 	for key := range forged {
 		assert.Empty(t, seen.Get(key), "%s reached the handler", key)
+	}
+}
+
+// TestAuthenticationRoutesAnswerBothSpellings drives the bug this rung fixed. Each authentication
+// endpoint has a V2 path under /auth, and the pair is what deployed agents and current clients
+// respectively call. The V2 spellings were mounted without their siblings' anonymity claim and
+// added to no allowlist, so the authenticator refused the very clients they exist for — the call
+// never reached the handler, and answered 401 whatever the credentials were worth.
+func TestAuthenticationRoutesAnswerBothSpellings(t *testing.T) {
+	cases := []struct {
+		description string
+		target      string
+		body        string
+		mock        func(*serviceMocks.MockService)
+	}{
+		{
+			description: "a device against the older path",
+			target:      "/api" + AuthDeviceURL,
+			body:        `{"info":{"id":"manjaro"},"hostname":"device","public_key":"key","tenant_id":"tenant"}`,
+			mock: func(service *serviceMocks.MockService) {
+				service.On("AuthDevice", mock.Anything, mock.AnythingOfType("requests.DeviceAuth")).
+					Return(&models.DeviceAuthResponse{}, nil).
+					Once()
+			},
+		},
+		{
+			description: "a device against the V2 path",
+			target:      "/api" + AuthDeviceURLV2,
+			body:        `{"info":{"id":"manjaro"},"hostname":"device","public_key":"key","tenant_id":"tenant"}`,
+			mock: func(service *serviceMocks.MockService) {
+				service.On("AuthDevice", mock.Anything, mock.AnythingOfType("requests.DeviceAuth")).
+					Return(&models.DeviceAuthResponse{}, nil).
+					Once()
+			},
+		},
+		{
+			description: "a user against the older path",
+			target:      "/api" + AuthLocalUserURL,
+			body:        `{"username":"user","password":"secret"}`,
+			mock: func(service *serviceMocks.MockService) {
+				service.On("AuthLocalUser", mock.Anything, mock.AnythingOfType("*requests.AuthLocalUser"), mock.Anything).
+					Return(&models.UserAuthResponse{}, int64(0), "", nil).
+					Once()
+			},
+		},
+		{
+			description: "a user against the V2 path",
+			target:      "/api" + AuthLocalUserURLV2,
+			body:        `{"username":"user","password":"secret"}`,
+			mock: func(service *serviceMocks.MockService) {
+				service.On("AuthLocalUser", mock.Anything, mock.AnythingOfType("*requests.AuthLocalUser"), mock.Anything).
+					Return(&models.UserAuthResponse{}, int64(0), "", nil).
+					Once()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			router, _, service := authenticatedRouter(t)
+			tc.mock(service)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, tc.target, strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		})
 	}
 }

--- a/server/api/routes/auth.go
+++ b/server/api/routes/auth.go
@@ -106,8 +106,9 @@ func (h *Handler) CreateUserToken(c *gateway.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
-// AuthPublicKey authenticates by SSH key, which is how the SSH gateway checks a key the
-// client offered before opening a session.
+// AuthPublicKey signs the payload with the private key the given fingerprint names, which is
+// how an agent proves to a device that the request reaching it came through ShellHub. The
+// fingerprint is the whole lookup: no namespace bounds it.
 func (h *Handler) AuthPublicKey(c *gateway.Context) error {
 	var req requests.PublicKeyAuth
 	if err := c.Bind(&req); err != nil {

--- a/server/api/routes/guard_test.go
+++ b/server/api/routes/guard_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/api/services/mocks"
 	"github.com/stretchr/testify/assert"
@@ -76,6 +77,60 @@ func TestGuardsRefuseWhatTheyRefusedBefore(t *testing.T) {
 				service.
 					On("ListAPIKeys", gomock.Anything, gomock.AnythingOfType("*requests.ListAPIKey")).
 					Return([]models.APIKey{}, 0, nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			description: "the any-permission guard refuses a role holding neither of the two",
+			method:      http.MethodDelete,
+			target:      "/api/ssh-identities/1234",
+			headers: map[string]string{
+				"X-ID":        "000000000000000000000000",
+				"X-Tenant-ID": guardTenant,
+				"X-Role":      authorizer.RoleObserver.String(),
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description: "the any-permission guard admits a role holding only the enrol one, and tells the service so",
+			method:      http.MethodDelete,
+			target:      "/api/ssh-identities/1234",
+			headers: map[string]string{
+				"X-ID":        "000000000000000000000000",
+				"X-Tenant-ID": guardTenant,
+				"X-Role":      authorizer.RoleOperator.String(),
+			},
+			mocks: func(service *mocks.MockService) {
+				service.
+					On("DeleteSSHIdentity", gomock.Anything, &requests.SSHIdentityDelete{
+						SSHIdentityIDParam: requests.SSHIdentityIDParam{ID: "1234"},
+						UserID:             "000000000000000000000000",
+						TenantID:           guardTenant,
+					}).
+					Return(nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			description: "the any-permission guard admits a role holding the manage one, and tells the service so",
+			method:      http.MethodDelete,
+			target:      "/api/ssh-identities/1234",
+			headers: map[string]string{
+				"X-ID":        "000000000000000000000000",
+				"X-Tenant-ID": guardTenant,
+				"X-Role":      authorizer.RoleOwner.String(),
+			},
+			mocks: func(service *mocks.MockService) {
+				service.
+					On("DeleteSSHIdentity", gomock.Anything, &requests.SSHIdentityDelete{
+						SSHIdentityIDParam: requests.SSHIdentityIDParam{ID: "1234"},
+						UserID:             "000000000000000000000000",
+						TenantID:           guardTenant,
+						Manage:             true,
+					}).
+					Return(nil).
 					Once()
 			},
 			expectedStatus: http.StatusOK,

--- a/server/api/routes/route_table_test.go
+++ b/server/api/routes/route_table_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v5"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
 	routesmiddleware "github.com/shellhub-io/shellhub/server/api/routes/middleware"
 	sshhttp "github.com/shellhub-io/shellhub/server/ssh/http"
@@ -52,6 +53,31 @@ func unstatedClaims(declarations []gateway.Declaration) []string {
 			unstated = append(unstated, declaration.Address()+" requires no actor and states no reason")
 		}
 	}
+
+	return unstated
+}
+
+func unstatedAuthority(declarations []gateway.Declaration) []string {
+	unstated := make([]string, 0)
+
+	for _, declaration := range declarations {
+		switch declaration.Authority {
+		case gateway.AuthorityPermission:
+			if len(declaration.Permissions) == 0 {
+				unstated = append(unstated, declaration.Address()+" demands a permission and names none")
+			}
+		case gateway.AuthorityInHandler, gateway.AuthorityNone:
+			if strings.TrimSpace(declaration.AuthorityReason) == "" {
+				unstated = append(unstated, declaration.Address()+" leaves its authority to the handler or demands none, and states no reason")
+			}
+		case gateway.AuthorityUnstated:
+			if !declaration.Anonymous {
+				unstated = append(unstated, declaration.Address()+" demands no permission and states no reason")
+			}
+		}
+	}
+
+	sort.Strings(unstated)
 
 	return unstated
 }
@@ -138,6 +164,43 @@ func anonymityMismatches(declarations []gateway.Declaration, allowlist []string)
 	return mismatches
 }
 
+func anonymityDisagreements(declarations []gateway.Declaration) []string {
+	byHandler := make(map[string][]gateway.Declaration, len(declarations))
+	for _, declaration := range declarations {
+		byHandler[declaration.Handler] = append(byHandler[declaration.Handler], declaration)
+	}
+
+	disagreements := make([]string, 0)
+
+	for _, mounts := range byHandler {
+		anonymous, credentialed := make([]string, 0), make([]string, 0)
+
+		for _, declaration := range mounts {
+			if declaration.Anonymous {
+				anonymous = append(anonymous, declaration.Address())
+
+				continue
+			}
+
+			credentialed = append(credentialed, declaration.Address())
+		}
+
+		if len(anonymous) == 0 || len(credentialed) == 0 {
+			continue
+		}
+
+		sort.Strings(anonymous)
+		sort.Strings(credentialed)
+
+		disagreements = append(disagreements,
+			strings.Join(credentialed, ", ")+" demand a credential but "+strings.Join(anonymous, ", ")+" serves the same handler without one")
+	}
+
+	sort.Strings(disagreements)
+
+	return disagreements
+}
+
 func misplacedComposedRoutes(router *echo.Echo, composed map[string]string) []string {
 	misplaced := make([]string, 0)
 
@@ -207,6 +270,10 @@ func TestRouteTableHoldsItsClaims(t *testing.T) {
 		assert.Empty(t, unstatedClaims(declarations))
 	})
 
+	t.Run("every route states the authority it demands", func(t *testing.T) {
+		assert.Empty(t, unstatedAuthority(declarations))
+	})
+
 	t.Run("every mounted route is declared or exempt", func(t *testing.T) {
 		assert.Empty(t, undeclaredRoutes(registered, declarations, gatewayExemptRoutes))
 	})
@@ -221,6 +288,10 @@ func TestRouteTableHoldsItsClaims(t *testing.T) {
 
 	t.Run("the anonymity claims and the allowlist agree", func(t *testing.T) {
 		assert.Empty(t, anonymityMismatches(declarations, authn.AnonymousRoutes()))
+	})
+
+	t.Run("routes serving the same handler agree on whether it needs a credential", func(t *testing.T) {
+		assert.Empty(t, anonymityDisagreements(declarations))
 	})
 
 	t.Run("every list route names a query contract", func(t *testing.T) {
@@ -248,6 +319,27 @@ func TestUnstatedClaimsRefusesAnEmptyReason(t *testing.T) {
 	for _, complaint := range unstated {
 		assert.Contains(t, complaint, "/silent")
 	}
+}
+
+// TestUnstatedAuthorityRefusesARouteThatDemandsNothingSilently proves the check above bites. Its
+// three complaints are the three ways a route can leave a reader unable to tell a decision from an
+// omission: no claim at all, a claim whose reason nobody typed, and a permission set naming
+// nothing.
+func TestUnstatedAuthorityRefusesARouteThatDemandsNothingSilently(t *testing.T) {
+	unstated := unstatedAuthority([]gateway.Declaration{
+		{Method: "GET", Path: "/anonymous", Anonymous: true},
+		{Method: "GET", Path: "/empty", Authority: gateway.AuthorityPermission},
+		{Method: "GET", Path: "/guarded", Authority: gateway.AuthorityPermission, Permissions: []authorizer.Permission{authorizer.DeviceRemove}},
+		{Method: "GET", Path: "/handler", Authority: gateway.AuthorityInHandler, AuthorityReason: "the path names the namespace"},
+		{Method: "GET", Path: "/silent"},
+		{Method: "GET", Path: "/unreasoned", Authority: gateway.AuthorityNone, AuthorityReason: "  "},
+	})
+
+	assert.Equal(t, []string{
+		"GET /empty demands a permission and names none",
+		"GET /silent demands no permission and states no reason",
+		"GET /unreasoned leaves its authority to the handler or demands none, and states no reason",
+	}, unstated)
 }
 
 // TestUndeclaredRoutesCatchesARouteThatClaimsNothing drives the case the invariant exists for: a
@@ -315,6 +407,25 @@ func TestAnonymityMismatchesCatchesBothDirections(t *testing.T) {
 	require.Len(t, mismatches, 2)
 	assert.Contains(t, mismatches[0], "/unreachable")
 	assert.Contains(t, mismatches[1], "/open")
+}
+
+// TestAnonymityDisagreementsCatchesASecondSpellingThatForgot is the direction anonymityMismatches
+// cannot see: a route claiming nothing and allowlisted nowhere reads as consistent to it, because
+// that is what every authenticated route looks like. What distinguishes the bug is the handler —
+// a second spelling of an endpoint mounted beside the first and given none of its claims answers
+// 401 to the very clients it exists for, and only its sibling says so.
+func TestAnonymityDisagreementsCatchesASecondSpellingThatForgot(t *testing.T) {
+	disagreements := anonymityDisagreements([]gateway.Declaration{
+		{Method: "POST", Path: "/devices/auth", Handler: "AuthDevice", Anonymous: true},
+		{Method: "POST", Path: "/auth/device", Handler: "AuthDevice"},
+		{Method: "GET", Path: "/tags", Handler: "GetTags"},
+		{Method: "GET", Path: "/namespaces/:tenant/tags", Handler: "GetTags"},
+		{Method: "GET", Path: "/info", Handler: "GetSystemInfo", Anonymous: true},
+	})
+
+	assert.Equal(t, []string{
+		"POST /auth/device demand a credential but POST /devices/auth serves the same handler without one",
+	}, disagreements)
 }
 
 // TestMisplacedComposedRoutesCatchesOneThatMoved keeps the naming honest in the only direction

--- a/server/api/routes/routes.go
+++ b/server/api/routes/routes.go
@@ -123,20 +123,26 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 		gateway.Unbounded("the health check reports on the instance, which belongs to no namespace"),
 		gateway.Anonymous("the health check is what a load balancer asks before any credential exists"))
 
-	gateway.GET(publicAPI, AuthLocalUserURLV2, gateway.Handler(handler.CreateUserToken))                         // TODO: method POST
-	gateway.GET(publicAPI, AuthUserTokenPublicURL, gateway.Handler(handler.CreateUserToken), gateway.NoAPIKey()) // TODO: method POST
+	gateway.GET(publicAPI, AuthLocalUserURLV2, gateway.Handler(handler.CreateUserToken), // TODO: method POST
+		gateway.PermissionInHandler("the service mints a token only for a namespace the caller already belongs to, which is a membership question and not a role one"))
+	gateway.GET(publicAPI, AuthUserTokenPublicURL, gateway.Handler(handler.CreateUserToken), gateway.NoAPIKey(), // TODO: method POST
+		gateway.PermissionInHandler("the service mints a token only for a namespace the caller already belongs to, which is a membership question and not a role one"))
 	gateway.POST(publicAPI, AuthDeviceURL, gateway.Handler(handler.AuthDevice),
 		gateway.Anonymous("a device authenticates with its own credentials, and holds none before this call answers"))
-	gateway.POST(publicAPI, AuthDeviceURLV2, gateway.Handler(handler.AuthDevice))
+	gateway.POST(publicAPI, AuthDeviceURLV2, gateway.Handler(handler.AuthDevice),
+		gateway.Anonymous("a device authenticates with its own credentials, and holds none before this call answers"))
 	gateway.POST(publicAPI, EnrollmentCallbackURL, gateway.Handler(handler.EnrollmentCallback),
 		gateway.Anonymous("the enrollment provider calls back with the token it was issued, not with a ShellHub credential"))
 	gateway.POST(publicAPI, AuthLocalUserURL, gateway.Handler(handler.AuthLocalUser),
 		gateway.Anonymous("signing in is what produces a credential, so it cannot demand one"))
-	gateway.POST(publicAPI, AuthLocalUserURLV2, gateway.Handler(handler.AuthLocalUser))
-	gateway.POST(publicAPI, AuthPublicKeyURL, gateway.Handler(handler.AuthPublicKey))
+	gateway.POST(publicAPI, AuthLocalUserURLV2, gateway.Handler(handler.AuthLocalUser),
+		gateway.Anonymous("signing in is what produces a credential, so it cannot demand one"))
+	gateway.POST(publicAPI, AuthPublicKeyURL, gateway.Handler(handler.AuthPublicKey),
+		gateway.NoPermission("the agent authenticates with its own device token, which carries no role, and the service signs with the private key the fingerprint names rather than reading the namespace the token is scoped to"))
 
 	gateway.POST(publicAPI, CreateAPIKeyURL, gateway.Handler(handler.CreateAPIKey), gateway.NoAPIKey(), gateway.Requires(authorizer.APIKeyCreate))
-	gateway.GET(publicAPI, ListAPIKeysURL, gateway.List(handler.ListAPIKeys), gateway.Accepts(services.APIKeyQuery), gateway.NoAPIKey())
+	gateway.GET(publicAPI, ListAPIKeysURL, gateway.List(handler.ListAPIKeys), gateway.Accepts(services.APIKeyQuery), gateway.NoAPIKey(),
+		gateway.NoPermission("the listing is bounded to the namespace the caller is scoped to, and names no key's secret"))
 	gateway.PATCH(publicAPI, UpdateAPIKeyURL, gateway.Handler(handler.UpdateAPIKey), gateway.NoAPIKey(), gateway.Requires(authorizer.APIKeyUpdate))
 	gateway.DELETE(publicAPI, DeleteAPIKeyURL, gateway.Handler(handler.DeleteAPIKey), gateway.NoAPIKey(), gateway.Requires(authorizer.APIKeyDelete))
 
@@ -146,88 +152,114 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	gateway.GET(publicAPI, RevealInstallKeyURL, gateway.Handler(handler.RevealInstallKey), gateway.NoAPIKey(), gateway.Requires(authorizer.InstallKeyReveal))
 	gateway.GET(publicAPI, HistoryInstallKeyURL, gateway.List(handler.HistoryInstallKey), gateway.Accepts(services.InstallKeyEventQuery), gateway.NoAPIKey(), gateway.Requires(authorizer.InstallKeyList))
 
-	gateway.PATCH(publicAPI, URLUpdateUser, gateway.Handler(handler.UpdateUser), gateway.NoAPIKey())
-	gateway.PATCH(publicAPI, URLDeprecatedUpdateUser, gateway.Handler(handler.UpdateUser), gateway.NoAPIKey())                 // WARN: DEPRECATED.
-	gateway.PATCH(publicAPI, URLDeprecatedUpdateUserPassword, gateway.Handler(handler.UpdateUserPassword), gateway.NoAPIKey()) // WARN: DEPRECATED.
+	gateway.PATCH(publicAPI, URLUpdateUser, gateway.Handler(handler.UpdateUser), gateway.NoAPIKey(),
+		gateway.NoPermission("the caller edits their own account, which is theirs to edit whatever role they hold anywhere"))
+	gateway.PATCH(publicAPI, URLDeprecatedUpdateUser, gateway.Handler(handler.UpdateUser), gateway.NoAPIKey(), // WARN: DEPRECATED.
+		gateway.NoPermission("the caller edits their own account, which is theirs to edit whatever role they hold anywhere"))
+	gateway.PATCH(publicAPI, URLDeprecatedUpdateUserPassword, gateway.Handler(handler.UpdateUserPassword), gateway.NoAPIKey(), // WARN: DEPRECATED.
+		gateway.NoPermission("the caller changes their own password, which is theirs to change whatever role they hold anywhere"))
 
 	gateway.POST(publicAPI, RegisterUserURL, gateway.Handler(handler.RegisterUser),
 		gateway.Anonymous("registering is what creates the person a credential would name"))
 	gateway.GET(publicAPI, URLResolveInvitation, gateway.Handler(handler.ResolveInvitation),
 		gateway.Anonymous("an invitee follows the link before holding an account, and the signed invitation is the credential"))
 	gateway.POST(publicAPI, URLGenerateInvitationLink, gateway.Handler(handler.GenerateInvitationLink), gateway.NoAPIKey(), gateway.Requires(authorizer.NamespaceAddMember))
-	gateway.PATCH(publicAPI, URLAcceptInvite, gateway.Handler(handler.AcceptInvite), gateway.NoAPIKey())
+	gateway.PATCH(publicAPI, URLAcceptInvite, gateway.Handler(handler.AcceptInvite), gateway.NoAPIKey(),
+		gateway.NoPermission("accepting is what grants the role, so the invitee holds none in the namespace yet"))
 	gateway.GET(publicAPI, URLUserMembershipInvitationList, gateway.List(handler.GetUserMembershipInvitationList), gateway.Accepts(services.MembershipInvitationQuery),
-		gateway.Unbounded("an invitation is addressed to a person across namespaces, and the invitee may belong to none yet"))
+		gateway.Unbounded("an invitation is addressed to a person across namespaces, and the invitee may belong to none yet"),
+		gateway.NoPermission("the listing answers which invitations name the caller, who holds no role in the namespaces inviting them"))
 	gateway.GET(publicAPI, URLNamespaceMembershipInvitationList, gateway.List(handler.GetNamespaceMembershipInvitationList), gateway.Accepts(services.MembershipInvitationQuery), gateway.Requires(authorizer.NamespaceEditMember))
 	gateway.DELETE(publicAPI, URLCancelMembershipInvitation, gateway.Handler(handler.CancelMembershipInvitation), gateway.Requires(authorizer.NamespaceRemoveMember))
 
-	gateway.GET(publicAPI, GetDeviceListURL, gateway.List(handler.GetDeviceList), gateway.Accepts(services.DeviceQuery), gateway.Guard(routesmiddleware.Authorize))
-	gateway.GET(publicAPI, GetDeviceURL, gateway.One(handler.GetDevice), gateway.Guard(routesmiddleware.Authorize))
-	gateway.GET(publicAPI, ResolveDeviceURL, gateway.Handler(handler.ResolveDevice), gateway.Guard(routesmiddleware.Authorize))
+	gateway.GET(publicAPI, GetDeviceListURL, gateway.List(handler.GetDeviceList), gateway.Accepts(services.DeviceQuery), gateway.Guard(routesmiddleware.Authorize),
+		gateway.NoPermission("every namespace member reads the namespace's devices, and the scope the request is bounded to is what limits the answer"))
+	gateway.GET(publicAPI, GetDeviceURL, gateway.One(handler.GetDevice), gateway.Guard(routesmiddleware.Authorize),
+		gateway.NoPermission("every namespace member reads the namespace's devices, and the scope the request is bounded to is what limits the answer"))
+	gateway.GET(publicAPI, ResolveDeviceURL, gateway.Handler(handler.ResolveDevice), gateway.Guard(routesmiddleware.Authorize),
+		gateway.NoPermission("every namespace member reads the namespace's devices, and the scope the request is bounded to is what limits the answer"))
 	gateway.PUT(publicAPI, UpdateDevice, gateway.Handler(handler.UpdateDevice), gateway.Requires(authorizer.DeviceUpdate))
 	gateway.PATCH(publicAPI, RenameDeviceURL, gateway.Handler(handler.RenameDevice), gateway.Requires(authorizer.DeviceRename))
 	gateway.PATCH(publicAPI, UpdateDeviceStatusURL, gateway.Handler(handler.UpdateDeviceStatus), gateway.Requires(authorizer.DeviceAccept)) // TODO: DeviceWrite
 
-	gateway.POST(publicAPI, CreateDeviceLoginCodeURL, gateway.Handler(handler.CreateDeviceLoginCode))
-	gateway.GET(publicAPI, GetDeviceAuthStatusURL, gateway.Handler(handler.GetDeviceAuthStatus))
-	gateway.GET(publicAPI, ResolveDeviceLoginCodeURL, gateway.Handler(handler.ResolveDeviceLoginCode), gateway.NoAPIKey())
+	gateway.POST(publicAPI, CreateDeviceLoginCodeURL, gateway.Handler(handler.CreateDeviceLoginCode),
+		gateway.NoPermission("the caller is a device authenticating with its own token, which names no member and carries no role"))
+	gateway.GET(publicAPI, GetDeviceAuthStatusURL, gateway.Handler(handler.GetDeviceAuthStatus),
+		gateway.NoPermission("the caller is a device polling its own login code, which names no member and carries no role"))
+	gateway.GET(publicAPI, ResolveDeviceLoginCodeURL, gateway.Handler(handler.ResolveDeviceLoginCode), gateway.NoAPIKey(),
+		gateway.PermissionInHandler("the device's namespace comes from the code in the path and not from the caller's session, so the service is where membership in it is checked — and a code that names a pairing rather than a device answers before there is a namespace to be a member of"))
 
 	gateway.POST(publicAPI, CreateDevicePairingURL, gateway.Handler(handler.CreateDevicePairing),
 		gateway.Anonymous("an unpaired agent asks for a pairing code with no namespace behind it yet"))
 	gateway.GET(publicAPI, GetDevicePairingStatusURL, gateway.Handler(handler.GetDevicePairingStatus),
 		gateway.Anonymous("the agent polls its own pairing code, which is the only secret the call needs"))
-	gateway.POST(publicAPI, AcceptDevicePairingURL, gateway.Handler(handler.AcceptDevicePairing), gateway.NoAPIKey())
+	gateway.POST(publicAPI, AcceptDevicePairingURL, gateway.Handler(handler.AcceptDevicePairing), gateway.NoAPIKey(),
+		gateway.PermissionInHandler("the namespace being paired into comes from the code in the path and not from the caller's session, so the service is where the role can be checked against it"))
 	gateway.POST(publicAPI, PrepareDevicePairingURL, gateway.Handler(handler.PrepareDevicePairing), gateway.NoAPIKey(), gateway.Requires(authorizer.DeviceAccept))
 
-	gateway.GET(publicAPI, GetSSHApprovalURL, gateway.Handler(handler.GetSSHApproval), gateway.NoAPIKey())
-	gateway.POST(publicAPI, ConfirmSSHApprovalURL, gateway.Handler(handler.ConfirmSSHApproval), gateway.NoAPIKey())
-	gateway.POST(publicAPI, RejectSSHApprovalURL, gateway.Handler(handler.RejectSSHApproval), gateway.NoAPIKey())
+	gateway.GET(publicAPI, GetSSHApprovalURL, gateway.Handler(handler.GetSSHApproval), gateway.NoAPIKey(),
+		gateway.PermissionInHandler("the approval names the namespace, not the caller's session, so the service is where membership in it is checked"))
+	gateway.POST(publicAPI, ConfirmSSHApprovalURL, gateway.Handler(handler.ConfirmSSHApproval), gateway.NoAPIKey(),
+		gateway.PermissionInHandler("the approval names the namespace, not the caller's session, so SessionApprove and SSHIdentityAdd are checked in the service against the role the caller holds there"))
+	gateway.POST(publicAPI, RejectSSHApprovalURL, gateway.Handler(handler.RejectSSHApproval), gateway.NoAPIKey(),
+		gateway.PermissionInHandler("the approval names the namespace, not the caller's session, so SessionApprove is checked in the service against the role the caller holds there"))
 	gateway.DELETE(publicAPI, DeleteDeviceURL, gateway.Handler(handler.DeleteDevice), gateway.Requires(authorizer.DeviceRemove))
 	gateway.PUT(publicAPI, SetDeviceCustomFieldURL, gateway.Handler(handler.SetDeviceCustomField), gateway.Requires(authorizer.DeviceCustomFieldUpdate))
 	gateway.DELETE(publicAPI, DeleteDeviceCustomFieldURL, gateway.Handler(handler.DeleteDeviceCustomField), gateway.Requires(authorizer.DeviceCustomFieldUpdate))
 
-	gateway.GET(publicAPI, URLGetTags, gateway.List(handler.GetTags), gateway.Accepts(services.TagQuery))
+	gateway.GET(publicAPI, URLGetTags, gateway.List(handler.GetTags), gateway.Accepts(services.TagQuery),
+		gateway.NoPermission("every namespace member reads the namespace's tags, and the scope the request is bounded to is what limits the answer"))
 	gateway.POST(publicAPI, URLCreateTag, gateway.Handler(handler.CreateTag), gateway.Requires(authorizer.TagCreate))
 	gateway.PATCH(publicAPI, URLUpdateTag, gateway.Handler(handler.UpdateTag), gateway.Requires(authorizer.TagUpdate))
 	gateway.DELETE(publicAPI, URLDeleteTag, gateway.Handler(handler.DeleteTag), gateway.Requires(authorizer.TagDelete))
 	gateway.POST(publicAPI, URLPushTagToDevice, gateway.Handler(handler.PushTagToDevice), gateway.Requires(authorizer.TagCreate))
 	gateway.DELETE(publicAPI, URLPullTagFromDevice, gateway.Handler(handler.PullTagFromDevice), gateway.Requires(authorizer.TagDelete))
 
-	gateway.GET(publicAPI, URLOldGetTags, gateway.List(handler.GetTags), gateway.Accepts(services.TagQuery))
+	gateway.GET(publicAPI, URLOldGetTags, gateway.List(handler.GetTags), gateway.Accepts(services.TagQuery),
+		gateway.NoPermission("every namespace member reads the namespace's tags, and the scope the request is bounded to is what limits the answer"))
 	gateway.POST(publicAPI, URLOldCreateTag, gateway.Handler(handler.CreateTag), gateway.Requires(authorizer.TagCreate))
 	gateway.PATCH(publicAPI, URLOldUpdateTag, gateway.Handler(handler.UpdateTag), gateway.Requires(authorizer.TagUpdate))
 	gateway.DELETE(publicAPI, URLOldDeleteTag, gateway.Handler(handler.DeleteTag), gateway.Requires(authorizer.TagDelete))
 	gateway.POST(publicAPI, URLOldPushTagToDevice, gateway.Handler(handler.PushTagToDevice), gateway.Requires(authorizer.TagCreate))
 	gateway.DELETE(publicAPI, URLOldPullTagFromDevice, gateway.Handler(handler.PullTagFromDevice), gateway.Requires(authorizer.TagDelete))
 
-	gateway.GET(publicAPI, GetSessionsURL, gateway.List(handler.GetSessionList), gateway.Accepts(services.SessionQuery), gateway.Guard(routesmiddleware.Authorize))
-	gateway.GET(publicAPI, GetSessionURL, gateway.Handler(handler.GetSession), gateway.Guard(routesmiddleware.Authorize))
+	gateway.GET(publicAPI, GetSessionsURL, gateway.List(handler.GetSessionList), gateway.Accepts(services.SessionQuery), gateway.Guard(routesmiddleware.Authorize),
+		gateway.NoPermission("every namespace member reads the namespace's sessions, and the scope the request is bounded to is what limits the answer"))
+	gateway.GET(publicAPI, GetSessionURL, gateway.Handler(handler.GetSession), gateway.Guard(routesmiddleware.Authorize),
+		gateway.NoPermission("every namespace member reads the namespace's sessions, and the scope the request is bounded to is what limits the answer"))
 
-	gateway.GET(publicAPI, GetStatsURL, gateway.Handler(handler.GetStats), gateway.Guard(routesmiddleware.Authorize))
+	gateway.GET(publicAPI, GetStatsURL, gateway.Handler(handler.GetStats), gateway.Guard(routesmiddleware.Authorize),
+		gateway.NoPermission("the counts describe the namespace the request is bounded to, and name nothing a member cannot already read"))
 	gateway.GET(publicAPI, GetSystemInfoURL, gateway.Handler(handler.GetSystemInfo),
 		gateway.Anonymous("the instance describes itself to a browser that has not signed in yet"))
 	gateway.GET(publicAPI, GetSystemDownloadInstallScriptURL, gateway.Handler(handler.GetSystemDownloadInstallScript),
 		gateway.Anonymous("the install script is fetched by a shell on a machine that holds no credential"))
 
 	gateway.POST(publicAPI, CreatePublicKeyURL, gateway.Handler(handler.CreatePublicKey), gateway.Requires(authorizer.PublicKeyCreate))
-	gateway.GET(publicAPI, GetPublicKeysURL, gateway.List(handler.GetPublicKeys), gateway.Accepts(services.PublicKeyQuery))
+	gateway.GET(publicAPI, GetPublicKeysURL, gateway.List(handler.GetPublicKeys), gateway.Accepts(services.PublicKeyQuery),
+		gateway.NoPermission("every namespace member reads the namespace's public keys, and the scope the request is bounded to is what limits the answer"))
 	gateway.PUT(publicAPI, UpdatePublicKeyURL, gateway.Handler(handler.UpdatePublicKey), gateway.Requires(authorizer.PublicKeyEdit))
 	gateway.DELETE(publicAPI, DeletePublicKeyURL, gateway.Handler(handler.DeletePublicKey), gateway.Requires(authorizer.PublicKeyRemove))
 
 	if envs.IsEnterpriseOrCloud() {
-		gateway.POST(publicAPI, CreateNamespaceURL, gateway.Handler(handler.CreateNamespace), gateway.NoAPIKey())
+		gateway.POST(publicAPI, CreateNamespaceURL, gateway.Handler(handler.CreateNamespace), gateway.NoAPIKey(),
+			gateway.NoPermission("creating a namespace is prior to holding a role in one, and the caller becomes its owner"))
 	}
-	gateway.GET(publicAPI, GetNamespaceURL, gateway.Handler(handler.GetNamespace), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)))
+	gateway.GET(publicAPI, GetNamespaceURL, gateway.Handler(handler.GetNamespace), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)),
+		gateway.PermissionInHandler("the handler refuses a user the namespace does not list as a member, which is a membership question and not a role one, and the tenant guard is what bounds a credential naming no user"))
 	gateway.GET(publicAPI, ListNamespaceURL, gateway.List(handler.GetNamespaceList), gateway.Accepts(services.NamespaceQuery), gateway.NoAPIKey(),
-		gateway.Unbounded("the list answers which namespaces the caller belongs to, and the caller may have selected none"))
+		gateway.Unbounded("the list answers which namespaces the caller belongs to, and the caller may have selected none"),
+		gateway.NoPermission("the answer is about the caller rather than about any one namespace, so there is no namespace to hold a role in"))
 	gateway.PUT(publicAPI, EditNamespaceURL, gateway.Handler(handler.EditNamespace), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)), gateway.Requires(authorizer.NamespaceUpdate))
 	gateway.DELETE(publicAPI, DeleteNamespaceURL, gateway.Handler(handler.DeleteNamespace), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)), gateway.Requires(authorizer.NamespaceDelete))
 
-	gateway.GET(publicAPI, ListNamespaceMembersURL, gateway.List(handler.ListNamespaceMembers), gateway.Accepts(services.MemberQuery), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)))
+	gateway.GET(publicAPI, ListNamespaceMembersURL, gateway.List(handler.ListNamespaceMembers), gateway.Accepts(services.MemberQuery), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)),
+		gateway.NoPermission("every namespace member reads who else belongs, and the scope the request is bounded to is what limits the answer"))
 	gateway.POST(publicAPI, AddNamespaceMemberURL, gateway.Handler(handler.AddNamespaceMember), gateway.Requires(authorizer.NamespaceAddMember))
 	gateway.PATCH(publicAPI, EditNamespaceMemberURL, gateway.Handler(handler.EditNamespaceMember), gateway.Requires(authorizer.NamespaceEditMember))
 	gateway.DELETE(publicAPI, RemoveNamespaceMemberURL, gateway.Handler(handler.RemoveNamespaceMember), gateway.Requires(authorizer.NamespaceRemoveMember))
-	gateway.DELETE(publicAPI, LeaveNamespaceURL, gateway.Handler(handler.LeaveNamespace), gateway.NoAPIKey())
+	gateway.DELETE(publicAPI, LeaveNamespaceURL, gateway.Handler(handler.LeaveNamespace), gateway.NoAPIKey(),
+		gateway.NoPermission("leaving removes the caller's own membership, which needs no authority over anyone else"))
 
 	gateway.PUT(publicAPI, EditSessionRecordStatusURL, gateway.Handler(handler.EditSessionRecordStatus), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)), gateway.Requires(authorizer.NamespaceEnableSessionRecord))
 	gateway.PUT(publicAPI, EditSSHAccessModeURL, gateway.Handler(handler.EditSSHAccessMode), gateway.Guard(routesmiddleware.RequiresTenant(ParamNamespaceTenant)), gateway.Requires(authorizer.NamespaceUpdate))
@@ -238,12 +270,15 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	gateway.PUT(publicAPI, UpdateAccessPolicyURL, gateway.Handler(handler.UpdateAccessPolicy), gateway.Requires(authorizer.AccessPolicyManage))
 	gateway.DELETE(publicAPI, DeleteAccessPolicyURL, gateway.Handler(handler.DeleteAccessPolicy), gateway.Requires(authorizer.AccessPolicyManage))
 
-	gateway.GET(publicAPI, ListSSHIdentitiesURL, gateway.List(handler.ListSSHIdentities), gateway.Accepts(services.SSHIdentityQuery))
+	gateway.GET(publicAPI, ListSSHIdentitiesURL, gateway.List(handler.ListSSHIdentities), gateway.Accepts(services.SSHIdentityQuery),
+		gateway.PermissionInHandler("the listing narrows to the caller's own identities without SSHIdentityManage, so the permission widens the answer rather than admitting the call"))
 	gateway.POST(publicAPI, CreateSSHIdentityURL, gateway.Handler(handler.CreateSSHIdentity), gateway.Requires(authorizer.SSHIdentityAdd))
 	gateway.PATCH(publicAPI, UpdateSSHIdentityURL, gateway.Handler(handler.UpdateSSHIdentity), gateway.Requires(authorizer.SSHIdentityAdd))
-	gateway.DELETE(publicAPI, DeleteSSHIdentityURL, gateway.Handler(handler.DeleteSSHIdentity))
+	gateway.DELETE(publicAPI, DeleteSSHIdentityURL, gateway.Handler(handler.DeleteSSHIdentity),
+		gateway.RequiresAny(authorizer.SSHIdentityAdd, authorizer.SSHIdentityManage))
 
-	gateway.POST(publicAPI, WebReauthURL, gateway.Handler(handler.WebReauthVerify))
+	gateway.POST(publicAPI, WebReauthURL, gateway.Handler(handler.WebReauthVerify),
+		gateway.NoPermission("the caller re-proves they are themselves, which is about their own credential and not about a role"))
 
 	gateway.GET(publicAPI, ListServiceAccountsURL, gateway.List(handler.ListServiceAccounts), gateway.Accepts(services.ServiceAccountQuery), gateway.Requires(authorizer.NamespaceAddMember))
 	gateway.POST(publicAPI, CreateServiceAccountURL, gateway.Handler(handler.CreateServiceAccount), gateway.Requires(authorizer.NamespaceAddMember))

--- a/server/api/routes/ssh-identity.go
+++ b/server/api/routes/ssh-identity.go
@@ -96,8 +96,9 @@ func (h *Handler) UpdateSSHIdentity(c *gateway.Context) error {
 	return c.JSON(http.StatusOK, identity)
 }
 
-// DeleteSSHIdentity revokes an identity. Revoking one's own needs the enroll
-// permission; revoking another member's needs the manage permission.
+// DeleteSSHIdentity revokes an identity. The route admits a caller holding either
+// SSH identity permission; which of the two they hold is what decides whether the
+// service lets them revoke another member's identity or only their own.
 func (h *Handler) DeleteSSHIdentity(c *gateway.Context) error {
 	req := new(requests.SSHIdentityDelete)
 	if err := c.Bind(req); err != nil {
@@ -113,13 +114,8 @@ func (h *Handler) DeleteSSHIdentity(c *gateway.Context) error {
 		return c.NoContent(http.StatusUnauthorized)
 	}
 
-	manage := c.Role().HasPermission(authorizer.SSHIdentityManage)
-	if !manage && !c.Role().HasPermission(authorizer.SSHIdentityAdd) {
-		return c.NoContent(http.StatusForbidden)
-	}
-
 	req.UserID = userID
-	req.Manage = manage
+	req.Manage = c.Role().HasPermission(authorizer.SSHIdentityManage)
 	if c.Tenant() != nil {
 		req.TenantID = c.Tenant().ID
 	}


### PR DESCRIPTION
## What

Every route registration now states what it demands of the caller's role, and a route-table invariant refuses the omission. This closes the last of the three claims a route makes — breadth and anonymity already could not arrive silently, because `Unbounded` and `Anonymous` each take a required reason.

It also fixes a reachability bug the audit turned up: `POST /api/auth/device` and `POST /api/auth/user` answered 401 to the clients they exist for.

## Why

`CONTEXT.md` already asserted the rule. Authority had no option and no check, so 34 of the community route table's registrations carried no permission and nothing asked why — a reader could not tell a route that genuinely demands none from one whose check merely moved somewhere the route table cannot see.

Closes #7036

## Changes

- **`gateway`**: three options, because the 34 do not share a reason. `RequiresAny` declares *and* installs its guard in one act, so the claim stays evidence rather than description; it exists because `DeleteSSHIdentity`'s rule is two permissions, which `Requires` cannot spell. `PermissionInHandler(reason)` and `NoPermission(reason)` install nothing and record why.
- **`Declaration`**: one enumerated `Authority` plus a `Permissions` slice, replacing `Permission`/`RequiresPermission`. The zero value is a route that stated nothing — the case the invariant exists to see — and one field cannot drift against another.
- **route table**: `unstatedAuthority` refuses a route that claims nothing, names an empty permission set, or leaves a reason blank. `anonymityDisagreements` refuses two mounts of one handler that disagree on whether it needs a credential.
- **`DeleteSSHIdentity`**: the two-permission check left the handler body for the mounting line. `req.Manage` still derives the ownership half, which is a data decision rather than an admission one.
- **`POST /api/auth/ssh`**: the handler's doc comment claimed it checks whether an offered key belongs to the namespace. It loads a private key by fingerprint and signs the caller's payload, reading no namespace at all. Corrected alongside its route reason.

## Deviations from the issue

Three, all deliberate:

1. **The anonymity check is not the one the issue proposed.** "A route whose authority claim says it expects no credential" is not derivable — `NoPermission` does not mean that (`GET /api/devices` demands a credential and claims it), so that predicate would have fired on ~20 correct routes. The handler-agreement rule is narrower than asked: a first-of-its-kind anonymous route with a unique handler still reads as consistent. It catches the V2-spelling shape, which is the shape that bit us.
2. **Two classifications the issue drafted were wrong.** `GET /api/ssh-approvals/:code` and `GET /api/devices/login-code/:code` were assigned `NoPermission` on the grounds that the credential carries no role. Both take a user token, and both services resolve the namespace from the code and refuse a non-member — so they claim `PermissionInHandler`. `NoPermission` would have been a false claim, which is the failure this change exists to prevent.
3. **`Authority` enum over four booleans**, which the issue explicitly left as an implementation choice.

## Testing

No caller observes a permission change. `RequiresAny(SSHIdentityAdd, SSHIdentityManage)` is exactly the guard deleted from the handler body, since no role holds `Manage` without `Add`. One ordering shifts: the 403 now precedes the bind, so an unpermitted caller sending a malformed body gets 403 where it got 400.

Each new predicate was verified against the **real** route table by deleting a claim, not only against its known-bad fixture — `unstatedAuthority` listed all 34 routes on first run, and `anonymityDisagreements` fired on `POST /api/auth/device`. Worth re-running that mutation if you want the green run to mean something.

Two things a reviewer should probe rather than take on trust: every `NoPermission` and `PermissionInHandler` reason is a claim about what the handler and service actually do, and a wrong one is worse than none. And `cloud/`'s 32 `/admin/api` routes are **not** yet held to this invariant — the vocabulary is built here so their policy is a separate decision (shellhub-io/team#238).

Note this is stacked on `refactor/list-query-contract`, so CI runs zero checks. Locally: server suite, `golangci-lint` and `go mod tidy` all clean.