### PR TITLE
feat(console): a public install page

### DIFF
--- a/ui/apps/console/src/App.tsx
+++ b/ui/apps/console/src/App.tsx
@@ -38,6 +38,7 @@ const AccessPolicies = lazy(() => import("./pages/access-policies"));
 const SSHIdentities = lazy(() => import("./pages/ssh-identities"));
 const DeviceDetails = lazy(() => import("./pages/DeviceDetails"));
 const AddDevice = lazy(() => import("./pages/AddDevice"));
+const Install = lazy(() => import("./pages/install"));
 const SSHApproval = lazy(() => import("./pages/SSHApproval"));
 const Team = lazy(() => import("./pages/team"));
 const InstallKeys = lazy(() => import("./pages/install-keys"));
@@ -123,6 +124,9 @@ export default function App() {
                 />
               </Route>
               <Route path="/accept-device" element={<AcceptDevice />} />
+              {/* Public: the install command needs no account to be useful, and the
+                  docs link straight at it. */}
+              <Route path="/install" element={<Install />} />
               {isCloud() && (
                 <>
                   <Route path="/forgot-password" element={<ForgotPassword />} />

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -1,24 +1,18 @@
-import { useState, type JSX } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import { useAuthStore } from "../stores/authStore";
 import {
-  ArchiveBoxIcon,
   ArrowTopRightOnSquareIcon,
   BookOpenIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   ChevronUpIcon,
-  CommandLineIcon,
   ComputerDesktopIcon,
-  CpuChipIcon,
-  CubeIcon,
   InformationCircleIcon,
   KeyIcon,
   PlusIcon,
   ServerStackIcon,
-  SparklesIcon,
-  WrenchIcon,
 } from "@heroicons/react/24/outline";
 import CopyButton from "../components/common/CopyButton";
 import BaseDialog from "@/components/common/BaseDialog";
@@ -26,6 +20,7 @@ import AcceptDeviceFlow from "@/components/devices/AcceptDeviceFlow";
 import CreateInstallKeyDrawer from "@/pages/install-keys/CreateInstallKeyDrawer";
 import { isSystemKey } from "@/pages/install-keys/helpers";
 import { modeInfo } from "@/pages/install-keys/constants";
+import { METHODS, type Method } from "@/pages/install/methods";
 import { useInstallKeys } from "@/hooks/useInstallKeys";
 import { useRevealInstallKey } from "@/hooks/useRevealInstallKey";
 import InputField from "@/components/common/fields/InputField";
@@ -36,31 +31,9 @@ import { LABEL_BASE } from "@/utils/styles";
 import {
   Button,
   Card,
-  DockerIcon,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
-
-type Method =
-  | "auto"
-  | "docker"
-  | "podman"
-  | "snap"
-  | "standalone"
-  | "wsl"
-  | "yocto"
-  | "buildroot"
-  | "freebsd";
-
-interface MethodInfo {
-  id: Method;
-  label: string;
-  tag?: string;
-  description: string;
-  icon: JSX.Element;
-  manual?: boolean;
-  docsUrl?: string;
-}
 
 const INITIAL_VISIBLE = 3;
 
@@ -105,81 +78,6 @@ const MODE_OUTCOME: Record<string, string> = {
   webhook: "decided by your integrator",
   allowlist: "accepted if its MAC is allowed",
 };
-
-const METHODS: MethodInfo[] = [
-  {
-    id: "auto",
-    label: "Auto Detect",
-    tag: "Recommended",
-    description:
-      "Automatically detects Docker, Snap, or Standalone and uses the best available method.",
-    icon: <SparklesIcon className="w-5 h-5" />,
-  },
-  {
-    id: "docker",
-    label: "Docker",
-    description:
-      "Run the agent as a Docker container. Requires Docker daemon running on the host.",
-    icon: <DockerIcon className="w-5 h-5" />,
-  },
-  {
-    id: "standalone",
-    label: "Standalone",
-    description:
-      "Install directly using runc and systemd. No container runtime required.",
-    icon: <ServerStackIcon className="w-5 h-5" />,
-  },
-  {
-    id: "podman",
-    label: "Podman",
-    description:
-      "Alternative to Docker with rootless container capabilities. Requires Podman daemon.",
-    icon: <CubeIcon className="w-5 h-5" />,
-  },
-  {
-    id: "snap",
-    label: "Snap",
-    description:
-      "Easy installation via Snap store with automatic updates. Requires snapd service.",
-    icon: <ArchiveBoxIcon className="w-5 h-5" />,
-  },
-  {
-    id: "wsl",
-    label: "WSL",
-    description:
-      "Optimized for Windows Subsystem for Linux 2 with systemd and mirrored networking.",
-    icon: <ComputerDesktopIcon className="w-5 h-5" />,
-  },
-  {
-    id: "yocto",
-    label: "Yocto Project",
-    tag: "Manual",
-    description:
-      "For embedded Linux systems built with the Yocto build system.",
-    manual: true,
-    docsUrl: "https://docs.shellhub.io/overview/supported-platforms/yocto",
-    icon: <CpuChipIcon className="w-5 h-5" />,
-  },
-  {
-    id: "buildroot",
-    label: "Buildroot",
-    tag: "Manual",
-    description: "For embedded Linux systems built with Buildroot toolchain.",
-    manual: true,
-    docsUrl: "https://docs.shellhub.io/overview/supported-platforms/buildroot",
-    icon: <WrenchIcon className="w-5 h-5" />,
-  },
-  {
-    id: "freebsd",
-    label: "FreeBSD",
-    tag: "Manual",
-    description:
-      "For FreeBSD systems. Requires ports tree and manual compilation.",
-    manual: true,
-    docsUrl: "https://docs.shellhub.io/overview/supported-platforms/freebsd",
-    icon: <CommandLineIcon className="w-5 h-5" />,
-  },
-];
 
 /**
  * How to add a device: the install command, the install key, and the alternatives. The command

--- a/ui/apps/console/src/pages/install/index.tsx
+++ b/ui/apps/console/src/pages/install/index.tsx
@@ -1,0 +1,196 @@
+import { useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import {
+  ArrowTopRightOnSquareIcon,
+  CheckCircleIcon,
+} from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
+import {
+  Button,
+  ShellHubLogo,
+  WindowChrome,
+} from "@shellhub/design-system/primitives";
+import CopyButton from "@/components/common/CopyButton";
+import { METHODS, PAIRING_METHODS, type Method } from "./methods";
+
+const DOCS_INSTALL_URL = "https://docs.shellhub.io/get-started/install";
+
+/** The methods a visitor can run without an account, in the order the installer tries them. */
+const OFFERED: Method[] = ["auto", "docker", "podman", "snap", "standalone", "wsl"];
+
+/**
+ * The public install page: the command to put an agent on a machine, with no account needed to
+ * read it.
+ *
+ * It is deliberately the one-device path. A fleet needs an install key, which needs a namespace
+ * to create it in, so that half of Add Device only makes sense signed in.
+ */
+export default function Install() {
+  const [method, setMethod] = useState<Method>("auto");
+
+  const methods = OFFERED.map(
+    (id) => METHODS.find((m) => m.id === id) as (typeof METHODS)[number],
+  );
+  const selected = methods.find((m) => m.id === method) ?? methods[0];
+  const pairs = PAIRING_METHODS.includes(selected.id);
+
+  const command = [
+    "curl -sSf",
+    `${window.location.origin}/install.sh`,
+    "|",
+    ...(selected.id === "auto" ? [] : [`INSTALL_METHOD=${selected.id}`]),
+    ...(pairs ? [] : ["TENANT_ID=<your-tenant-id>"]),
+    "sh",
+  ].join(" ");
+
+  return (
+    <div className="w-full max-w-2xl animate-slide-up">
+      <div className="text-center mb-8">
+        <ShellHubLogo className="h-7 mx-auto mb-6" />
+        <h1 className="text-3xl font-bold text-text-primary mb-3">
+          Install ShellHub
+        </h1>
+        <p className="text-sm text-text-muted max-w-md mx-auto leading-relaxed">
+          Run one command on the machine you want to reach. Nothing listens on
+          it, and nothing is installed on your side.
+        </p>
+      </div>
+
+      <div className="bg-card/80 border border-border rounded-2xl backdrop-blur-sm overflow-hidden">
+        <div
+          role="tablist"
+          aria-label="Installation method"
+          className="flex items-center gap-1 px-3 pt-3 overflow-x-auto border-b border-border"
+        >
+          {methods.map((m) => {
+            const isActive = m.id === selected.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setMethod(m.id)}
+                className={cn(
+                  "flex items-center gap-2 shrink-0 px-3 py-2.5 -mb-px text-sm font-medium",
+                  "border-b-2 transition-colors duration-150",
+                  isActive
+                    ? "text-primary border-primary"
+                    : "text-text-muted border-transparent hover:text-text-primary",
+                )}
+              >
+                {m.icon}
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="p-6">
+          <p className="text-xs text-text-muted leading-relaxed mb-6">
+            {selected.description}
+          </p>
+
+          <Step number={1} title="Run this on the device">
+            <WindowChrome
+              variant="terminal"
+              size="sm"
+              titleBarSlot={<CopyButton text={command} showLabel />}
+            >
+              <pre className="text-accent-cyan whitespace-pre overflow-x-auto">
+                <span className="text-text-muted select-none">$ </span>
+                {command}
+              </pre>
+            </WindowChrome>
+            {!pairs && (
+              <p className="text-2xs text-text-muted leading-relaxed mt-2">
+                Snap is the one method that needs the namespace named up front.
+                Your tenant ID is on the namespace's settings page.
+              </p>
+            )}
+          </Step>
+
+          <Step number={2} title="Accept it in your browser" last>
+            <p className="text-xs text-text-secondary leading-relaxed">
+              {pairs ? (
+                <>
+                  The agent prints a code and a link, and waits. Open the link —
+                  or enter the code at{" "}
+                  <Link to="/accept-device" className="text-primary">
+                    accept-device
+                  </Link>{" "}
+                  — and the device joins the namespace you pick. The code lasts
+                  ten minutes.
+                </>
+              ) : (
+                <>
+                  The device enrols into the namespace you named and waits to be
+                  accepted, in the activity of the install key it used.
+                </>
+              )}
+            </p>
+          </Step>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 px-6 py-4 bg-surface/40 border-t border-border">
+          <p className="text-2xs text-text-muted">
+            Adding more than one? An install key enrols a fleet unattended.
+          </p>
+          <Button
+            as="a"
+            variant="ghost"
+            size="sm"
+            href={DOCS_INSTALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            iconRight={
+              <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5" strokeWidth={2} />
+            }
+          >
+            Installation guide
+          </Button>
+        </div>
+      </div>
+
+      <p className="text-center text-xs text-text-muted mt-6">
+        Already have a namespace?{" "}
+        <Link to="/login" className="text-primary">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+/** A numbered step on a rail, so the two read as an order rather than as two cards. */
+function Step({
+  number,
+  title,
+  children,
+  last = false,
+}: {
+  number: number;
+  title: string;
+  children: ReactNode;
+  last?: boolean;
+}) {
+  return (
+    <div className="flex gap-4">
+      <div className="flex flex-col items-center shrink-0">
+        <span className="w-6 h-6 rounded-full bg-primary/15 border border-primary/25 flex items-center justify-center text-2xs font-mono font-semibold text-primary">
+          {last ? (
+            <CheckCircleIcon className="w-3.5 h-3.5" strokeWidth={2} />
+          ) : (
+            number
+          )}
+        </span>
+        {!last && <span className="w-px flex-1 bg-border mt-1" />}
+      </div>
+
+      <div className={cn("min-w-0 flex-1", !last && "pb-6")}>
+        <p className="text-sm font-medium text-text-primary mb-2.5">{title}</p>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/ui/apps/console/src/pages/install/methods.tsx
+++ b/ui/apps/console/src/pages/install/methods.tsx
@@ -1,0 +1,126 @@
+import type { JSX } from "react";
+import {
+  ArchiveBoxIcon,
+  CommandLineIcon,
+  ComputerDesktopIcon,
+  CpuChipIcon,
+  CubeIcon,
+  ServerStackIcon,
+  SparklesIcon,
+  WrenchIcon,
+} from "@heroicons/react/24/outline";
+import { DockerIcon } from "@shellhub/design-system/primitives";
+
+/** An installation method the installer knows how to run, or a platform that needs its own. */
+export type Method =
+  | "auto"
+  | "docker"
+  | "podman"
+  | "snap"
+  | "standalone"
+  | "wsl"
+  | "yocto"
+  | "buildroot"
+  | "freebsd";
+
+/** One method as the screens present it: what it is called, what it does, and what it needs. */
+export interface MethodInfo {
+  id: Method;
+  label: string;
+  tag?: string;
+  description: string;
+  icon: JSX.Element;
+  /** The installer does not do this one; the platform's own toolchain does. */
+  manual?: boolean;
+  docsUrl?: string;
+}
+
+/**
+ * Methods that install without being told a namespace: the agent boots with no credentials,
+ * mints a pairing code at runtime and prints an accept URL, so nothing sensitive rides on the
+ * command line. Snap is the exception the installer itself enforces (`require_tenant`), and the
+ * manual methods never reach the installer at all.
+ */
+export const PAIRING_METHODS: Method[] = [
+  "auto",
+  "docker",
+  "podman",
+  "standalone",
+  "wsl",
+];
+
+/** Every method, in the order the screens offer them. */
+export const METHODS: MethodInfo[] = [
+  {
+    id: "auto",
+    label: "Auto Detect",
+    tag: "Recommended",
+    description:
+      "Automatically detects Docker, Snap, or Standalone and uses the best available method.",
+    icon: <SparklesIcon className="w-5 h-5" />,
+  },
+  {
+    id: "docker",
+    label: "Docker",
+    description:
+      "Run the agent as a Docker container. Requires Docker daemon running on the host.",
+    icon: <DockerIcon className="w-5 h-5" />,
+  },
+  {
+    id: "standalone",
+    label: "Standalone",
+    description:
+      "Install directly using runc and systemd. No container runtime required.",
+    icon: <ServerStackIcon className="w-5 h-5" />,
+  },
+  {
+    id: "podman",
+    label: "Podman",
+    description:
+      "Alternative to Docker with rootless container capabilities. Requires Podman daemon.",
+    icon: <CubeIcon className="w-5 h-5" />,
+  },
+  {
+    id: "snap",
+    label: "Snap",
+    description:
+      "Easy installation via Snap store with automatic updates. Requires snapd service.",
+    icon: <ArchiveBoxIcon className="w-5 h-5" />,
+  },
+  {
+    id: "wsl",
+    label: "WSL",
+    description:
+      "Optimized for Windows Subsystem for Linux 2 with systemd and mirrored networking.",
+    icon: <ComputerDesktopIcon className="w-5 h-5" />,
+  },
+  {
+    id: "yocto",
+    label: "Yocto Project",
+    tag: "Manual",
+    description:
+      "For embedded Linux systems built with the Yocto build system.",
+    manual: true,
+    docsUrl: "https://docs.shellhub.io/overview/supported-platforms/yocto",
+    icon: <CpuChipIcon className="w-5 h-5" />,
+  },
+  {
+    id: "buildroot",
+    label: "Buildroot",
+    tag: "Manual",
+    description: "For embedded Linux systems built with Buildroot toolchain.",
+    manual: true,
+    docsUrl: "https://docs.shellhub.io/overview/supported-platforms/buildroot",
+    icon: <WrenchIcon className="w-5 h-5" />,
+  },
+  {
+    id: "freebsd",
+    label: "FreeBSD",
+    tag: "Manual",
+    description:
+      "For FreeBSD systems. Requires ports tree and manual compilation.",
+    manual: true,
+    docsUrl: "https://docs.shellhub.io/overview/supported-platforms/freebsd",
+    icon: <CommandLineIcon className="w-5 h-5" />,
+  },
+];


### PR DESCRIPTION
## What
`/install`, reachable without an account: the command that puts an agent on a
machine, per method, with what happens after it.

## Why
Nothing links to a place that answers "how do I install this". Add Device is the
page for it and sits behind a login — which is the wrong door for the one case
that needs no account at all: a single device, installed with no credentials,
accepted from the browser afterwards.

The documentation's install page now sends people here, and the website can too.

## Changes
- **`pages/install/`**: the six methods the installer runs, as tabs. Picking one
  builds the command; the two steps below say what to run and what the agent does
  next. Snap is the one method that cannot pair (`install.sh:338-339` calls
  `require_tenant`), so it shows the tenant placeholder and where to find the
  value.
- **`pages/install/methods.tsx`**: the method list moves out of `AddDevice` so
  both pages read the same one, rather than drifting into describing the same
  method differently.
- **route**: public, alongside `/accept-device` — the two halves of the same flow.

The fleet half of Add Device does not come along: it needs an install key, which
needs a namespace to create it in.

## Testing
Visit `/install` signed out. Switching to Snap should change the command and add
the note; every other method's command should be the bare one-liner.

https://claude.ai/code/session_01Y5mkMMGGGvNyBfozQBKjsm