### PR TITLE
fix(console): landmarks on the signed-out screens, and a tenant asked for where none is needed

### DIFF
--- a/ui/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespace.tsx
@@ -201,7 +201,10 @@ export default function CreateNamespace() {
     <div className="relative w-full min-h-0 flex-1 flex overflow-auto">
       <AmbientBackground />
 
-      <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col">
+      <div
+        data-testid="create-namespace"
+        className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col"
+      >
         {/* Hero */}
         <div className="text-center mb-12 animate-fade-in">
           <div className="animate-float mb-6 inline-block">

--- a/ui/apps/console/src/components/common/NamespaceGuard.tsx
+++ b/ui/apps/console/src/components/common/NamespaceGuard.tsx
@@ -112,9 +112,9 @@ export default function NamespaceGuard() {
     return (
       <div className="min-h-screen bg-background flex flex-col">
         <MinimalHeader />
-        <div className="flex-1 flex">
+        <main className="flex-1 flex">
           <CreateNamespace />
-        </div>
+        </main>
       </div>
     );
   }

--- a/ui/apps/console/src/components/layout/LoginLayout.tsx
+++ b/ui/apps/console/src/components/layout/LoginLayout.tsx
@@ -8,9 +8,9 @@ export default function LoginLayout() {
   return (
     <div className="relative min-h-screen flex items-center justify-center bg-background overflow-hidden">
       <AmbientBackground />
-      <div className="relative z-raised w-full px-8 py-12 flex flex-col items-center">
+      <main className="relative z-raised w-full px-8 py-12 flex flex-col items-center">
         <Outlet />
-      </div>
+      </main>
     </div>
   );
 }

--- a/ui/apps/console/src/components/layout/LoginLayoutCard.tsx
+++ b/ui/apps/console/src/components/layout/LoginLayoutCard.tsx
@@ -13,6 +13,7 @@ export default function LoginLayoutCard({
 }) {
   return (
     <div
+      data-testid="login-card"
       className={cn(
         "w-full max-w-md bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up",
         className,

--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -66,6 +66,7 @@ export default function NamespaceSelector({
         <Dropdown.Trigger>
           <button
             type="button"
+            data-testid="namespace-selector"
             aria-label={
               isAdminContext
                 ? "Admin Console"

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -37,12 +37,18 @@ import { cn } from "@shellhub/design-system/cn";
 
 const INITIAL_VISIBLE = 3;
 
-/* Methods that run the agent in a container support a tenant-less install: the
- * agent boots without credentials, mints its own pairing code at runtime and
- * prints an accept URL for the browser, so nothing sensitive rides on the
- * command line. Other methods still take a tenant and land the device in the
- * pending list. */
-const CODELESS_METHODS: Method[] = ["auto", "docker", "podman"];
+/* Methods that support a tenant-less install: the agent boots without
+ * credentials, mints its own pairing code at runtime and prints an accept URL
+ * for the browser, so nothing sensitive rides on the command line. Snap is the
+ * exception the installer enforces (require_tenant), and WSL is here because it
+ * installs through the standalone path. */
+const CODELESS_METHODS: Method[] = [
+  "auto",
+  "docker",
+  "podman",
+  "standalone",
+  "wsl",
+];
 
 /* Two audiences, because the mechanism follows from who is being added: one
  * machine installs clean and confirms in the browser; a fleet bakes a reusable

--- a/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
+++ b/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
@@ -19,7 +19,12 @@ export default function SessionPlayerDialog({
   if (!open) return null;
 
   return (
-    <div className="absolute inset-0 z-overlay flex flex-col bg-[#121314]">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Session recording"
+      className="absolute inset-0 z-overlay flex flex-col bg-[#121314]"
+    >
       <IconButton
         onClick={onClose}
         aria-label="Close"


### PR DESCRIPTION
## What
Four fixes found while photographing the console for the documentation. None of
them depend on that work.

## Why
Three screens had their entire contents outside any landmark, so navigating them
by landmark — how a screen reader user finds the content of a page — reached
nothing at all. A fourth put `TENANT_ID` into an install command for two methods
that do not need it, and the device landed pending as a result.

## Changes
- **`LoginLayout`**: the shell of the unauthenticated screens was two nested
  divs. Login, sign-up, account recovery and accept-device all render inside it.
- **`NamespaceGuard`**: the create-namespace screen is what an account with no
  namespace is held on, and it had the same shape.
- **`SessionPlayerDialog`**: a bare div over the page, with nothing announcing it
  as a dialog or naming what had just opened.
- **`AddDevice`**: only the container methods were treated as able to install
  without a tenant, so choosing Standalone or WSL put `TENANT_ID` in the command
  and left the device pending. `install.sh` pairs on both — WSL installs through
  the standalone path (`install.sh:518-528`), and `standalone_install` calls
  `enroll_agent_interactively` (`:437`). Snap is the real exception, and the
  installer is the one enforcing it (`:338-339`).

Two test ids come along: the namespace switcher is named after the namespace,
which is right to announce and different on every instance, and the
create-namespace column has no name of its own. Both are addressed by test id
from the documentation capture.
