### PR TITLE
Publish the documentation from a stable branch

### DIFF
--- a/.github/workflows/docs-cd.yml
+++ b/.github/workflows/docs-cd.yml
@@ -1,13 +1,12 @@
 name: Docs CD
 
 on:
+  # No path filter on push. `docs/stable` is moved to the release tag with a force-push, which
+  # carries no dependable list of changed files, so a filtered trigger would skip the release.
   push:
     branches:
       - master
-    paths:
-      - "ui/apps/docs/**"
-      - "ui/packages/design-system/**"
-      - ".github/workflows/docs-cd.yml"
+      - docs/stable
   pull_request:
     paths:
       - "ui/apps/docs/**"
@@ -54,10 +53,12 @@ jobs:
       # no image and an image no page references, instead of quietly rewriting the checkout.
       - name: Build
         working-directory: ui
+        env:
+          PUBLIC_DOCS_CHANNEL: ${{ github.ref_name == 'docs/stable' && 'stable' || 'unreleased' }}
         run: npm run build -w @shellhub/docs
 
-      # A branch other than master publishes to a preview URL rather than to the site, which
-      # is how a documentation change gets read before it is merged.
+      # Only `docs/stable`, the project's production branch, publishes to the site. Every other
+      # branch lands on a preview URL, which is how master and open pull requests get read.
       - name: Deploy to Cloudflare Pages
         id: deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0

--- a/ui/apps/docs/src/components/UnreleasedBanner.astro
+++ b/ui/apps/docs/src/components/UnreleasedBanner.astro
@@ -1,0 +1,25 @@
+---
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { releasedDocsUrl } from "../data/links";
+
+// Only the build from `docs/stable` describes a version anyone can install. Every other build
+// comes off master, where a page may document a feature that has not shipped in any release.
+const isUnreleasedBuild = import.meta.env.PUBLIC_DOCS_CHANNEL !== "stable";
+---
+
+{isUnreleasedBuild && (
+  <div class="bg-primary-50 border-b border-primary-100 text-text-secondary">
+    <p class="max-w-7xl mx-auto px-8 py-2 text-[12px] text-center">
+      Built from master, may describe features that are not in any release yet.{" "}
+      <a
+        href={releasedDocsUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-1 align-baseline font-semibold text-primary underline underline-offset-2 hover:no-underline"
+      >
+        Released documentation
+        <ArrowTopRightOnSquareIcon className="w-3 h-3 opacity-80" strokeWidth={2} aria-hidden="true" />
+      </a>
+    </p>
+  </div>
+)}

--- a/ui/apps/docs/src/data/links.ts
+++ b/ui/apps/docs/src/data/links.ts
@@ -2,10 +2,20 @@
  * URL of the public website used by the docs app.
  * Uses a local development host when running in DEV mode, otherwise the production URL.
  */
-export const websiteUrl = import.meta.env.DEV ? "http://website.localhost" : "https://shellhub.io";
+export const websiteUrl = import.meta.env.DEV
+  ? "http://website.localhost"
+  : "https://shellhub.io";
 
 /**
  * URL of this documentation site. Same rule as the website: a local host in development, the
  * published address otherwise.
  */
-export const docsUrl = import.meta.env.DEV ? "http://docs.localhost" : "https://docs.shellhub.io";
+export const docsUrl = import.meta.env.DEV
+  ? "http://docs.localhost"
+  : "https://docs.shellhub.io";
+
+/**
+ * URL of the documentation for the released version. The unreleased build points readers here;
+ * it is the address `docs/stable` is published to, which is docsv2 until it takes over docs.
+ */
+export const releasedDocsUrl = "https://docsv2.shellhub.io";

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -9,6 +9,7 @@ import {
 import { sidebar, flattenItems } from "../data/sidebar";
 import { websiteUrl } from "../data/links";
 import CommandPalette from "../components/CommandPalette.astro";
+import UnreleasedBanner from "../components/UnreleasedBanner.astro";
 
 interface Props {
   title: string;
@@ -42,6 +43,7 @@ const nextPage = currentIndex < allPages.length - 1 ? allPages[currentIndex + 1]
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   </head>
   <body class="bg-background text-text-primary font-sans antialiased">
+    <UnreleasedBanner />
     <header class="sticky top-0 z-appbar h-14 bg-background/40 backdrop-blur-xl border-b border-border shadow-lg shadow-black/10">
       <div class="flex items-center justify-between h-full max-w-7xl mx-auto px-8">
         <div class="flex items-center gap-3">

--- a/ui/apps/docs/src/pages/index.astro
+++ b/ui/apps/docs/src/pages/index.astro
@@ -9,6 +9,7 @@ import {
 import { sidebar, flattenItems } from "../data/sidebar";
 import { websiteUrl, docsUrl } from "../data/links";
 import CommandPalette from "../components/CommandPalette.astro";
+import UnreleasedBanner from "../components/UnreleasedBanner.astro";
 
 const sections = sidebar.map(section => ({
   label: section.label,
@@ -27,6 +28,7 @@ const sections = sidebar.map(section => ({
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   </head>
   <body class="bg-background text-text-primary font-sans antialiased">
+    <UnreleasedBanner />
     <header class="sticky top-0 z-appbar h-14 bg-background/40 backdrop-blur-xl border-b border-border shadow-lg shadow-black/10">
       <div class="flex items-center justify-between h-full max-w-7xl mx-auto px-8">
         <div class="flex items-center gap-3">


### PR DESCRIPTION
The documentation site is published continuously from master. A page written for
a feature that has not shipped yet becomes visible the moment it is merged, so
writing documentation alongside the feature means publishing it early.

This splits the site in two. The `docs/stable` branch becomes the production
branch of the Cloudflare Pages project and is the only one that publishes to the
site; it is moved to the release tag when a version is cut. Master and open pull
requests land on preview URLs, so documentation can be merged together with the
feature it describes without reaching readers.

A build that does not come from `docs/stable` carries a banner saying it is
built from master and may describe features that are not in any release yet,
linking to the documentation for the released version.

`robots.txt` is left alone: it still disallows everything, which is correct
while the site is served from docsv2. When it takes over the published address,
that file becomes the knob that lets the stable build be indexed and keeps the
builds from master out.

## Manual steps

Merging this is not enough. After it lands, in this order:

1. Create the branch from the tag of the current release and push it:

       git branch docs/stable "$(git describe --tags --abbrev=0 origin/master)"
       git push origin docs/stable

2. Wait for Docs CD to finish publishing that branch.

3. In the Cloudflare Pages project `shellhub-docs`, change the production branch
   to `docs/stable`.

4. Run Docs CD on master again, from the Actions tab. Until master stops being
   the production branch it publishes to the root of the project and has no
   branch alias, so this run is what creates
   `master.shellhub-docs.pages.dev` and puts the unreleased documentation there.

Doing 3 before 1 leaves the project without a production branch.

## Cutting a release

Moving the published documentation to a new version is one command:

    git branch -f docs/stable <tag> && git push -f origin docs/stable

A fix to the published documentation has to land on master first and be
cherry-picked to `docs/stable`. A commit that exists only on `docs/stable` is
discarded by the next release.
