### PR TITLE
fix(agent): stop an offline agent logging a line per retry attempt

### DIFF
--- a/agent/pkg/agentd/agent.go
+++ b/agent/pkg/agentd/agent.go
@@ -69,6 +69,7 @@ import (
 	"github.com/shellhub-io/shellhub/agent/server"
 	"github.com/shellhub-io/shellhub/pkg/api/client"
 	"github.com/shellhub-io/shellhub/pkg/clock"
+	"github.com/shellhub-io/shellhub/pkg/connectivity"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/validator"
@@ -576,7 +577,8 @@ const (
 )
 
 // Listen serves connections until ctx is cancelled, using the transport named by the
-// configuration.
+// configuration. It requires a prior Authorize, whose token it reconnects with and whose logger it
+// reports through.
 func (a *Agent) Listen(ctx context.Context) error {
 	a.mode.Serve(a)
 
@@ -599,11 +601,15 @@ func (a *Agent) listenV1(ctx context.Context) error {
 
 	go a.ping(ctx, AgentPingDefaultInterval) //nolint:errcheck
 
+	logger := a.logger.WithField("transport", "tunnel")
+
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
+		tunnelServer := connectivity.NewTracker(logger)
+
 		for {
 			if a.isClosed() {
-				a.logger.Info("Stopped listening for connections")
+				logger.Info("Stopped listening for connections")
 
 				cancel()
 
@@ -612,7 +618,7 @@ func (a *Agent) listenV1(ctx context.Context) error {
 
 			ShellHubConnectV1Path := "/ssh/connection"
 
-			a.logger.Debug("Using tunnel version 1")
+			logger.Debug("Using tunnel version 1")
 
 			listener, err := a.cli.NewReverseListenerV1(
 				ctx,
@@ -620,20 +626,22 @@ func (a *Agent) listenV1(ctx context.Context) error {
 				ShellHubConnectV1Path,
 			)
 			if err != nil {
-				a.logger.Error("Failed to connect to server through reverse tunnel. Retry in 10 seconds")
+				tunnelServer.Lost(err)
 
-				time.Sleep(time.Second * 10)
+				time.Sleep(tunnelReconnectInterval)
 
 				continue
 			}
 			a.listener.Store(&listener)
 
-			a.logger.Info("Server connection established")
+			if !tunnelServer.Recovered() {
+				logger.Info("Server connection established")
+			}
 
 			a.listening <- true
 
 			if err := tun.Listen(ctx, listener); err != nil {
-				a.logger.WithError(err).Error("Tunnel listener exited with error")
+				logger.WithError(err).Error("Tunnel listener exited with error")
 			}
 
 			a.listening <- false
@@ -654,11 +662,15 @@ func (a *Agent) listenV2(ctx context.Context) error {
 
 	go a.ping(ctx, AgentPingDefaultInterval) //nolint:errcheck
 
+	logger := a.logger.WithField("transport", "tunnel")
+
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
+		tunnelServer := connectivity.NewTracker(logger)
+
 		for {
 			if a.isClosed() {
-				a.logger.Info("Stopped listening for connections")
+				logger.Info("Stopped listening for connections")
 
 				cancel()
 
@@ -667,7 +679,7 @@ func (a *Agent) listenV2(ctx context.Context) error {
 
 			ShellHubConnectV2Path := "/agent/connection"
 
-			a.logger.Debug("Using tunnel version 2")
+			logger.Debug("Using tunnel version 2")
 
 			listener, err := a.cli.NewReverseListenerV2(
 				ctx,
@@ -676,20 +688,22 @@ func (a *Agent) listenV2(ctx context.Context) error {
 				client.NewReverseV2ConfigFromMap(a.authData.Config),
 			)
 			if err != nil {
-				a.logger.Error("Failed to connect to server through reverse tunnel. Retry in 10 seconds")
+				tunnelServer.Lost(err)
 
-				time.Sleep(time.Second * 10)
+				time.Sleep(tunnelReconnectInterval)
 
 				continue
 			}
 			a.listener.Store(&listener)
 
-			a.logger.Info("Server connection established")
+			if !tunnelServer.Recovered() {
+				logger.Info("Server connection established")
+			}
 
 			a.listening <- true
 
 			if err := tun.Listen(ctx, listener); err != nil {
-				a.logger.WithError(err).Error("Tunnel listener exited with error")
+				logger.WithError(err).Error("Tunnel listener exited with error")
 			}
 
 			a.listening <- false
@@ -703,6 +717,8 @@ func (a *Agent) listenV2(ctx context.Context) error {
 
 // AgentPingDefaultInterval is the default time interval between ping on agent.
 const AgentPingDefaultInterval = 10 * time.Minute
+
+const tunnelReconnectInterval = 10 * time.Second
 
 func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 	a.listening = make(chan bool)

--- a/agent/pkg/agentd/agent.go
+++ b/agent/pkg/agentd/agent.go
@@ -730,6 +730,8 @@ func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 	<-a.listening // NOTE: wait for the first connection to start to ping the server.
 	ticker := time.NewTicker(interval)
 
+	authorization := connectivity.NewTracker(a.logger.WithField("transport", "ping"))
+
 	for {
 		if a.isClosed() {
 			return nil
@@ -766,6 +768,10 @@ func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 			}
 		case <-ticker.C:
 			if err := a.authorize(); err != nil {
+				authorization.Refused(err)
+			} else {
+				authorization.Recovered()
+
 				a.server.SetDeviceName(a.authData.Name)
 			}
 

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -43,12 +43,13 @@ type Client interface {
 }
 
 type client struct {
-	scheme   string
-	host     string
-	port     int
-	http     *resty.Client
-	logger   *log.Logger
-	reverser reverser.Reverser
+	scheme    string
+	host      string
+	port      int
+	http      *resty.Client
+	logger    *log.Logger
+	retryWait func() time.Duration
+	reverser  reverser.Reverser
 }
 
 // ErrParseAddress is returned by NewClient when the server address is not a URL carrying scheme,
@@ -77,74 +78,44 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 		const MinRetryAfterSecs int = 5
 		const MaxRetryAfterSecs int = 65
 
-		t := time.Duration(rand.IntN(MaxRetryAfterSecs-MinRetryAfterSecs)+MinRetryAfterSecs) * time.Second //nolint:gosec
-
-		log.WithFields(log.Fields{
-			"retry_after": t,
-		}).Warn("retrying request after a random time period")
-
-		return t
+		return time.Duration(rand.IntN(MaxRetryAfterSecs-MinRetryAfterSecs)+MinRetryAfterSecs) * time.Second //nolint:gosec
 	}
 
 	client := new(client)
+	client.retryWait = randomWaitTimeSecs
 	client.http = resty.New()
 	client.http.SetRetryCount(math.MaxInt32)
 	client.http.SetRedirectPolicy(SameDomainRedirectPolicy())
 	client.http.SetBaseURL(uri.String())
 	client.http.SetContentLength(true)
 	client.http.AddRetryCondition(func(r *resty.Response, err error) bool {
+		if r == nil {
+			return false
+		}
+
 		var netErr net.Error
 		if errors.As(err, &netErr) {
-			log.WithFields(log.Fields{
-				"url": r.Request.URL,
-			}).WithError(err).Error("network error")
-
 			return true
 		}
 
-		switch {
-		case r.StatusCode() == http.StatusTooManyRequests:
-			log.WithFields(log.Fields{
-				"status_code": r.StatusCode(),
-				"url":         r.Request.URL,
-				"data":        r.String(),
-			}).Warn("too many requests")
-
-			return true
-		case r.StatusCode() >= http.StatusInternalServerError && r.StatusCode() != http.StatusNotImplemented:
-			log.WithFields(log.Fields{
-				"status_code": r.StatusCode(),
-				"url":         r.Request.URL,
-				"data":        r.String(),
-			}).Warn("failed to achieve the server")
-
-			return true
-		}
-
-		return false
+		return serverAtFault(r.StatusCode())
 	})
-	client.http.SetRetryAfter(func(c *resty.Client, r *resty.Response) (time.Duration, error) {
+	client.http.SetRetryAfter(func(_ *resty.Client, r *resty.Response) (time.Duration, error) {
 		switch r.StatusCode() {
 		case http.StatusTooManyRequests, http.StatusServiceUnavailable:
 			retryAfterHeader := r.Header().Get(RetryAfterHeader)
 			if retryAfterHeader == "" {
-				return randomWaitTimeSecs(), nil
+				return client.retryWait(), nil
 			}
 
 			retryAfterSeconds, err := strconv.Atoi(retryAfterHeader)
 			if err != nil {
-				return randomWaitTimeSecs(), err
+				return client.retryWait(), err
 			}
-
-			log.WithFields(log.Fields{
-				"status":      r.StatusCode(),
-				"retry_after": retryAfterSeconds,
-				"url":         r.Request.URL,
-			}).Warn("retrying request after a defined time period")
 
 			return time.Duration(retryAfterSeconds) * time.Second, nil
 		default:
-			return randomWaitTimeSecs(), nil
+			return client.retryWait(), nil
 		}
 	})
 	client.http.SetRetryMaxWaitTime(MaxRetryWaitTime)
@@ -164,4 +135,21 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 	client.http.SetLogger(&LeveledLogger{client.logger})
 
 	return client, nil
+}
+
+func serverAtFault(status int) bool {
+	if status == http.StatusTooManyRequests {
+		return true
+	}
+
+	return status >= http.StatusInternalServerError && status != http.StatusNotImplemented
+}
+
+func operatorCanResolve(status int) bool {
+	switch status {
+	case http.StatusNotFound, http.StatusPaymentRequired, http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -3,16 +3,19 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	resty "github.com/go-resty/resty/v2"
 	"github.com/shellhub-io/shellhub/pkg/api/client/reverser"
+	"github.com/shellhub-io/shellhub/pkg/connectivity"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -48,6 +51,7 @@ type client struct {
 	port      int
 	http      *resty.Client
 	logger    *log.Logger
+	logEntry  *log.Entry
 	retryWait func() time.Duration
 	reverser  reverser.Reverser
 }
@@ -62,8 +66,11 @@ var ErrParseAddress = errors.New("could not parse the address to the required fo
 //
 // The client retries indefinitely, backing off on the server's Retry-After when it sends one and on
 // a random delay when it does not, so an agent left running against a server that is down reconnects
-// on its own. Body-less requests go out with Content-Length: 0 rather than an empty chunked body,
-// which proxies and request binders handle far more predictably.
+// on its own. An outage costs two log lines, one when the server stops answering and one when it
+// answers again; every attempt in between is logged at debug level.
+//
+// Body-less requests go out with Content-Length: 0 rather than an empty chunked body, which proxies
+// and request binders handle far more predictably.
 func NewClient(address string, opts ...Opt) (Client, error) {
 	uri, err := url.ParseRequestURI(address)
 	if err != nil {
@@ -100,6 +107,34 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 
 		return serverAtFault(r.StatusCode())
 	})
+	client.http.OnBeforeRequest(func(_ *resty.Client, r *resty.Request) error {
+		if r.Attempt <= 1 {
+			r.SetContext(context.WithValue(r.Context(), firstAttemptAt{}, time.Now())) //nolint:forbidigo // an elapsed-time measurement: how long the server stays away
+		}
+
+		return nil
+	})
+	client.http.AddRetryHook(func(r *resty.Response, err error) {
+		if r == nil {
+			return
+		}
+
+		switch {
+		case r.StatusCode() == 0:
+			connectivity.Lost(client.logEntry, r.Request.Attempt, err)
+		case serverAtFault(r.StatusCode()):
+			connectivity.Lost(client.logEntry, r.Request.Attempt, answer(r))
+		default:
+			connectivity.Refused(client.logEntry, r.Request.Attempt, answer(r))
+		}
+	})
+	client.http.OnSuccess(func(_ *resty.Client, r *resty.Response) {
+		if r.IsError() || r.Request.Attempt <= 1 {
+			return
+		}
+
+		connectivity.Recovered(client.logEntry, r.Request.Attempt, since(r))
+	})
 	client.http.SetRetryAfter(func(_ *resty.Client, r *resty.Response) (time.Duration, error) {
 		switch r.StatusCode() {
 		case http.StatusTooManyRequests, http.StatusServiceUnavailable:
@@ -134,6 +169,8 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 
 	client.http.SetLogger(&LeveledLogger{client.logger})
 
+	client.logEntry = client.logger.WithField("server_address", uri.String())
+
 	return client, nil
 }
 
@@ -152,4 +189,30 @@ func operatorCanResolve(status int) bool {
 	default:
 		return false
 	}
+}
+
+type firstAttemptAt struct{}
+
+func since(r *resty.Response) time.Duration {
+	startedAt, ok := r.Request.Context().Value(firstAttemptAt{}).(time.Time)
+	if !ok {
+		return 0
+	}
+
+	return time.Since(startedAt)
+}
+
+const maxAnswerBodyLength = 256
+
+func answer(r *resty.Response) error {
+	body := strings.TrimSpace(r.String())
+	if len(body) > maxAnswerBodyLength {
+		body = strings.ToValidUTF8(body[:maxAnswerBodyLength], "") + "..."
+	}
+
+	if body == "" {
+		return errors.New("the server answered " + r.Status())
+	}
+
+	return fmt.Errorf("the server answered %s: %s", r.Status(), body)
 }

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -149,10 +149,6 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 	})
 	client.http.SetRetryMaxWaitTime(MaxRetryWaitTime)
 
-	if client.logger != nil {
-		client.http.SetLogger(&LeveledLogger{client.logger})
-	}
-
 	client.reverser = NewReverser(client.http.BaseURL)
 
 	for _, opt := range opts {
@@ -160,6 +156,12 @@ func NewClient(address string, opts ...Opt) (Client, error) {
 			return nil, err
 		}
 	}
+
+	if client.logger == nil {
+		client.logger = log.StandardLogger()
+	}
+
+	client.http.SetLogger(&LeveledLogger{client.logger})
 
 	return client, nil
 }

--- a/pkg/api/client/client_common_test.go
+++ b/pkg/api/client/client_common_test.go
@@ -126,7 +126,7 @@ func TestListDevices(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			cli, err := NewClient("https://www.shellhub.io/")
+			cli, err := NewClient("https://www.shellhub.io/", withImmediateRetries())
 			require.NoError(t, err)
 
 			client, ok := cli.(*client)
@@ -244,7 +244,7 @@ func TestGetDevice(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			cli, err := NewClient("https://www.shellhub.io/")
+			cli, err := NewClient("https://www.shellhub.io/", withImmediateRetries())
 			require.NoError(t, err)
 
 			client, ok := cli.(*client)

--- a/pkg/api/client/client_public.go
+++ b/pkg/api/client/client_public.go
@@ -33,31 +33,25 @@ func (c *client) GetInfo(agentVersion string) (*models.Info, error) {
 	return requireBody(info)
 }
 
+// AuthDevice registers the device on the server and returns the token the agent authenticates the
+// rest of its calls with.
+//
+// Of the refusals the server can answer with, it retries only the three an operator resolves
+// without touching the device: 404 for a namespace that does not exist yet, and 402 or 403 for a
+// device limit that has been reached. Every other refusal is returned to the caller, whose device
+// is misconfigured in a way that repeating the same request cannot settle. Transport failures, 429
+// and 5xx are left to the client-wide retry condition, which reports them as a server that cannot
+// answer rather than one that refuses the device.
 func (c *client) AuthDevice(req *models.DeviceAuthRequest) (*models.DeviceAuthResponse, error) {
 	var res *models.DeviceAuthResponse
 
 	response, err := c.http.R().
-		AddRetryCondition(func(r *resty.Response, _ error) bool {
-			identity := func(mac, hostname string) string {
-				if mac != "" {
-					return mac
-				}
-
-				return hostname
+		AddRetryCondition(func(r *resty.Response, err error) bool {
+			if err != nil || r == nil || serverAtFault(r.StatusCode()) {
+				return false
 			}
 
-			if r.IsError() {
-				log.WithFields(log.Fields{
-					"tenant_id":   req.TenantID,
-					"identity":    identity(req.Identity.MAC, req.Hostname),
-					"status_code": r.StatusCode(),
-					"data":        r.String(),
-				}).Warn("failed to authenticate device")
-
-				return true
-			}
-
-			return false
+			return r.IsError() && operatorCanResolve(r.StatusCode())
 		}).
 		SetBody(req).
 		SetResult(&res).

--- a/pkg/api/client/client_public_test.go
+++ b/pkg/api/client/client_public_test.go
@@ -137,7 +137,7 @@ func TestGetInfo(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			cli, err := NewClient("https://www.cloud.shellhub.io/")
+			cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries())
 			require.NoError(t, err)
 
 			client, ok := cli.(*client)
@@ -280,7 +280,7 @@ func TestAuthDevice(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			cli, err := NewClient("https://www.cloud.shellhub.io/")
+			cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries())
 			require.NoError(t, err)
 
 			client, ok := cli.(*client)
@@ -489,7 +489,7 @@ func TestAuthPublicKey(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			cli, err := NewClient("https://www.cloud.shellhub.io/")
+			cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries())
 			require.NoError(t, err)
 
 			client, ok := cli.(*client)

--- a/pkg/api/client/client_public_test.go
+++ b/pkg/api/client/client_public_test.go
@@ -297,6 +297,94 @@ func TestAuthDevice(t *testing.T) {
 	}
 }
 
+func TestAuthDeviceRetriesOnlyWhatAnOperatorCanResolve(t *testing.T) {
+	tests := []struct {
+		description string
+		status      int
+		recovers    bool
+		attempts    int
+	}{
+		{
+			description: "gives up on a request the server calls malformed",
+			status:      http.StatusBadRequest,
+			attempts:    1,
+		},
+		{
+			description: "gives up on a request the server cannot process",
+			status:      http.StatusUnprocessableEntity,
+			attempts:    1,
+		},
+		{
+			description: "gives up when the device is not authorized",
+			status:      http.StatusUnauthorized,
+			attempts:    1,
+		},
+		{
+			description: "gives up when the device conflicts with one already registered",
+			status:      http.StatusConflict,
+			attempts:    1,
+		},
+		{
+			description: "waits for a namespace that does not exist yet",
+			status:      http.StatusNotFound,
+			recovers:    true,
+			attempts:    2,
+		},
+		{
+			description: "waits for a namespace that is at its device limit",
+			status:      http.StatusPaymentRequired,
+			recovers:    true,
+			attempts:    2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries())
+			require.NoError(t, err)
+
+			client, ok := cli.(*client)
+			require.True(t, ok)
+
+			mock.ActivateNonDefault(client.http.GetClient())
+			defer mock.DeactivateAndReset()
+
+			refusal := mock.NewStringResponder(test.status, `{"message":"the server refused the device"}`)
+			if test.recovers {
+				accepted, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{Name: "83-18-77-25-78-0d"})
+				refusal = refusal.Then(accepted)
+			}
+
+			mock.RegisterResponder("POST", "/api/devices/auth", refusal)
+
+			response, err := cli.AuthDevice(&models.DeviceAuthRequest{
+				Info: &models.DeviceInfo{ID: "manjaro", PrettyName: "Manjaro", Version: "latest", Arch: "amd64"},
+				DeviceAuth: &models.DeviceAuth{
+					Hostname:  "83-18-77-25-78-0d",
+					Identity:  &models.DeviceIdentity{MAC: "83:18:77:25:78:0d"},
+					TenantID:  "00000000-0000-4000-0000-000000000000",
+					PublicKey: "",
+				},
+			})
+
+			if test.recovers {
+				require.NoError(t, err)
+				assert.NotNil(t, response)
+			} else {
+				assert.Nil(t, response)
+				require.Error(t, err)
+			}
+
+			calls := 0
+			for _, count := range mock.GetCallCountInfo() {
+				calls += count
+			}
+
+			assert.Equal(t, test.attempts, calls)
+		})
+	}
+}
+
 func TestAuthPublicKey(t *testing.T) {
 	type Signature struct {
 		Username  string `json:"Username"`

--- a/pkg/api/client/client_test.go
+++ b/pkg/api/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -134,4 +135,12 @@ func FuzzNewClient(f *testing.F) {
 		_, err := NewClient(address)
 		assert.NoError(t, err)
 	})
+}
+
+func withImmediateRetries() Opt {
+	return func(c *client) error {
+		c.retryWait = func() time.Duration { return time.Millisecond }
+
+		return nil
+	}
 }

--- a/pkg/api/client/connectivity_test.go
+++ b/pkg/api/client/connectivity_test.go
@@ -1,0 +1,245 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	resty "github.com/go-resty/resty/v2"
+	mock "github.com/jarcoal/httpmock"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func authRequest() *models.DeviceAuthRequest {
+	return &models.DeviceAuthRequest{
+		Info: &models.DeviceInfo{ID: "manjaro", PrettyName: "Manjaro", Version: "latest", Arch: "amd64"},
+		DeviceAuth: &models.DeviceAuth{
+			Hostname: "83-18-77-25-78-0d",
+			Identity: &models.DeviceIdentity{MAC: "83:18:77:25:78:0d"},
+			TenantID: "00000000-0000-4000-0000-000000000000",
+		},
+	}
+}
+
+func TestRetriedAttemptsAreReportedAsWhatTheServerDid(t *testing.T) {
+	tests := []struct {
+		description string
+		status      int
+		expected    string
+	}{
+		{
+			description: "a server too busy to answer is unreachable, not a refusal of the device",
+			status:      http.StatusTooManyRequests,
+			expected:    "Cannot reach the server, retrying until it answers",
+		},
+		{
+			description: "a server that failed on its own side is unreachable, not a refusal of the device",
+			status:      http.StatusInternalServerError,
+			expected:    "Cannot reach the server, retrying until it answers",
+		},
+		{
+			description: "a server that is up and rejecting the device is a refusal",
+			status:      http.StatusNotFound,
+			expected:    "Cannot authorize the device, retrying until the server accepts it",
+		},
+		{
+			description: "a namespace at its device limit is a refusal",
+			status:      http.StatusPaymentRequired,
+			expected:    "Cannot authorize the device, retrying until the server accepts it",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			backend, hook := logtest.NewNullLogger()
+			backend.SetLevel(logrus.DebugLevel)
+
+			cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries(), WithLogger(backend))
+			require.NoError(t, err)
+
+			client, ok := cli.(*client)
+			require.True(t, ok)
+
+			mock.ActivateNonDefault(client.http.GetClient())
+			defer mock.DeactivateAndReset()
+
+			accepted, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{Name: "83-18-77-25-78-0d"})
+			mock.RegisterResponder("POST", "/api/devices/auth",
+				mock.NewStringResponder(test.status, `{"message":"nope"}`).Then(accepted))
+
+			_, err = cli.AuthDevice(authRequest())
+			require.NoError(t, err)
+
+			require.NotEmpty(t, hook.AllEntries())
+			assert.Equal(t, test.expected, hook.AllEntries()[0].Message)
+			assert.Equal(t, logrus.WarnLevel, hook.AllEntries()[0].Level)
+		})
+	}
+}
+
+func TestForbiddenIsRetriedAsSomethingAnOperatorClears(t *testing.T) {
+	cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries())
+	require.NoError(t, err)
+
+	client, ok := cli.(*client)
+	require.True(t, ok)
+
+	mock.ActivateNonDefault(client.http.GetClient())
+	defer mock.DeactivateAndReset()
+
+	accepted, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{Name: "83-18-77-25-78-0d"})
+	mock.RegisterResponder("POST", "/api/devices/auth",
+		mock.NewStringResponder(http.StatusForbidden, `{"message":"device limit reached"}`).Then(accepted))
+
+	response, err := cli.AuthDevice(authRequest())
+	require.NoError(t, err)
+	assert.NotNil(t, response)
+
+	calls := 0
+	for _, count := range mock.GetCallCountInfo() {
+		calls += count
+	}
+
+	assert.Equal(t, 2, calls)
+}
+
+func TestARequestThatNeverLeftIsNotRetried(t *testing.T) {
+	cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries())
+	require.NoError(t, err)
+
+	client, ok := cli.(*client)
+	require.True(t, ok)
+
+	client.http.SetRetryCount(3)
+
+	rejected := errors.New("the request never left")
+
+	runs := 0
+	client.http.OnBeforeRequest(func(_ *resty.Client, _ *resty.Request) error {
+		runs++
+
+		return rejected
+	})
+
+	mock.ActivateNonDefault(client.http.GetClient())
+	defer mock.DeactivateAndReset()
+
+	_, err = cli.GetInfo("v0.13.0")
+	require.ErrorIs(t, err, rejected)
+
+	assert.Equal(t, 1, runs)
+}
+
+func TestARefusalDoesNotReportThatTheServerCameBack(t *testing.T) {
+	backend, hook := logtest.NewNullLogger()
+	backend.SetLevel(logrus.DebugLevel)
+
+	cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries(), WithLogger(backend))
+	require.NoError(t, err)
+
+	client, ok := cli.(*client)
+	require.True(t, ok)
+
+	mock.ActivateNonDefault(client.http.GetClient())
+	defer mock.DeactivateAndReset()
+
+	mock.RegisterResponder("POST", "/api/devices/auth",
+		mock.NewStringResponder(http.StatusNotFound, `{"message":"no such namespace"}`).
+			Then(mock.NewStringResponder(http.StatusBadRequest, `{"message":"malformed"}`)))
+
+	_, err = cli.AuthDevice(authRequest())
+	require.Error(t, err)
+
+	for _, entry := range hook.AllEntries() {
+		assert.NotEqual(t, "Recovered after retrying", entry.Message)
+	}
+}
+
+func TestARecoveryIsReportedOnlyAfterAnOutage(t *testing.T) {
+	tests := []struct {
+		description string
+		outage      bool
+	}{
+		{
+			description: "says nothing when the first attempt already answered",
+			outage:      false,
+		},
+		{
+			description: "reports the attempt that ended the outage",
+			outage:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			backend, hook := logtest.NewNullLogger()
+			backend.SetLevel(logrus.DebugLevel)
+
+			cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries(), WithLogger(backend))
+			require.NoError(t, err)
+
+			client, ok := cli.(*client)
+			require.True(t, ok)
+
+			mock.ActivateNonDefault(client.http.GetClient())
+			defer mock.DeactivateAndReset()
+
+			answered, _ := mock.NewJsonResponder(200, models.Info{Version: "v0.13.0"})
+
+			responder := answered
+			if test.outage {
+				responder = mock.NewErrorResponder(errors.New("dial tcp: connection refused")).Then(answered)
+			}
+
+			mock.RegisterResponder("GET", "/info?agent_version=v0.13.0", responder)
+
+			_, err = cli.GetInfo("v0.13.0")
+			require.NoError(t, err)
+
+			recovered := false
+			for _, entry := range hook.AllEntries() {
+				if entry.Message == "Recovered after retrying" {
+					recovered = true
+				}
+			}
+
+			assert.Equal(t, test.outage, recovered)
+		})
+	}
+}
+
+func TestTheServerAnswerIsBoundedBeforeItReachesTheLog(t *testing.T) {
+	backend, hook := logtest.NewNullLogger()
+	backend.SetLevel(logrus.DebugLevel)
+
+	cli, err := NewClient("https://www.cloud.shellhub.io/", withImmediateRetries(), WithLogger(backend))
+	require.NoError(t, err)
+
+	client, ok := cli.(*client)
+	require.True(t, ok)
+
+	mock.ActivateNonDefault(client.http.GetClient())
+	defer mock.DeactivateAndReset()
+
+	page := strings.Repeat("<html>a proxy error page nobody wants a line of</html>", 100)
+
+	accepted, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{Name: "83-18-77-25-78-0d"})
+	mock.RegisterResponder("POST", "/api/devices/auth",
+		mock.NewStringResponder(http.StatusBadGateway, page).Then(accepted))
+
+	_, err = cli.AuthDevice(authRequest())
+	require.NoError(t, err)
+
+	require.NotEmpty(t, hook.AllEntries())
+
+	reported, ok := hook.AllEntries()[0].Data[logrus.ErrorKey].(error)
+	require.True(t, ok)
+
+	assert.Less(t, len(reported.Error()), len(page))
+	assert.Contains(t, reported.Error(), "502")
+}

--- a/pkg/api/client/logger.go
+++ b/pkg/api/client/logger.go
@@ -1,44 +1,32 @@
 package client
 
 import (
-	"fmt"
-
 	"github.com/sirupsen/logrus"
 )
 
 // LeveledLogger adapts a logrus logger to resty's leveled-logger interface, so the HTTP client's
-// own diagnostics land in the same log as everything else.
+// own diagnostics land in the same log as everything else. Its methods are printf-style, which is
+// what resty's Logger interface means by a format and its arguments.
 type LeveledLogger struct {
 	Logger *logrus.Logger
 }
 
-// Errorf logs at error level. The variadic arguments are key/value pairs, not printf arguments,
-// despite the name the interface requires.
-func (l *LeveledLogger) Errorf(msg string, keysAndValues ...any) {
-	l.Logger.WithFields(toFields(keysAndValues)).Error(msg)
+// Errorf logs at error level, where resty reports a request it gave up on.
+func (l *LeveledLogger) Errorf(format string, v ...any) {
+	l.Logger.Errorf(format, v...)
 }
 
-// Debugf logs at debug level, taking key/value pairs as Errorf does.
-func (l *LeveledLogger) Debugf(msg string, keysAndValues ...any) {
-	l.Logger.WithFields(toFields(keysAndValues)).Debug(msg)
+// Warnf logs at debug level rather than warn. resty warns once per retry attempt, and this client
+// retries for as long as the server is away, so at warn level that one line is what fills a
+// device's disk; the outage itself is reported once, on its own. The demotion is indiscriminate:
+// resty's other per-request warnings, a response body it could not unmarshal and Basic Auth over
+// plain HTTP, are buried at debug along with it.
+func (l *LeveledLogger) Warnf(format string, v ...any) {
+	l.Logger.Debugf(format, v...)
 }
 
-// Warnf logs at warning level, taking key/value pairs as Errorf does.
-func (l *LeveledLogger) Warnf(msg string, keysAndValues ...any) {
-	l.Logger.WithFields(toFields(keysAndValues)).Warn(msg)
-}
-
-func toFields(keysAndValues []any) logrus.Fields {
-	fields := make(map[string]any)
-
-	for i := 0; i < len(keysAndValues); i += 2 {
-		key, ok := keysAndValues[i].(string)
-		if !ok {
-			key = fmt.Sprint(keysAndValues[i])
-		}
-
-		fields[key] = keysAndValues[i+1]
-	}
-
-	return fields
+// Debugf logs resty's request and response dumps, which it produces only while its own debug mode
+// is on. This client never turns that on, so nothing reaches here today.
+func (l *LeveledLogger) Debugf(format string, v ...any) {
+	l.Logger.Debugf(format, v...)
 }

--- a/pkg/api/client/logger_test.go
+++ b/pkg/api/client/logger_test.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeveledLogger(t *testing.T) {
+	failure := errors.New("dial tcp: connection refused")
+
+	tests := []struct {
+		description string
+		log         func(l *LeveledLogger)
+		expected    logrus.Level
+	}{
+		{
+			description: "sends resty's per-attempt retry warning to debug",
+			log:         func(l *LeveledLogger) { l.Warnf("%v, Attempt %v", failure, 679) },
+			expected:    logrus.DebugLevel,
+		},
+		{
+			description: "leaves the request resty gave up on at error, so the demotion is not blanket",
+			log:         func(l *LeveledLogger) { l.Errorf("%v", failure) },
+			expected:    logrus.ErrorLevel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			backend, hook := logtest.NewNullLogger()
+			backend.SetLevel(logrus.DebugLevel)
+
+			test.log(&LeveledLogger{Logger: backend})
+
+			entry := hook.LastEntry()
+			require.NotNil(t, entry)
+
+			assert.Equal(t, test.expected, entry.Level)
+		})
+	}
+}

--- a/pkg/api/client/options.go
+++ b/pkg/api/client/options.go
@@ -66,7 +66,8 @@ func WithPort(port int) Opt {
 	}
 }
 
-// WithLogger gives the client somewhere to log. Without it the client stays silent.
+// WithLogger sends the client's own logging, and resty's, through logger. Without it they go to
+// logrus' standard logger, which is where the rest of the agent already writes.
 func WithLogger(logger *logrus.Logger) Opt {
 	return func(c *client) error {
 		c.logger = logger

--- a/pkg/connectivity/connectivity.go
+++ b/pkg/connectivity/connectivity.go
@@ -1,0 +1,103 @@
+// Package connectivity reports a server's reachability as transitions rather than as attempts, so
+// a component that retries for as long as it is offline logs when it loses the server and when it
+// gets it back instead of once per retry.
+//
+// The attempt number is the transition. A caller whose retry loop already counts attempts, as
+// resty's Request.Attempt does, passes the count in to the package-level Lost, Refused and
+// Recovered; one that has no counter of its own uses a Tracker, which keeps it.
+package connectivity
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func level(attempt int) logrus.Level {
+	if attempt > 1 {
+		return logrus.DebugLevel
+	}
+
+	return logrus.WarnLevel
+}
+
+// Lost reports one failed attempt to reach the server. The first attempt is logged at warn level
+// and every one after it at debug, so an outage costs one line however long it lasts.
+func Lost(logger logrus.FieldLogger, attempt int, err error) {
+	logger.
+		WithError(err).
+		WithField("attempt", attempt).
+		Log(level(attempt), "Cannot reach the server, retrying until it answers")
+}
+
+// Recovered reports the attempt the server finally answered, naming how many it took and how long
+// since the first one. Callers report only the attempt that ended a run of failures; one that
+// succeeded first time has nothing to say. The wording stays neutral because the run it ends may
+// have been a server that could not answer or one that answered and refused, and only the caller
+// knows which.
+func Recovered(logger logrus.FieldLogger, attempt int, elapsed time.Duration) {
+	logger.
+		WithFields(logrus.Fields{
+			"attempts": attempt,
+			"after":    elapsed.String(),
+		}).
+		Info("Recovered after retrying")
+}
+
+// Refused reports one attempt the server answered by refusing to authorize the device. It reads as
+// a distinct condition from an unreachable server because it is: the server is up, and what has to
+// change is the namespace or the device limit. Levels follow Lost.
+func Refused(logger logrus.FieldLogger, attempt int, err error) {
+	logger.
+		WithError(err).
+		WithField("attempt", attempt).
+		Log(level(attempt), "Cannot authorize the device, retrying until the server accepts it")
+}
+
+// Tracker counts consecutive failures for a caller whose retry loop has no attempt counter to pass
+// in, and reports them through Lost, Refused and Recovered. It holds no lock: a Tracker belongs to
+// the single goroutine running the loop it counts, and two of them covering one server would each
+// report the same outage.
+type Tracker struct {
+	logger  logrus.FieldLogger
+	attempt int
+	lostAt  time.Time
+}
+
+// NewTracker returns a Tracker reporting through logger, with no outage in progress.
+func NewTracker(logger logrus.FieldLogger) *Tracker {
+	return &Tracker{logger: logger}
+}
+
+// Lost counts one failed attempt to reach the server and reports it.
+func (t *Tracker) Lost(err error) {
+	Lost(t.logger, t.count(), err)
+}
+
+// Refused counts one attempt the server answered by refusing the device and reports it.
+func (t *Tracker) Refused(err error) {
+	Refused(t.logger, t.count(), err)
+}
+
+// Recovered reports the attempt that ended a run of failures and clears the count, returning false
+// when there was no run to end so the caller can say for itself what a first-time success means.
+func (t *Tracker) Recovered() bool {
+	if t.attempt == 0 {
+		return false
+	}
+
+	Recovered(t.logger, t.attempt, time.Since(t.lostAt))
+	t.attempt = 0
+
+	return true
+}
+
+func (t *Tracker) count() int {
+	if t.attempt == 0 {
+		t.lostAt = time.Now() //nolint:forbidigo // an elapsed-time measurement: how long the server stays away
+	}
+
+	t.attempt++
+
+	return t.attempt
+}

--- a/pkg/connectivity/connectivity_test.go
+++ b/pkg/connectivity/connectivity_test.go
@@ -1,0 +1,206 @@
+package connectivity
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLost(t *testing.T) {
+	failure := errors.New("dial tcp: lookup cloud.shellhub.io: no such host")
+
+	tests := []struct {
+		description string
+		attempt     int
+		expected    logrus.Level
+	}{
+		{
+			description: "warns on the attempt that finds the server gone",
+			attempt:     1,
+			expected:    logrus.WarnLevel,
+		},
+		{
+			description: "debugs the second attempt, so an outage costs one line",
+			attempt:     2,
+			expected:    logrus.DebugLevel,
+		},
+		{
+			description: "debugs an attempt deep into a long outage",
+			attempt:     679,
+			expected:    logrus.DebugLevel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			backend, hook := logtest.NewNullLogger()
+			backend.SetLevel(logrus.DebugLevel)
+
+			Lost(backend, test.attempt, failure)
+
+			entry := hook.LastEntry()
+			require.NotNil(t, entry)
+
+			assert.Equal(t, test.expected, entry.Level)
+			assert.Equal(t, test.attempt, entry.Data["attempt"])
+			assert.Equal(t, failure, entry.Data[logrus.ErrorKey])
+		})
+	}
+}
+
+func TestRefused(t *testing.T) {
+	refusal := errors.New("the server answered 404 Not Found")
+
+	tests := []struct {
+		description string
+		attempt     int
+		expected    logrus.Level
+	}{
+		{
+			description: "warns on the first refusal",
+			attempt:     1,
+			expected:    logrus.WarnLevel,
+		},
+		{
+			description: "debugs the refusals after it",
+			attempt:     9,
+			expected:    logrus.DebugLevel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			backend, hook := logtest.NewNullLogger()
+			backend.SetLevel(logrus.DebugLevel)
+
+			Refused(backend, test.attempt, refusal)
+
+			entry := hook.LastEntry()
+			require.NotNil(t, entry)
+
+			assert.Equal(t, test.expected, entry.Level)
+			assert.Equal(t, test.attempt, entry.Data["attempt"])
+			assert.Equal(t, refusal, entry.Data[logrus.ErrorKey])
+		})
+	}
+}
+
+func TestRecovered(t *testing.T) {
+	backend, hook := logtest.NewNullLogger()
+	backend.SetLevel(logrus.DebugLevel)
+
+	Recovered(backend, 23, 3*time.Minute+50*time.Second)
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+
+	assert.Equal(t, logrus.InfoLevel, entry.Level)
+	assert.Equal(t, 23, entry.Data["attempts"])
+	assert.Equal(t, "3m50s", entry.Data["after"])
+}
+
+func TestTrackerReportsAnOutageOnceHoweverLongItLasts(t *testing.T) {
+	failure := errors.New("dial tcp: lookup cloud.shellhub.io: no such host")
+
+	backend, hook := logtest.NewNullLogger()
+	backend.SetLevel(logrus.DebugLevel)
+
+	tracker := NewTracker(backend)
+
+	tracker.Lost(failure)
+	tracker.Lost(failure)
+	tracker.Lost(failure)
+
+	levels := make([]logrus.Level, 0, len(hook.AllEntries()))
+	for _, entry := range hook.AllEntries() {
+		levels = append(levels, entry.Level)
+	}
+
+	assert.Equal(t, []logrus.Level{logrus.WarnLevel, logrus.DebugLevel, logrus.DebugLevel}, levels)
+	assert.Equal(t, 3, hook.LastEntry().Data["attempt"])
+}
+
+func TestTrackerCountsRefusalsAndReachabilityOnTheSameRun(t *testing.T) {
+	backend, hook := logtest.NewNullLogger()
+	backend.SetLevel(logrus.DebugLevel)
+
+	tracker := NewTracker(backend)
+
+	tracker.Lost(errors.New("dial tcp: connection refused"))
+	tracker.Refused(errors.New("the server answered 404 Not Found"))
+
+	assert.Equal(t, logrus.DebugLevel, hook.LastEntry().Level)
+	assert.Equal(t, 2, hook.LastEntry().Data["attempt"])
+}
+
+func TestTrackerRecovered(t *testing.T) {
+	tests := []struct {
+		description string
+		failures    int
+		expected    bool
+	}{
+		{
+			description: "says nothing when there was no run of failures to end",
+			failures:    0,
+			expected:    false,
+		},
+		{
+			description: "reports the attempt that ended a run of failures",
+			failures:    4,
+			expected:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			backend, hook := logtest.NewNullLogger()
+			backend.SetLevel(logrus.DebugLevel)
+
+			tracker := NewTracker(backend)
+			for range test.failures {
+				tracker.Lost(errors.New("dial tcp: connection refused"))
+			}
+
+			hook.Reset()
+
+			assert.Equal(t, test.expected, tracker.Recovered())
+
+			entry := hook.LastEntry()
+			if !test.expected {
+				assert.Nil(t, entry)
+
+				return
+			}
+
+			require.NotNil(t, entry)
+			assert.Equal(t, logrus.InfoLevel, entry.Level)
+			assert.Equal(t, test.failures, entry.Data["attempts"])
+		})
+	}
+}
+
+func TestTrackerStartsANewRunAfterRecovering(t *testing.T) {
+	backend, hook := logtest.NewNullLogger()
+	backend.SetLevel(logrus.DebugLevel)
+
+	tracker := NewTracker(backend)
+
+	tracker.Lost(errors.New("dial tcp: connection refused"))
+	tracker.Lost(errors.New("dial tcp: connection refused"))
+	tracker.Recovered()
+
+	hook.Reset()
+
+	tracker.Lost(errors.New("dial tcp: connection refused"))
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+
+	assert.Equal(t, logrus.WarnLevel, entry.Level)
+	assert.Equal(t, 1, entry.Data["attempt"])
+}


### PR DESCRIPTION
## What

An agent that cannot reach the server retries indefinitely, and logged a line for every attempt. A
whole outage now costs two lines — one when the server stops answering, one when it answers again —
and the per-attempt trail moves to debug level, where it is still there for anyone who turns it on.

## Why

Fixes #7058, where a device left without internet grew its Docker JSON log to several gigabytes and
filled the disk. The reported line had reached `Attempt 679`:

```
ERROR RESTY Get "https://.../info?agent_version=v0.16.0": dial tcp: lookup ...: server misbehaving, Attempt 679
```

That line is resty's own, from `request.go`, at warn level once per retry. It reached the device's
stderr because the client never installed a logger over it: `SetLogger` was called *before* the
options ran, guarded by a nil check on the very field `WithLogger` sets, so the guard was always
false and the call never happened. resty kept its own logger, writing outside logrus where
`SHELLHUB_LOG_LEVEL` could not reach it.

The reverse-tunnel loop had the same shape from the other direction: one error line every ten
seconds, about 8,600 a day, for as long as a device stayed offline.

## Commits

Seven commits, each self-contained and green on its own.

| Commit | What it does |
|---|---|
| `feat(agent): report a server's reachability as transitions, not as attempts` | New `pkg/connectivity`. Turns a count of attempts into the two moments worth a line. |
| `fix(agent): send the client's logging, and resty's, through the agent's logger` | The `SetLogger` ordering bug, and `LeveledLogger` rewritten printf-style. **This is the commit that closes #7058.** |
| `fix(agent): retry device authorization only on what an operator can clear` | `AuthDevice` stops retrying every refusal forever. Adds the backoff seam. |
| `fix(agent): report an outage once instead of once per retry attempt` | Reporting moves into `AddRetryHook`; dispatch, recovery and the nil-response guard. |
| `fix(agent): log a tunnel outage as a transition rather than once per dial` | The reverse-tunnel reconnect loop. |
| `fix(agent): propagate the device name after a ping re-authorizes, not before` | Independent bug: an inverted condition in the ping loop. |
| `test(agent): take the real backoff out of every test that retries` | `pkg/api/client` goes from 392s to 2.2s. |

## What it logs now

`pkg/connectivity` emits three lines. The first attempt of a run is warn, every one after it debug,
so an outage costs one line however long it lasts:

- `Cannot reach the server, retrying until it answers` — fields `attempt`, `error`
- `Cannot authorize the device, retrying until the server accepts it` — fields `attempt`, `error`
- `Recovered after retrying` — info, fields `attempts`, `after`

Callers that already count attempts pass the count in — resty's `Request.Attempt` is one. Callers
whose retry loop has no counter (the tunnel loop, the ping loop) use a `Tracker`, which keeps it.
Tunnel lines carry `transport=tunnel`, ping lines `transport=ping`, and client lines
`server_address`.

The two conditions are kept apart because they send an operator to different places: the network,
or the namespace and the device limit. A request that got no answer, and a `429` or `5xx` the
client-wide condition retried, are both a server that could not answer. Only a status the
request-level condition retried is a device refusal.

## Retry policy

`AuthDevice` retries just the three statuses an operator clears without touching the device: `404`
for a namespace that does not exist yet, `402` and `403` for one at its device limit. All three are
settled from the console while the agent waits, which is what makes waiting useful.

Everything else fails fast. The list is an allowlist, so a status nobody reasoned about — `400`,
`401`, `409`, `422` — goes back to the caller rather than being retried for the life of the
process. Transport failures, `429` and `5xx` fall through to the client-wide condition. `501` is
excluded from the server's fault: a server that does not implement a route will not grow the
ability by being asked again.

## Testing

`pkg/connectivity` (7 tests) covers the level policy, the fields, and `Tracker` across a run of
failures, a recovery, and the start of a fresh run. `pkg/api/client/connectivity_test.go` (6 tests)
covers the seam rather than the leaf helpers: which status is reported as which condition, `403`
retried, a request that never left not retried, a refusal not reporting a recovery, recovery only
after an outage, and the response body bounded.

Each of those six was verified red against the code before its fix — the defect reverted
individually, the test observed failing, then restored.

`go build`, `go vet` and `golangci-lint` are clean on both modules, and every commit builds and
tests green in isolation, not just the tip.

## Review notes

- The log lines above are the emitted format, read from `pkg/connectivity/connectivity.go`. They
  are not a captured session — the previous version of this description quoted a live run against
  field names (`unreachable_for`) and messages (`Reached the server again`) that no longer exist.
- SSH through the reverse tunnel is not verified end to end here. The edits to `listenV1`/`listenV2`
  swap one log call for another at the same position and do not touch the `a.listening <- true`
  ordering, but a reviewer with a working SSH path should confirm a session still opens after a
  reconnect.
- `Warnf` mapping to debug is deliberate and indiscriminate: resty's other per-request warnings, a
  body it could not unmarshal and Basic Auth over plain HTTP, are buried along with the retry line.
  `Errorf` stays at error, so the request resty finally gave up on is still visible.
