### PR TITLE
ci: finalize the review tracking comment in its own job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,9 @@ jobs:
       pull-requests: write
       issues: write
 
+    outputs:
+      claude-ref: ${{ steps.claude-branch.outputs.ref }}
+
     steps:
       - name: Generate cross-repo token
         id: app-token
@@ -188,9 +191,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Supplies both the review action below and the workspace.sh that syncs
-      # the config. Pairing is gated on the author being an admin, so a fork PR
-      # can never point this at a branch it controls.
       - name: Checkout claude config
         if: steps.gate.outputs.proceed == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -217,3 +217,44 @@ jobs:
           app-token: ${{ steps.app-token.outputs.token }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  # A separate job so that a review job cancelled by its own timeout, or a runner
+  # that died under it, cannot leave the tracking comment stranded mid-progress.
+  finalize:
+    name: Finalize tracking comment
+    needs: review
+    if: always() && needs.review.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Generate cross-repo token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.CLOUD_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CLOUD_DISPATCH_APP_PRIVATE_KEY }}
+          owner: shellhub-io
+          repositories: claude
+
+      - name: Checkout claude config
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: shellhub-io/claude
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+          ref: ${{ needs.review.outputs.claude-ref || 'master' }}
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          path: claude
+
+      - name: Finalize
+        uses: ./claude/.github/actions/pr-review-finalize
+        with:
+          repo: ${{ github.repository }}
+          pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Paired with shellhub-io/claude#64, which carries the substance — including a fix for
`claude-code-action` wiping the synced `.claude/` before the review runs, which has meant CI reviews
in this repo have not been reading the repo rules or the `code-review` skill at all.

## What changes here

The tracking-comment finalize moves out of the review job into its own `needs: review, if: always()`
job. As a step it shared a job with the review it exists to clean up after, so the job-level
timeout — the only kind available inside a composite action — cancelled the finalize along with the
hang that triggered it. A separate job also survives the runner dying, which the step never did. It
checks out only the claude repo, at master, sparsely.

Also drops a three-line comment that restated the commit body, which `code-style.md` bans — flagged
by the automated review on shellhub-io/cloud#2549.

## Testing

actionlint and yamllint clean.

As before, this PR does not exercise its own change: `pull_request_target` runs the workflow from
the base branch. shellhub-io/cloud#2550 verifies the new path, including whether the reviewer can
now read `$GITHUB_WORKSPACE/claude/.claude/skills/code-review/SKILL.md`.

Merge order: claude#64, then cloud#2550 (check its run log for that read), then this one.