### PR TITLE
fix(ui): link a device to the source it registered through

### DIFF
--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import { LABEL_BASE } from "@/utils/styles";
 import {
@@ -17,8 +22,10 @@ import {
 } from "../hooks/useDeviceMutations";
 import { useNamespace } from "../hooks/useNamespaces";
 import { useInstallKeys } from "../hooks/useInstallKeys";
-import { resolveEnrollmentSource } from "@/pages/install-keys/helpers";
-import { DeprecatedBadge } from "@/pages/install-keys/StatusChip";
+import {
+  enrollmentSourceName,
+  resolveEnrollmentSource,
+} from "@/pages/install-keys/helpers";
 import { useAuthStore } from "../stores/authStore";
 import { useTerminalStore } from "../stores/terminalStore";
 import ActionDialog from "@/components/common/ActionDialog";
@@ -300,16 +307,13 @@ export default function DeviceDetails() {
           mac={device.identity?.mac ?? ""}
           remoteAddr={device.remote_addr ?? ""}
           registeredVia={
-            enrollment ? (
-              enrollment.kind === "legacy" ? (
-                <DeprecatedBadge />
-              ) : (
-                <span className="text-sm font-medium text-text-primary">
-                  {enrollment.kind === "pairing"
-                    ? "Pairing code"
-                    : enrollment.name}
-                </span>
-              )
+            enrollment && device.install_key_id ? (
+              <Link
+                to={`/install-keys/${encodeURIComponent(device.install_key_id)}/activity`}
+                className="text-sm font-medium text-text-primary hover:text-primary hover:underline"
+              >
+                {enrollmentSourceName(enrollment)}
+              </Link>
             ) : (
               <span className="text-sm text-text-muted">—</span>
             )

--- a/ui/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
@@ -7,6 +7,7 @@ import { createTestWrapper } from "@/tests/wrapper";
 import { mockSdkResponse, paginatedResponse } from "@/tests/sdk";
 import {
   mockDevice as mockDeviceFactory,
+  mockInstallKey,
   mockNamespace,
 } from "@/tests/factories";
 import { seedAuthStore } from "@/tests/seedAuthStore";
@@ -169,6 +170,23 @@ describe("DeviceDetails", () => {
     it("renders the operating system", async () => {
       renderPage();
       expect(await screen.findByText("Ubuntu 22.04 LTS")).toBeInTheDocument();
+    });
+
+    it("names the source a keyless device registered through, linked to its activity", async () => {
+      sdk.getDevice.mockResolvedValue(
+        mockSdkResponse(makeDevice({ install_key_id: "legacy-digest" })),
+      );
+      sdk.installKeyList.mockResolvedValue(
+        paginatedResponse([
+          mockInstallKey({ id: "legacy-digest", name: "legacy", type: "legacy" }),
+        ]),
+      );
+
+      renderPage();
+
+      expect(
+        await screen.findByRole("link", { name: "Tenant-only registration" }),
+      ).toHaveAttribute("href", "/install-keys/legacy-digest/activity");
     });
 
     it('renders the "Custom Fields" section label', async () => {

--- a/ui/apps/console/src/pages/install-keys/helpers.ts
+++ b/ui/apps/console/src/pages/install-keys/helpers.ts
@@ -16,10 +16,15 @@ export function isPairingKey(key: InstallKey): boolean {
   return key.type === "pairing";
 }
 
+const SYSTEM_SOURCE_NAMES = {
+  legacy: "Tenant-only registration",
+  pairing: "Pairing code",
+} as const;
+
 /** The display name for a key: a friendly label for either system key, else the key's own name. */
 export function installKeyDisplayName(key: InstallKey): string {
-  if (isPairingKey(key)) return "Pairing code";
-  if (isSystemKey(key)) return "Tenant-only registration";
+  if (isPairingKey(key)) return SYSTEM_SOURCE_NAMES.pairing;
+  if (isSystemKey(key)) return SYSTEM_SOURCE_NAMES.legacy;
   return key.name;
 }
 
@@ -46,6 +51,11 @@ export function resolveEnrollmentSource(
   if (isSystemKey(match))
     return isPairingKey(match) ? { kind: "pairing" } : { kind: "legacy" };
   return { kind: "key", name: match.name };
+}
+
+/** The display name for an enrollment source, matching what the keys list calls it. */
+export function enrollmentSourceName(source: EnrollmentSource): string {
+  return source.kind === "key" ? source.name : SYSTEM_SOURCE_NAMES[source.kind];
 }
 
 /** Split a MAC-allowlist textarea into a normalized, deduped list (lowercased, blanks dropped). */


### PR DESCRIPTION
`REGISTERED VIA` on the device page rendered `<DeprecatedBadge />` alone for an enrollment whose source is the tenant-only path, so the field answered `Deprecated` and named no source at all. That path is what the install script uses when no install key is given, which makes it the most common device in a namespace.

The name now comes from `enrollmentSourceName`, which shares the two system-source labels with `installKeyDisplayName`, so what a device reports and what the keys list shows cannot drift apart. It links to that key's activity, where this device's registration record lives: what the agent reported, the key fingerprint, the decision. All three sources link, including the two system keys, which have activity pages like any other.

The deprecation badge does not come along. Whether the mechanism is on its way out is a fact about the key, and the keys list is where it is actionable; on a device page it answers a question nobody asked there.

```
REGISTERED VIA          REGISTERED VIA
Deprecated              Tenant-only registration   -> /install-keys/<digest>/activity
```
