### PR TITLE
fix(server): let the SSH server decide the web terminal's public key access

### DIFF
--- a/server/ssh/session/auther.go
+++ b/server/ssh/session/auther.go
@@ -13,7 +13,6 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/ssh/pkg/banner"
-	"github.com/shellhub-io/shellhub/server/ssh/pkg/magickey"
 	log "github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -101,37 +100,29 @@ func (p *publicKeyAuth) Offer(session *Session) error {
 		}
 	}
 
+	ctx := context.Background()
 	fingerprint := gossh.FingerprintLegacyMD5(p.pk)
 
-	magic, err := gossh.NewPublicKey(&magickey.GetReference().PublicKey)
+	key, err := session.service.GetPublicKey(ctx, fingerprint, session.Device.TenantID)
 	if err != nil {
 		return err
 	}
 
-	if gossh.FingerprintLegacyMD5(magic) != fingerprint {
-		ctx := context.Background()
-
-		key, err := session.service.GetPublicKey(ctx, fingerprint, session.Device.TenantID)
-		if err != nil {
-			return err
-		}
-
-		usernameOK, err := session.service.EvaluateKeyUsername(ctx, key, session.Data.Target.Username)
-		if err != nil {
-			return ErrEvaluatePublicKey
-		}
-
-		filterOK, err := session.service.EvaluateKeyFilter(ctx, key, *session.Device)
-		if err != nil {
-			return ErrEvaluatePublicKey
-		}
-
-		if !usernameOK || !filterOK {
-			return ErrEvaluatePublicKey
-		}
+	usernameOK, err := session.service.EvaluateKeyUsername(ctx, key, session.Data.Target.Username)
+	if err != nil {
+		return ErrEvaluatePublicKey
 	}
 
-	return err
+	filterOK, err := session.service.EvaluateKeyFilter(ctx, key, *session.Device)
+	if err != nil {
+		return ErrEvaluatePublicKey
+	}
+
+	if !usernameOK || !filterOK {
+		return ErrEvaluatePublicKey
+	}
+
+	return nil
 }
 
 type passwordAuth struct {

--- a/server/ssh/session/auther_test.go
+++ b/server/ssh/session/auther_test.go
@@ -1,0 +1,196 @@
+package session
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	servicemocks "github.com/shellhub-io/shellhub/server/api/services/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newAgentVersionSession(service *servicemocks.MockService, version string) *Session {
+	sess := newTestSession(service)
+	sess.Device.Info = &models.DeviceInfo{Version: version}
+
+	return sess
+}
+
+func withAllowPublickeyAccessBelow060(t *testing.T, allow bool) {
+	t.Helper()
+
+	previous := *sshconf
+	t.Cleanup(func() { Configure(previous) })
+
+	next := previous
+	next.AllowPublickeyAccessBelow060 = allow
+	Configure(next)
+}
+
+func TestPublicKeyOfferAgentVersionFloor(t *testing.T) {
+	cases := []struct {
+		name        string
+		version     string
+		allowBelow  bool
+		expectedErr error
+	}{
+		{
+			name:        "refuses an agent older than 0.6.0",
+			version:     "0.5.9",
+			expectedErr: ErrUnsuportedPublicKeyAuth,
+		},
+		{
+			name:        "refuses an agent older than 0.6.0 reported with a v prefix",
+			version:     "v0.5.9",
+			expectedErr: ErrUnsuportedPublicKeyAuth,
+		},
+		{
+			name:        "refuses the oldest agent that ever reported a version",
+			version:     "0.0.1",
+			expectedErr: ErrUnsuportedPublicKeyAuth,
+		},
+		{
+			name:        "refuses a version it cannot parse",
+			version:     "not-a-version",
+			expectedErr: ErrInvalidVersion,
+		},
+		{
+			name:        "refuses an agent reporting no version at all",
+			version:     "",
+			expectedErr: ErrInvalidVersion,
+		},
+		{
+			name:       "allows an agent older than 0.6.0 when the instance opts in",
+			version:    "0.5.9",
+			allowBelow: true,
+		},
+		{
+			name:       "allows a version it cannot parse when the instance opts in",
+			version:    "not-a-version",
+			allowBelow: true,
+		},
+		{
+			name:    "allows exactly 0.6.0",
+			version: "0.6.0",
+		},
+		{
+			name:    "allows an agent newer than the floor",
+			version: "0.19.4",
+		},
+		{
+			name:    "allows an agent reporting latest",
+			version: "latest",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withAllowPublickeyAccessBelow060(t, tc.allowBelow)
+
+			serviceMock := servicemocks.NewMockService(t)
+			if tc.expectedErr == nil {
+				expectKeyAdmitted(serviceMock)
+			}
+
+			sess := newAgentVersionSession(serviceMock, tc.version)
+
+			err := AuthPublicKey(newTestSSHKey(t)).Offer(sess)
+
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPublicKeyOfferKeyEvaluation(t *testing.T) {
+	errStore := errors.New("store is unreachable")
+	key := &models.PublicKey{Fingerprint: "fingerprint"}
+
+	cases := []struct {
+		name        string
+		mocks       func(*servicemocks.MockService)
+		expectedErr error
+	}{
+		{
+			name:  "admits a key the username and the filter both accept",
+			mocks: expectKeyAdmitted,
+		},
+		{
+			name: "refuses a key the username rejects",
+			mocks: func(s *servicemocks.MockService) {
+				s.EXPECT().GetPublicKey(mock.Anything, mock.Anything, "tenant-id").Return(key, nil).Once()
+				s.EXPECT().EvaluateKeyUsername(mock.Anything, key, "user").Return(false, nil).Once()
+				s.EXPECT().EvaluateKeyFilter(mock.Anything, key, mock.Anything).Return(true, nil).Once()
+			},
+			expectedErr: ErrEvaluatePublicKey,
+		},
+		{
+			name: "refuses a key the filter rejects",
+			mocks: func(s *servicemocks.MockService) {
+				s.EXPECT().GetPublicKey(mock.Anything, mock.Anything, "tenant-id").Return(key, nil).Once()
+				s.EXPECT().EvaluateKeyUsername(mock.Anything, key, "user").Return(true, nil).Once()
+				s.EXPECT().EvaluateKeyFilter(mock.Anything, key, mock.Anything).Return(false, nil).Once()
+			},
+			expectedErr: ErrEvaluatePublicKey,
+		},
+		{
+			name: "refuses a key whose username evaluation fails",
+			mocks: func(s *servicemocks.MockService) {
+				s.EXPECT().GetPublicKey(mock.Anything, mock.Anything, "tenant-id").Return(key, nil).Once()
+				s.EXPECT().EvaluateKeyUsername(mock.Anything, key, "user").Return(false, errStore).Once()
+			},
+			expectedErr: ErrEvaluatePublicKey,
+		},
+		{
+			name: "refuses a key whose filter evaluation fails",
+			mocks: func(s *servicemocks.MockService) {
+				s.EXPECT().GetPublicKey(mock.Anything, mock.Anything, "tenant-id").Return(key, nil).Once()
+				s.EXPECT().EvaluateKeyUsername(mock.Anything, key, "user").Return(true, nil).Once()
+				s.EXPECT().EvaluateKeyFilter(mock.Anything, key, mock.Anything).Return(false, errStore).Once()
+			},
+			expectedErr: ErrEvaluatePublicKey,
+		},
+		{
+			name: "surfaces the lookup error for a key the namespace does not hold",
+			mocks: func(s *servicemocks.MockService) {
+				s.EXPECT().GetPublicKey(mock.Anything, mock.Anything, "tenant-id").Return(nil, errStore).Once()
+			},
+			expectedErr: errStore,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withAllowPublickeyAccessBelow060(t, false)
+
+			serviceMock := servicemocks.NewMockService(t)
+			tc.mocks(serviceMock)
+
+			sess := newAgentVersionSession(serviceMock, "latest")
+
+			err := AuthPublicKey(newTestSSHKey(t)).Offer(sess)
+
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func expectKeyAdmitted(service *servicemocks.MockService) {
+	key := &models.PublicKey{Fingerprint: "fingerprint"}
+
+	service.EXPECT().GetPublicKey(mock.Anything, mock.Anything, "tenant-id").Return(key, nil).Once()
+	service.EXPECT().EvaluateKeyUsername(mock.Anything, key, "user").Return(true, nil).Once()
+	service.EXPECT().EvaluateKeyFilter(mock.Anything, key, mock.Anything).Return(true, nil).Once()
+}

--- a/server/ssh/web/errors.go
+++ b/server/ssh/web/errors.go
@@ -14,7 +14,6 @@ var (
 	ErrWebData                 = errors.New("failed to get the data to connect to device")
 	ErrFindDevice              = errors.New("failed to find the device")
 	ErrFindPublicKey           = errors.New("failed to get the public key from the server")
-	ErrEvaluatePublicKey       = errors.New("failed to evaluate the public key in the server")
 	ErrForbiddenPublicKey      = errors.New("failed to use the public key for this action")
 	ErrDataPublicKey           = errors.New("failed to parse the public key data")
 	ErrPty                     = errors.New("failed to request the pty to agent")

--- a/server/ssh/web/session.go
+++ b/server/ssh/web/session.go
@@ -113,20 +113,6 @@ func getAuth(ctx context.Context, service services.Service, conn *Conn, creds *C
 		return nil, ErrFindPublicKey
 	}
 
-	usernameOK, err := service.EvaluateKeyUsername(ctx, key, creds.Username)
-	if err != nil {
-		return nil, ErrEvaluatePublicKey
-	}
-
-	filterOK, err := service.EvaluateKeyFilter(ctx, key, *device)
-	if err != nil {
-		return nil, ErrEvaluatePublicKey
-	}
-
-	if !usernameOK || !filterOK {
-		return nil, ErrForbiddenPublicKey
-	}
-
 	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(key.Data) //nolint:dogsled
 	if err != nil {
 		return nil, ErrDataPublicKey
@@ -225,6 +211,10 @@ func newSession(ctx context.Context, service services.Service, handoff *webhando
 		}
 
 		logger.WithError(err).Debug("failed to dial to the ssh server")
+
+		if creds.isPublicKey() || creds.PublicKey != "" {
+			return ErrForbiddenPublicKey
+		}
 
 		return ErrAuthentication
 	}


### PR DESCRIPTION
## What

The web terminal evaluated an offered public key itself and then dialled the SSH server, which
evaluated the same key again. One decision now lives in one place — the SSH server — and the web
terminal only fetches the key material it has to present.

## Why

The two copies had drifted. They disagreed on the error sentinel, and more importantly on the
namespace's SSH access mode: the server chooses between `publicKeyAuth` and `ResolveKeyAuth` based
on it, while `getAuth` knew nothing about it and applied the legacy key filters even in an
identity-mode namespace, where the server applies none. A browser session could be refused a key
the server would have admitted.

Not a privilege escalation — the duplicate was stricter than the server, never laxer.

Found by an architecture review of the SSH path; there is no issue for it.

## Changes

- **`server/ssh/web/session.go`** — `getAuth` keeps `GetDevice` and `GetPublicKey`, because the
  `Signer` needs the key material to present and the device supplies the tenant that bounds the
  lookup. The two `Evaluate*` calls and the refusal go. This is how the browser-held-key branch
  above it already worked: present the key, let the server admit or refuse it.

- **`server/ssh/web/session.go`** — a handshake that fails on a public-key credential now answers
  `ErrForbiddenPublicKey` instead of `ErrAuthentication`. Without this the change would have told a
  public-key user their *password* was wrong and offered a reconnect that cannot help. The console
  has an entry for `ErrForbiddenPublicKey` — "this public key is not authorized for this device" —
  that nothing has ever been able to trigger, because `newSession` discards `getAuth`'s error and
  answers `ErrGetAuth`. That mapping becomes reachable for the first time; no UI change needed.

- **`server/ssh/session/auther.go`** — removes the magic-key bypass, which skipped the lookup and
  both evaluations when the offered key matched `magickey.GetReference()`. That key is a
  process-local RSA key generated at startup; its public half never leaves the process, so nothing
  can present it. It dates from 2022, when the web terminal signed the loopback dial with it — the
  bypass existed *because* the web terminal had already evaluated the key. It lost its caller long
  ago while the duplication it excused stayed. Also removes a trailing `return err` that could only
  ever be nil.

- **`server/ssh/session/auther_test.go`** — new. `Offer` had no test and decides two things.

## Testing

**The agent version floor is the thing to check.** Agents 0.5.x and earlier do not validate the
public key request and may panic, so the server refuses public-key auth against them unless
`SHELLHUB_ALLOW_PUBLIC_KEY_ACCESS_BELLOW_0_6_0` is set. Customers still run those agents. That rule
had no test at all before this PR.

The test commit is deliberately first and touches no production code, so it can be checked against
`master`:

```
git checkout $(git rev-list --max-parents=1 origin/master..HEAD | tail -1)
go test ./ssh/session/ -run TestPublicKeyOffer -count=1   # passes on master + test only
git checkout fix/web-terminal-duplicate-key-authz
go test ./ssh/session/ -run TestPublicKeyOffer -count=1   # still passes after the change
```

Both were verified in a worktree. The floor block in `Offer` is byte-identical to `master`.

Two behaviours worth a reviewer's eye:

- The parse failures are pinned **as they behave, not as they arguably should**. An agent whose
  version does not parse — including one reporting no version at all — is refused with
  `ErrInvalidVersion` while the opt-in is off. That means a version-less agent cannot use a public
  key on a default instance. Preserved deliberately; say so if it should change.
- The refused cases assert through a `MockService` with no expectations, so they fail if the floor
  ever lets a call reach the store rather than merely returning some error.

Not done here, and deliberately: a nil-guard on `Device.Info` (`DeviceToModel` always populates it,
so it is unreachable and the guard would be speculative), and carrying the server's refusal *reason*
across as an SSH banner. The latter is worth doing — it would give plain SSH clients the explanation
they get nothing of today — but a banner in `Offer` would fire on every key a client merely queries,
so it belongs in `Evaluate` and is its own change.

## Scope: legacy access mode only

Worth knowing before reading the diff. `resolveKeyAuth` picks between `publicKeyAuth` and
`ResolveKeyAuth` on the namespace's `ssh_access_mode`, and the column defaults to `identity`. A
namespace created today therefore never reaches `publicKeyAuth.Offer` — the function this PR
changes — and the web terminal's registered-key branch is likewise a legacy-mode path.

So the blast radius is narrower than the diff suggests: **namespaces still on legacy mode**.
Identity-mode namespaces are untouched, which is also why `getAuth` applying legacy key filters
regardless of mode was wrong rather than merely redundant.

## Verified against a running instance

Beyond the unit tests, the change was exercised end-to-end on a live `v0.27.0-rc.8` community dev
stack (real agent, real SSH client, real WebSocket bridge), with a namespace switched to legacy
mode. Three registered keys with different filters: unrestricted, `username=nobodyxyz`,
`hostname=no-such-host`.

**SSH** — unrestricted key connects and runs a command; username-filtered and device-filtered keys
are both refused, server logging `refused the offered public key error="failed to evaluate the
provided public key"`. That is the evaluation running unconditionally with the magic-key branch
gone.

**Web terminal** — completing the real signature exchange over `/ws/ssh`, the unrestricted key
reaches `{"kind":5}` (session established). The unauthorized key is refused, and the refusal is the
reason the third commit exists. Same fixtures, the fix toggled:

| | frame the browser receives | what the console renders |
|---|---|---|
| without the fix | `failed to authenticate to device` | "The username or password is incorrect." + reconnect |
| with the fix | `failed to use the public key for this action` | "This public key is not authorized for this device." |

A wrong *password* still returns `failed to authenticate to device`, so the discrimination is not
over-broad.

**Old-agent floor** — with the device reporting `0.5.9`, the key that connects above is refused,
server logging `connections using public keys are not permitted when the agent version is 0.5.x or
earlier`. The hard constraint holds on a live server, not only in the unit tests.
