### PR TITLE
feat(server): say what was wrong with a rejected filter

### DIFF
--- a/pkg/api/query/filter.go
+++ b/pkg/api/query/filter.go
@@ -8,19 +8,75 @@ import (
 )
 
 var (
-	// ErrFilterInvalid is returned when a filter is not base64url-encoded JSON of the expected shape.
+	// ErrFilterNotBase64 is returned when a filter's raw value decodes under neither base64 alphabet.
+	ErrFilterNotBase64 = errors.New("filter is not valid base64")
+	// ErrFilterInvalid is returned when a filter decodes as base64 but does not parse as JSON. A raw
+	// value that is not base64 at all returns [ErrFilterNotBase64] instead, and JSON that parses but
+	// is not a filter returns [ErrFilterShapeInvalid].
 	ErrFilterInvalid = errors.New("filter is invalid")
-	// ErrFilterPropertyInvalid is returned when a property node names a field the store does not
-	// allow filtering on.
+	// ErrFilterShapeInvalid is returned when a filter parses as JSON but is not a filter: not an
+	// array of nodes, a node naming a type this package does not define, or a node whose params are
+	// not the shape its type names. The JSON is well formed, which separates it from
+	// [ErrFilterInvalid].
+	ErrFilterShapeInvalid = errors.New("filter shape is not valid")
+	// ErrFilterPropertyInvalid is returned when a property node names a field the contract does not
+	// allow filtering on. A field the contract names but with an operator it does not allow returns
+	// [ErrFilterOperatorInvalid] instead.
 	ErrFilterPropertyInvalid = errors.New("filter property is not valid")
-	// ErrFilterOperatorInvalid is returned when a node names an operator the store does not support.
+	// ErrFilterOperatorInvalid is returned when a property node names a field the contract allows
+	// and an operator that field does not accept.
 	ErrFilterOperatorInvalid = errors.New("filter operator is not valid")
+	// ErrFilterValueInvalid is returned when a property node's value is not a primitive, or is of a
+	// type the field's operator cannot compare against. A value of the right type that is merely too
+	// long returns [ErrFilterValueTooLarge] instead.
+	ErrFilterValueInvalid = errors.New("filter value is not valid")
+	// ErrFilterValueTooLarge is returned when a property node's value is a type the field accepts but
+	// exceeds [MaxStringValueLen] or [MaxArrayLen], directly or through an array item.
+	ErrFilterValueTooLarge = errors.New("filter value exceeds the maximum size")
+	// ErrFilterTooManyItems is returned when a filter carries more conditions than [MaxFilterItems].
+	ErrFilterTooManyItems = errors.New("filter carries too many conditions")
 	// ErrFilterTooLarge is returned when the encoded filter is longer than the cap, which bounds the
 	// work a single query can ask for.
 	ErrFilterTooLarge = errors.New("filter exceeds the maximum size")
 	// ErrSorterFieldInvalid is returned when a sort names a field the store does not allow sorting on.
 	ErrSorterFieldInvalid = errors.New("sort field is not valid")
 )
+
+// FilterError carries the input a refusal is about alongside the sentinel naming the refusal,
+// so a caller can say which field or operator offended without validating the filter a second time
+// to find out. Field is empty when the refusal is about the filter as a whole rather than one of
+// its nodes; Operator is empty unless the operator itself is what was refused.
+//
+// It wraps its sentinel, so errors.Is against one of this package's sentinels holds either way.
+type FilterError struct {
+	Err      error
+	Field    string
+	Operator string
+}
+
+// Error returns the sentinel's own message, so a rejection reads exactly as the sentinel it wraps
+// and no caller has to special-case the carrier when formatting it.
+func (e *FilterError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the sentinel, which is what makes errors.Is hold against this package's sentinels
+// for a rejection as it does for a bare one.
+func (e *FilterError) Unwrap() error {
+	return e.Err
+}
+
+func rejectFilter(err error) error {
+	return &FilterError{Err: err}
+}
+
+func rejectField(err error, field string) error {
+	return &FilterError{Err: err, Field: field}
+}
+
+func rejectOperator(err error, field, operator string) error {
+	return &FilterError{Err: err, Field: field, Operator: operator}
+}
 
 // Filters represents a set of filters that can be applied to queries.
 type Filters struct {
@@ -54,12 +110,17 @@ func (fs *Filters) Unmarshal() error {
 	if err != nil {
 		raw, err = base64.RawURLEncoding.DecodeString(unpadded)
 		if err != nil {
-			return ErrFilterInvalid
+			return ErrFilterNotBase64
 		}
 	}
 
 	if err := json.Unmarshal(raw, &fs.Data); len(raw) > 0 && err != nil {
-		return ErrFilterInvalid
+		var syntax *json.SyntaxError
+		if errors.As(err, &syntax) {
+			return ErrFilterInvalid
+		}
+
+		return ErrFilterShapeInvalid
 	}
 
 	return nil
@@ -84,8 +145,9 @@ type Filter struct {
 	Params any    `json:"params,omitempty"`
 }
 
-// UnmarshalJSON decodes Params into the struct named by Type. An unrecognized Type leaves Params
-// nil rather than failing, so a filter the server does not know narrows nothing.
+// UnmarshalJSON decodes Params into the struct named by Type, and returns [ErrFilterShapeInvalid]
+// when Type names no known shape or Params is not the shape it names. The enclosing JSON has
+// already parsed by then, which is why this is not [ErrFilterInvalid].
 func (f *Filter) UnmarshalJSON(data []byte) error {
 	var params json.RawMessage
 
@@ -104,7 +166,7 @@ func (f *Filter) UnmarshalJSON(data []byte) error {
 	case FilterTypeProperty:
 		var property FilterProperty
 		if err := json.Unmarshal(params, &property); err != nil {
-			return err
+			return ErrFilterShapeInvalid
 		}
 		f.Params = &property
 
@@ -112,12 +174,12 @@ func (f *Filter) UnmarshalJSON(data []byte) error {
 	case FilterTypeOperator:
 		var operator FilterOperator
 		if err := json.Unmarshal(params, &operator); err != nil {
-			return err
+			return ErrFilterShapeInvalid
 		}
 		f.Params = &operator
 
 		return nil
 	default:
-		return ErrFilterInvalid
+		return ErrFilterShapeInvalid
 	}
 }

--- a/pkg/api/query/filter_test.go
+++ b/pkg/api/query/filter_test.go
@@ -138,9 +138,9 @@ func TestFilters_Unmarshal(t *testing.T) {
 			},
 		},
 		{
-			description: "non-base64 garbage returns ErrFilterInvalid",
+			description: "non-base64 garbage returns ErrFilterNotBase64",
 			raw:         "!!!not-base64!!!",
-			wantErr:     ErrFilterInvalid,
+			wantErr:     ErrFilterNotBase64,
 		},
 		{
 			description: "invalid JSON in valid base64 returns ErrFilterInvalid",
@@ -148,9 +148,14 @@ func TestFilters_Unmarshal(t *testing.T) {
 			wantErr:     ErrFilterInvalid,
 		},
 		{
-			description: "valid base64 + valid JSON with unknown filter type returns ErrFilterInvalid",
+			description: "valid base64 + valid JSON with unknown filter type returns ErrFilterShapeInvalid",
 			raw:         base64.StdEncoding.EncodeToString([]byte(`[{"type":"unknown","params":{}}]`)),
-			wantErr:     ErrFilterInvalid,
+			wantErr:     ErrFilterShapeInvalid,
+		},
+		{
+			description: "valid base64 + valid JSON whose params do not match its type returns ErrFilterShapeInvalid",
+			raw:         base64.StdEncoding.EncodeToString([]byte(`[{"type":"property","params":"not-an-object"}]`)),
+			wantErr:     ErrFilterShapeInvalid,
 		},
 	}
 

--- a/pkg/api/query/validate.go
+++ b/pkg/api/query/validate.go
@@ -72,6 +72,15 @@ func NewFieldConstraints(entries map[string][]string, virtualBools ...string) Fi
 	}
 }
 
+// Names reports whether the field is one the constraints allow filtering on at all, whatever the
+// operator. It separates a field nobody may filter on from one this operator may not be used with,
+// which [FieldConstraints.Allows] answers as one.
+func (c FieldConstraints) Names(name string) bool {
+	_, ok := c.operators[name]
+
+	return ok
+}
+
 // Allows reports whether operator is valid for the given field name.
 func (c FieldConstraints) Allows(name, operator string) bool {
 	ops, ok := c.operators[name]
@@ -110,10 +119,13 @@ func ValidateSorter(sorter *Sorter, allowed FieldSet) error {
 	return nil
 }
 
-// ValidateFilters returns [ErrFilterPropertyInvalid] if any property filter
-// references a (field, operator) pair not in constraints, carries a
-// non-primitive Value, or exceeds the configured size limits. Operator
-// filters (and/or) are left to the store to parse.
+// ValidateFilters returns a [FilterError] naming what it refused and the node it refused:
+// [ErrFilterTooManyItems] past [MaxFilterItems], [ErrFilterPropertyInvalid] for a field the
+// constraints do not name, [ErrFilterOperatorInvalid] for an operator that field does not accept,
+// [ErrFilterValueInvalid] for a value that is not primitive or is of a type the operator cannot
+// compare, [ErrFilterValueTooLarge] for one of an acceptable type that exceeds the size limits, and
+// [ErrFilterShapeInvalid] for a property node whose params are not one. Operator filters (and/or)
+// are left to the store to parse.
 //
 // Equality on a virtual bool-backed field (see [FieldConstraints.IsVirtualBoolField]) accepts
 // anything bool-convertible, because ParseFilterProperty intercepts those before any column is
@@ -125,7 +137,7 @@ func ValidateFilters(filters *Filters, constraints FieldConstraints) error {
 	}
 
 	if len(filters.Data) > MaxFilterItems {
-		return ErrFilterPropertyInvalid
+		return rejectFilter(ErrFilterTooManyItems)
 	}
 
 	for _, f := range filters.Data {
@@ -135,29 +147,37 @@ func ValidateFilters(filters *Filters, constraints FieldConstraints) error {
 
 		prop, ok := f.Params.(*FilterProperty)
 		if !ok {
-			return ErrFilterPropertyInvalid
+			return rejectFilter(ErrFilterShapeInvalid)
+		}
+
+		if !constraints.Names(prop.Name) {
+			return rejectField(ErrFilterPropertyInvalid, prop.Name)
 		}
 
 		if !constraints.Allows(prop.Name, prop.Operator) {
-			return ErrFilterPropertyInvalid
+			return rejectOperator(ErrFilterOperatorInvalid, prop.Name, prop.Operator)
 		}
 
-		if !isPrimitive(prop.Value) || !isValueWithinLimits(prop.Value) {
-			return ErrFilterPropertyInvalid
+		if !isPrimitive(prop.Value) {
+			return rejectField(ErrFilterValueInvalid, prop.Name)
+		}
+
+		if !isValueWithinLimits(prop.Value) {
+			return rejectField(ErrFilterValueTooLarge, prop.Name)
 		}
 
 		if prop.Operator == "bool" && !isBoolConvertible(prop.Value) {
-			return ErrFilterPropertyInvalid
+			return rejectField(ErrFilterValueInvalid, prop.Name)
 		}
 
 		if prop.Operator == "eq" || prop.Operator == "ne" {
 			if constraints.IsVirtualBoolField(prop.Name) {
 				if !isBoolConvertible(prop.Value) {
-					return ErrFilterPropertyInvalid
+					return rejectField(ErrFilterValueInvalid, prop.Name)
 				}
 			} else {
 				if _, ok := prop.Value.(string); !ok {
-					return ErrFilterPropertyInvalid
+					return rejectField(ErrFilterValueInvalid, prop.Name)
 				}
 			}
 		}

--- a/pkg/api/query/validate_test.go
+++ b/pkg/api/query/validate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFieldSet_Allows(t *testing.T) {
@@ -94,9 +95,11 @@ func TestValidateFilters(t *testing.T) {
 	}, "online" /* virtual bool fields */)
 
 	cases := []struct {
-		name    string
-		filters *Filters
-		wantErr error
+		name         string
+		filters      *Filters
+		wantErr      error
+		wantField    string
+		wantOperator string
 	}{
 		{
 			name:    "nil filters",
@@ -134,42 +137,48 @@ func TestValidateFilters(t *testing.T) {
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "tenant_id", Operator: "eq", Value: "x"}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterPropertyInvalid,
+			wantField: "tenant_id",
 		},
 		{
 			name: "operator not allowed for field",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "contains", Value: "x"}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:      ErrFilterOperatorInvalid,
+			wantField:    "status",
+			wantOperator: "contains",
 		},
 		{
 			name: "mongo operator as field",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "$where", Operator: "contains", Value: "x"}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterPropertyInvalid,
+			wantField: "$where",
 		},
 		{
 			name: "nested object as value",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: map[string]any{"$ne": "accepted"}}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "array of objects as value",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: []any{map[string]any{"$ne": "accepted"}}}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "wrong params type",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: "not-a-filter-property"},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr: ErrFilterShapeInvalid,
 		},
 		{
 			name: "too many items",
@@ -181,14 +190,15 @@ func TestValidateFilters(t *testing.T) {
 
 				return &Filters{Data: data}
 			}(),
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr: ErrFilterTooManyItems,
 		},
 		{
 			name: "string value over limit",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "name", Operator: "eq", Value: strings.Repeat("A", MaxStringValueLen+1)}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueTooLarge,
+			wantField: "name",
 		},
 		{
 			name: "array over length limit",
@@ -202,14 +212,16 @@ func TestValidateFilters(t *testing.T) {
 					return a
 				}()}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueTooLarge,
+			wantField: "name",
 		},
 		{
 			name: "array item string over limit",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "name", Operator: "contains", Value: []any{strings.Repeat("A", MaxStringValueLen+1)}}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueTooLarge,
+			wantField: "name",
 		},
 		{
 			name: "bool operator with bool value is accepted",
@@ -237,28 +249,32 @@ func TestValidateFilters(t *testing.T) {
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "bool", Value: "yes"}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "online",
 		},
 		{
 			name: "bool operator with nil value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "bool", Value: nil}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "online",
 		},
 		{
 			name: "eq operator with array value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: []any{"a", "b"}}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "ne operator with array value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: []any{"a"}}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "eq operator with scalar string is accepted",
@@ -279,42 +295,48 @@ func TestValidateFilters(t *testing.T) {
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: float64(123)}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "eq operator with bool value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: true}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "ne operator with float64 (JSON number) is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: float64(0)}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "ne operator with bool value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: false}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "eq operator with nil value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: nil}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "ne operator with nil value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: nil}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "status",
 		},
 		{
 			name: "online: eq operator with bool true is accepted",
@@ -349,28 +371,32 @@ func TestValidateFilters(t *testing.T) {
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: "yes"}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "online",
 		},
 		{
 			name: "online: eq operator with nil is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: nil}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "online",
 		},
 		{
 			name: "realclosed (non-virtual): eq with bool value is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "realclosed", Operator: "eq", Value: true}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "realclosed",
 		},
 		{
 			name: "realclosed (non-virtual): eq with float64 (JSON number) is rejected",
 			filters: &Filters{Data: []Filter{
 				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "realclosed", Operator: "eq", Value: float64(1)}},
 			}},
-			wantErr: ErrFilterPropertyInvalid,
+			wantErr:   ErrFilterValueInvalid,
+			wantField: "realclosed",
 		},
 		{
 			name: "realclosed (non-virtual): eq with string value is accepted",
@@ -383,7 +409,19 @@ func TestValidateFilters(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.wantErr, ValidateFilters(tc.filters, allowed))
+			err := ValidateFilters(tc.filters, allowed)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorIs(t, err, tc.wantErr)
+
+			var rejection *FilterError
+			require.ErrorAs(t, err, &rejection)
+			assert.Equal(t, tc.wantField, rejection.Field)
+			assert.Equal(t, tc.wantOperator, rejection.Operator)
 		})
 	}
 }

--- a/server/api/pkg/gateway/route.go
+++ b/server/api/pkg/gateway/route.go
@@ -6,11 +6,13 @@ import (
 	"reflect"
 	"runtime"
 	"strconv"
+	"unicode/utf8"
 
 	"github.com/labstack/echo/v5"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
+	"github.com/shellhub-io/shellhub/pkg/errors"
 	routes "github.com/shellhub-io/shellhub/server/api/routes/errors"
 )
 
@@ -211,11 +213,11 @@ func applyQuery[T any](req *T, declaration Declaration) error {
 		filters := filtered.GetFilters()
 
 		if err := filters.Unmarshal(); err != nil {
-			return routes.NewErrInvalidEntity(map[string]string{"filter": "cannot be decoded"})
+			return routes.NewErrInvalidEntity(map[string]string{"filter": filterRejectionReason(err)})
 		}
 
 		if err := query.ValidateFilters(filters, declaration.Query.Filter); err != nil {
-			return routes.NewErrInvalidEntity(map[string]string{"filter": "is not valid"})
+			return routes.NewErrInvalidEntity(map[string]string{"filter": filterRejectionReason(err)})
 		}
 	}
 
@@ -227,6 +229,50 @@ func applyQuery[T any](req *T, declaration Declaration) error {
 	}
 
 	return nil
+}
+
+const maxEchoedIdentifier = 64
+
+func filterRejectionReason(err error) string {
+	var (
+		rejection       *query.FilterError
+		field, operator string
+	)
+
+	if errors.As(err, &rejection) {
+		field, operator = echoIdentifier(rejection.Field), echoIdentifier(rejection.Operator)
+	}
+
+	switch {
+	case errors.Is(err, query.ErrFilterNotBase64):
+		return "is not valid base64"
+	case errors.Is(err, query.ErrFilterTooLarge):
+		return "exceeds the maximum size"
+	case errors.Is(err, query.ErrFilterTooManyItems):
+		return "carries too many conditions"
+	case errors.Is(err, query.ErrFilterInvalid):
+		return "is not valid JSON"
+	case errors.Is(err, query.ErrFilterShapeInvalid):
+		return "is valid JSON but not a filter"
+	case errors.Is(err, query.ErrFilterPropertyInvalid):
+		return "names an unknown field: " + field
+	case errors.Is(err, query.ErrFilterOperatorInvalid):
+		return "operator " + operator + " is not valid for " + field
+	case errors.Is(err, query.ErrFilterValueTooLarge):
+		return "value exceeds the maximum size for " + field
+	case errors.Is(err, query.ErrFilterValueInvalid):
+		return "value has the wrong type for " + field
+	}
+
+	return "is not valid"
+}
+
+func echoIdentifier(name string) string {
+	if utf8.RuneCountInString(name) <= maxEchoedIdentifier {
+		return name
+	}
+
+	return string([]rune(name)[:maxEchoedIdentifier]) + "..."
 }
 
 // RouteOption states one claim a route's registration makes, and returns the guard that enforces

--- a/server/api/pkg/gateway/route_test.go
+++ b/server/api/pkg/gateway/route_test.go
@@ -396,28 +396,70 @@ func TestListHoldsTheQueryToTheContractItsRegistrationNamed(t *testing.T) {
 		assert         func(*testing.T, *probeCall)
 	}{
 		{
-			description:    "refuses a filter naming a field the contract does not allow",
+			description:    "names the field a filter the contract does not allow asked for",
 			target:         "/probe?filter=" + encodeProbeFilter(t, "signature", "contains"),
 			expectedStatus: http.StatusBadRequest,
-			expectedFields: map[string]string{"filter": "is not valid"},
+			expectedFields: map[string]string{"filter": "names an unknown field: signature"},
 		},
 		{
-			description:    "refuses a filter naming an operator the contract does not allow",
+			description:    "names the operator a filter used against a field that does not accept it",
 			target:         "/probe?filter=" + encodeProbeFilter(t, "name", "eq"),
 			expectedStatus: http.StatusBadRequest,
-			expectedFields: map[string]string{"filter": "is not valid"},
+			expectedFields: map[string]string{"filter": "operator eq is not valid for name"},
 		},
 		{
-			description:    "refuses a filter that is not base64",
+			description:    "says a filter is not base64 when it decodes under neither alphabet",
 			target:         "/probe?filter=not-base64!!",
 			expectedStatus: http.StatusBadRequest,
-			expectedFields: map[string]string{"filter": "cannot be decoded"},
+			expectedFields: map[string]string{"filter": "is not valid base64"},
 		},
 		{
-			description:    "refuses a filter larger than the cap",
+			description:    "says a filter is not JSON when it decodes but does not parse",
+			target:         "/probe?filter=" + base64.RawURLEncoding.EncodeToString([]byte(`not json at all`)),
+			expectedStatus: http.StatusBadRequest,
+			expectedFields: map[string]string{"filter": "is not valid JSON"},
+		},
+		{
+			description:    "separates JSON that parses but is not a filter from JSON that does not parse",
+			target:         "/probe?filter=" + base64.RawURLEncoding.EncodeToString([]byte(`{"nonsense":true}`)),
+			expectedStatus: http.StatusBadRequest,
+			expectedFields: map[string]string{"filter": "is valid JSON but not a filter"},
+		},
+		{
+			description:    "says a filter node names a type the package does not define",
+			target:         "/probe?filter=" + base64.RawURLEncoding.EncodeToString([]byte(`[{"type":"unknown","params":{}}]`)),
+			expectedStatus: http.StatusBadRequest,
+			expectedFields: map[string]string{"filter": "is valid JSON but not a filter"},
+		},
+		{
+			description:    "blames the size of a value of an acceptable type rather than its type",
+			target:         "/probe?filter=" + encodeProbeFilterValue(t, "name", "contains", strings.Repeat("A", query.MaxStringValueLen+1)),
+			expectedStatus: http.StatusBadRequest,
+			expectedFields: map[string]string{"filter": "value exceeds the maximum size for name"},
+		},
+		{
+			description:    "truncates an echoed field name and marks that it truncated it",
+			target:         "/probe?filter=" + encodeProbeFilter(t, strings.Repeat("z", 80), "contains"),
+			expectedStatus: http.StatusBadRequest,
+			expectedFields: map[string]string{"filter": "names an unknown field: " + strings.Repeat("z", 64) + "..."},
+		},
+		{
+			description:    "says a filter exceeds the maximum size rather than blaming its contents",
 			target:         "/probe?filter=" + strings.Repeat("A", query.MaxFilterRawBytes+1),
 			expectedStatus: http.StatusBadRequest,
-			expectedFields: map[string]string{"filter": "cannot be decoded"},
+			expectedFields: map[string]string{"filter": "exceeds the maximum size"},
+		},
+		{
+			description:    "says a filter carries too many conditions",
+			target:         "/probe?filter=" + encodeProbeFilters(t, query.MaxFilterItems+1),
+			expectedStatus: http.StatusBadRequest,
+			expectedFields: map[string]string{"filter": "carries too many conditions"},
+		},
+		{
+			description:    "names the field whose value has the wrong type",
+			target:         "/probe?filter=" + encodeProbeFilterValue(t, "name", "contains", map[string]any{"nested": true}),
+			expectedStatus: http.StatusBadRequest,
+			expectedFields: map[string]string{"filter": "value has the wrong type for name"},
 		},
 		{
 			description:    "refuses a sort naming a field the contract does not allow",
@@ -499,13 +541,33 @@ func TestAcceptsRecordsTheContractOnTheDeclaration(t *testing.T) {
 	assert.False(t, accepts["/silent"])
 }
 
-func encodeProbeFilter(t *testing.T, name, operator string) string {
+func encodeProbeFilters(t *testing.T, count int) string {
+	t.Helper()
+
+	data := make([]query.Filter, count)
+	for i := range data {
+		data[i] = query.Filter{Type: query.FilterTypeProperty, Params: &query.FilterProperty{Name: "name", Operator: "contains", Value: "value"}}
+	}
+
+	encoded, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func encodeProbeFilterValue(t *testing.T, name, operator string, value any) string {
 	t.Helper()
 
 	encoded, err := json.Marshal([]query.Filter{
-		{Type: query.FilterTypeProperty, Params: &query.FilterProperty{Name: name, Operator: operator, Value: "value"}},
+		{Type: query.FilterTypeProperty, Params: &query.FilterProperty{Name: name, Operator: operator, Value: value}},
 	})
 	require.NoError(t, err)
 
 	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func encodeProbeFilter(t *testing.T, name, operator string) string {
+	t.Helper()
+
+	return encodeProbeFilterValue(t, name, operator, "value")
 }


### PR DESCRIPTION
## What

A rejected `filter` now names its own reason in the `fields` map the error envelope already carries. Nine distinct causes get nine distinct reasons where there used to be two strings. The envelope, the 400 status and the OpenAPI schema are unchanged, so a client that only reads the status code is unaffected.

Companion PR: shellhub-io/cloud#2543 , which moves cloud's three list routes onto the same seam so they answer identically. Merge this one first.

Closes #6467

## Why

`ValidateFilters` returned one sentinel for six causes and `applyQuery` collapsed seven into two strings, so a script author could not tell a typo in a field name from a filter that was merely too big. The server knew the difference at the moment it decided to refuse, and threw it away one call before anything needed it.

| Before | After |
|---|---|
| `"filter": "is not valid"` | `"filter": "names an unknown field: nmae"` |
| `"filter": "is not valid"` | `"filter": "operator gt is not valid for name"` |
| `"filter": "is not valid"` | `"filter": "value exceeds the maximum size for name"` |
| `"filter": "cannot be decoded"` | `"filter": "is not valid base64"` |

## Changes

**`pkg/api/query`** classifies its own refusals instead of discarding the classification. `FieldConstraints.Names` separates "no such field" from "that operator is not allowed here", which `Allows` used to answer as one. Three sentinels are added: `ErrFilterNotBase64`, `ErrFilterTooManyItems`, and `ErrFilterShapeInvalid` for JSON that parses but is not a filter. `ErrFilterValueTooLarge` splits an oversized value of an acceptable type from one of the wrong type. `ErrFilterOperatorInvalid` was declared but never returned by production code; it is now real. A `FilterError` carrier holds the offending field and operator alongside the sentinel and wraps it, so every existing `errors.Is` check keeps working.

**`server/api/pkg/gateway`** maps sentinel to reason in one place, at the seam every list route crosses, so no route can drift from the wording. The echoed identifier is capped at 64 runes and marks a cut, since the field name is client-supplied and only filter values are otherwise length-bounded.

## Testing

Unit and HTTP-level tests pass: `pkg/api/query`, the gateway package, and the full `server` module. The gateway's rejection table went from 5 cases to 13, each asserting a distinct `fields` map. The one pre-existing failure, `TestInstallScriptRendersAValidShellScript`, is unrelated (the script is not mounted in the container).

```bash
./bin/docker-compose exec server go test ./api/pkg/gateway/ -run TestListHoldsTheQueryToTheContractItsRegistrationNamed -v
./bin/docker-compose exec server go test ./../pkg/api/query/...
```

Also exercised end to end against a running dev stack, since the reason strings are a client-facing contract and only a real request proves what a client receives.

```bash
TOKEN=$(curl -s -X POST http://localhost/api/login -H 'Content-Type: application/json' -d '{"username":"<you>","password":"<pw>"}' | jq -r .token)
AUTH="Authorization: Bearer $TOKEN"
b64() { echo -n "$1" | basenc --base64url -w0 | tr -d '='; }

curl -s "http://localhost/api/devices?filter=$(b64 '[{"type":"property","params":{"name":"nmae","operator":"eq","value":"x"}}]')" -H "$AUTH"
curl -s "http://localhost/api/devices?filter=$(b64 '[{"type":"property","params":{"name":"name","operator":"gt","value":"x"}}]')" -H "$AUTH"
curl -s "http://localhost/api/devices?filter=$(b64 '[{"type":"property","params":{"name":"name","operator":"eq","value":{"a":1}}}]')" -H "$AUTH"
curl -s "http://localhost/api/devices?filter=$(b64 "[{\"type\":\"property\",\"params\":{\"name\":\"name\",\"operator\":\"contains\",\"value\":\"$(printf 'A%.0s' {1..2000})\"}}]")" -H "$AUTH"
curl -s "http://localhost/api/devices?filter=$(b64 '{"nonsense":true}')" -H "$AUTH"
curl -s "http://localhost/api/devices?filter=$(b64 'not json at all')" -H "$AUTH"
curl -s "http://localhost/api/devices?filter=notbase64!!!" -H "$AUTH"
```

Observed, all `400`:

```
{"message":"invalid entity","fields":{"filter":"names an unknown field: nmae"}}
{"message":"invalid entity","fields":{"filter":"operator gt is not valid for name"}}
{"message":"invalid entity","fields":{"filter":"value has the wrong type for name"}}
{"message":"invalid entity","fields":{"filter":"value exceeds the maximum size for name"}}
{"message":"invalid entity","fields":{"filter":"is valid JSON but not a filter"}}
{"message":"invalid entity","fields":{"filter":"is not valid JSON"}}
{"message":"invalid entity","fields":{"filter":"is not valid base64"}}
```

Controls: a valid filter still returns `200`, and `?sort_by=nope` still returns `400` with `{"sort_by": "nope"}` unchanged.
