### PR TITLE
docs(console): drop a third-party reference from a code comment

### DIFF
--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -71,9 +71,8 @@ const INITIAL_VISIBLE = 3;
  * pending list. */
 const CODELESS_METHODS: Method[] = ["auto", "docker", "podman"];
 
-/* Two audiences, following the pattern the field has settled on (Tailscale,
- * NetBird): you pick who you're adding, and the mechanism follows. "This
- * machine" installs clean and confirms in the browser; "Fleet" bakes a reusable
+/* Two audiences, because the mechanism follows from who is being added: one
+ * machine installs clean and confirms in the browser; a fleet bakes a reusable
  * install key into many machines. */
 type Audience = "machine" | "fleet";
 


### PR DESCRIPTION
## What
Removes the names of two other products from a comment in `AddDevice.tsx`.

## Why
The comment justified the screen's two-audience split by naming competitors. The
justification does not need them: the mechanism follows from who is being added,
which is what the comment says now.

It has been on `master` since `e4a095cb4`.

## Changes
- **`AddDevice.tsx`**: the comment above `Audience` states the reason on its own.

https://claude.ai/code/session_01Y5mkMMGGGvNyBfozQBKjsm