### PR TITLE
fix(server): return 204 from registerUser when no auth is issued

### DIFF
--- a/openapi/spec/paths/api@register.yaml
+++ b/openapi/spec/paths/api@register.yaml
@@ -59,7 +59,17 @@ post:
             - email_marketing
   responses:
     '200':
-      description: User registered successfully
+      description: |
+        Invitation-based registration where the user is auto-confirmed.
+        Returns session credentials so the client can log in immediately.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/userAuth.yaml
+    '204':
+      description: |
+        Open registration completed. The account requires email confirmation
+        before the user can log in.
     '400':
       $ref: ../components/responses/400.yaml
     '401':

--- a/server/api/routes/invitation.go
+++ b/server/api/routes/invitation.go
@@ -44,7 +44,7 @@ func (h *Handler) RegisterUser(c *gateway.Context) error {
 		return c.JSON(http.StatusOK, authInfo)
 	}
 
-	return c.NoContent(http.StatusOK)
+	return c.NoContent(http.StatusNoContent)
 }
 
 // ResolveInvitation serves what an invite code stands for, so the accept page can route the


### PR DESCRIPTION
## What
`POST /api/register` now returns 204 (no body) for open registrations and 200 with `userAuth` credentials for invitation-based registrations. The OpenAPI spec documents both paths.

## Why
The handler returned 200 for both cases — with a `UserAuthResponse` body on the invitation path and an empty body on the open-registration path. The spec declared no response schema at all, so codegen tools (hey-api, Orval) typed the return as `void`. The invited-user flow that auto-logs in after signup relied on reading `token` and `tenant` from the response, which the generated type said didn't exist.

This surfaced during the Orval migration (#7023): `customInstance` calls `response.json()` on every non-204 response, so an empty 200 body throws a `SyntaxError` instead of succeeding silently like hey-api did.

## Changes
- **`server/api/routes/invitation.go`**: `RegisterUser` returns `http.StatusNoContent` instead of `http.StatusOK` when `authInfo` is nil (open registration, no credentials to return)
- **`openapi/spec/paths/api@register.yaml`**: split the 200 response into 200 (with `userAuth` schema) and 204 (no body), so codegen produces the correct return type

## Testing
Register via both paths and verify the status codes:
- Open registration (no `sig`): should return 204
- Invitation registration with a valid `sig` where the user is auto-confirmed: should return 200 with `token` and `tenant` in the JSON body
- Invitation registration where the user still needs admin approval: should return 204